### PR TITLE
fix: harden hybrid OCR region extraction path

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -82,7 +82,7 @@ pub(crate) fn extract_page_text_items(
     page_num: u32,
     font_cmaps: &FontCMaps,
     include_invisible: bool,
-) -> Result<(PageExtraction, bool), PdfError> {
+) -> Result<(PageExtraction, bool, bool), PdfError> {
     use lopdf::content::Content;
 
     let mut items = Vec::new();
@@ -182,7 +182,7 @@ pub(crate) fn extract_page_text_items(
             content.operations.len(),
             MAX_OPERATIONS
         );
-        return Ok(((Vec::new(), Vec::new(), Vec::new()), false));
+        return Ok(((Vec::new(), Vec::new(), Vec::new()), false, false));
     }
 
     // Graphics state tracking
@@ -1009,11 +1009,12 @@ pub(crate) fn extract_page_text_items(
     // Some PDFs embed landscape content in portrait pages using a rotated text
     // matrix (e.g. [0, b, -b, 0, tx, ty] for 90° CCW).  The layout engine
     // assumes x=horizontal, y=vertical — so we swap coordinates to match.
-    let (items, rects, lines) = correct_rotated_page(items, rects, lines, &rotation_votes);
+    let (items, rects, lines, coords_rotated) =
+        correct_rotated_page(items, rects, lines, &rotation_votes);
 
     let items = super::merge_text_items(items);
     let items = super::merge_subscript_items(items);
-    Ok(((items, rects, lines), has_gid_fonts))
+    Ok(((items, rects, lines), has_gid_fonts, coords_rotated))
 }
 
 /// Counts of text operators with horizontal vs rotated combined matrices.
@@ -1030,9 +1031,9 @@ fn correct_rotated_page(
     mut rects: Vec<PdfRect>,
     mut lines: Vec<PdfLine>,
     votes: &RotationVotes,
-) -> (Vec<TextItem>, Vec<PdfRect>, Vec<PdfLine>) {
+) -> (Vec<TextItem>, Vec<PdfRect>, Vec<PdfLine>, bool) {
     if items.len() < 2 {
-        return (items, rects, lines);
+        return (items, rects, lines, false);
     }
 
     // Use the combined-matrix direction votes collected during extraction.
@@ -1041,7 +1042,7 @@ fn correct_rotated_page(
     let total_votes = votes.horizontal + votes.rotated;
     if total_votes == 0 || votes.rotated * 3 < total_votes * 2 {
         // Less than ~67% of text operators are rotated → not a rotated page
-        return (items, rects, lines);
+        return (items, rects, lines, false);
     }
 
     log::debug!(
@@ -1092,7 +1093,7 @@ fn correct_rotated_page(
         line.y2 = new_y2;
     }
 
-    (items, rects, lines)
+    (items, rects, lines, true)
 }
 
 /// Remove near-duplicate rects (same coordinates within 0.5 pt tolerance).
@@ -1228,7 +1229,7 @@ mod tests {
 
         let font_cmaps = FontCMaps::from_doc(&doc);
         let result = extract_page_text_items(&doc, page_id, 1, &font_cmaps, false).unwrap();
-        let ((items, rects, lines), _has_gid) = result;
+        let ((items, rects, lines), _has_gid, _coords_rotated) = result;
         assert!(items.is_empty());
         assert!(rects.is_empty());
         assert!(lines.is_empty());

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -188,7 +188,7 @@ fn extract_positioned_text_impl(
                 continue;
             }
         }
-        let ((mut items, rects, lines), has_gid_fonts) =
+        let ((mut items, rects, lines), has_gid_fonts, _coords_rotated) =
             extract_page_text_items(doc, page_id, *page_num, font_cmaps, include_invisible)?;
         if has_gid_fonts {
             gid_encoded_pages.insert(*page_num);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,8 @@ pub fn extract_text_in_regions_mem(
     let mut items_by_page: HashMap<u32, Vec<TextItem>> = HashMap::new();
     let mut page_heights: HashMap<u32, f32> = HashMap::new();
     let mut gid_pages: HashSet<u32> = HashSet::new();
+    let mut page_thresholds: HashMap<u32, f32> = HashMap::new();
+    let mut rotated_pages: HashSet<u32> = HashSet::new();
 
     for (page_num, &page_id) in pages.iter() {
         if !needed_pages.contains(page_num) {
@@ -369,7 +371,7 @@ pub fn extract_text_in_regions_mem(
         page_heights.insert(*page_num, height);
 
         // Extract text items for this page
-        let ((mut items, _rects, _lines), has_gid) =
+        let ((mut items, _rects, _lines), has_gid, coords_rotated) =
             extractor::content_stream::extract_page_text_items(
                 &doc,
                 page_id,
@@ -377,9 +379,15 @@ pub fn extract_text_in_regions_mem(
                 &font_cmaps,
                 false,
             )?;
-        text_utils::fix_letterspaced_items(&mut items);
+        let threshold = text_utils::fix_letterspaced_items(&mut items);
+        if threshold > 0.10 {
+            page_thresholds.insert(*page_num, threshold);
+        }
         if has_gid {
             gid_pages.insert(*page_num);
+        }
+        if coords_rotated {
+            rotated_pages.insert(*page_num);
         }
         items_by_page.insert(*page_num, items);
     }
@@ -392,6 +400,12 @@ pub fn extract_text_in_regions_mem(
         let items = items_by_page.get(&page_1idx);
         let page_h = page_heights.get(&page_1idx).copied().unwrap_or(792.0);
         let page_has_gid = gid_pages.contains(&page_1idx);
+        let adaptive_threshold = page_thresholds.get(&page_1idx).copied().unwrap_or(0.10);
+        let coords = if rotated_pages.contains(&page_1idx) {
+            RegionCoordSpace::Rotated90Ccw
+        } else {
+            RegionCoordSpace::Standard
+        };
 
         let mut page_results = Vec::with_capacity(regions.len());
 
@@ -399,7 +413,16 @@ pub fn extract_text_in_regions_mem(
             let [rx1, ry1, rx2, ry2] = *rect;
 
             let text = match items {
-                Some(items) => collect_text_in_region(items, rx1, ry1, rx2, ry2, page_h),
+                Some(items) => collect_text_in_region_with_options(
+                    items,
+                    rx1,
+                    ry1,
+                    rx2,
+                    ry2,
+                    page_h,
+                    coords,
+                    adaptive_threshold,
+                ),
                 None => String::new(),
             };
 
@@ -454,6 +477,20 @@ fn obj_to_f32(obj: &lopdf::Object) -> Option<f32> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum RegionCoordSpace {
+    Standard,
+    Rotated90Ccw,
+}
+
+#[derive(Clone, Copy)]
+struct RegionBounds {
+    x_min: f32,
+    y_min: f32,
+    x_max: f32,
+    y_max: f32,
+}
+
 /// Collect text items that fall within a region bbox (top-left origin, PDF points)
 /// and return them as a single string in reading order.
 pub fn collect_text_in_region(
@@ -464,65 +501,108 @@ pub fn collect_text_in_region(
     ry2: f32,
     page_height: f32,
 ) -> String {
-    // Convert region from top-left to bottom-left origin
-    let by1 = page_height - ry2; // top-left y2 → bottom-left y1
-    let by2 = page_height - ry1; // top-left y1 → bottom-left y2
+    collect_text_in_region_with_options(
+        items,
+        rx1,
+        ry1,
+        rx2,
+        ry2,
+        page_height,
+        infer_region_coord_space(items),
+        0.10,
+    )
+}
 
-    // Collect items whose center falls within the region
-    let mut matched: Vec<&TextItem> = items
+fn collect_text_in_region_with_options(
+    items: &[TextItem],
+    rx1: f32,
+    ry1: f32,
+    rx2: f32,
+    ry2: f32,
+    page_height: f32,
+    coord_space: RegionCoordSpace,
+    adaptive_threshold: f32,
+) -> String {
+    let bounds = region_bounds(rx1, ry1, rx2, ry2, page_height, coord_space);
+    let Some(page) = items.first().map(|item| item.page) else {
+        return String::new();
+    };
+    let matched: Vec<TextItem> = items
         .iter()
-        .filter(|item| {
-            let cx = item.x + item.width / 2.0;
-            let cy = item.y + item.height / 2.0;
-            cx >= rx1 && cx <= rx2 && cy >= by1 && cy <= by2
-        })
+        .filter(|item| region_overlaps_item(item, bounds))
+        .cloned()
         .collect();
-
     if matched.is_empty() {
         return String::new();
     }
-
-    // Sort top→bottom (descending Y in bottom-left coords), then left→right.
-    // Uses strict total_cmp ordering to guarantee transitivity (required by
-    // Rust's sort). The line-grouping phase below handles fuzzy Y matching.
-    matched.sort_by(|a, b| {
-        b.y.total_cmp(&a.y) // descending Y = top to bottom
-            .then(a.x.total_cmp(&b.x)) // ascending X = left to right
-    });
-
-    // Group into lines and join
-    let mut lines: Vec<String> = Vec::new();
-    let mut current_line = String::new();
-    let mut last_y = f32::NAN;
-    let mut last_x_end = 0.0_f32;
-
-    for item in &matched {
-        let line_threshold = item.font_size * 0.5;
-        let same_line = (item.y - last_y).abs() < line_threshold;
-
-        if !same_line && !current_line.is_empty() {
-            lines.push(current_line.clone());
-            current_line.clear();
-        }
-
-        if !current_line.is_empty() {
-            // Insert space if there's a gap between items on the same line
-            let gap = item.x - last_x_end;
-            if gap > item.font_size * 0.15 {
-                current_line.push(' ');
-            }
-        }
-
-        current_line.push_str(&item.text);
-        last_y = item.y;
-        last_x_end = item.x + item.width;
+    let mut thresholds = HashMap::new();
+    if adaptive_threshold > 0.10 {
+        thresholds.insert(page, adaptive_threshold);
     }
+    let lines = extractor::group_into_lines_with_thresholds(matched, &thresholds, &HashSet::new());
+    lines
+        .into_iter()
+        .map(|line| line.text())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
-    if !current_line.is_empty() {
-        lines.push(current_line);
+fn infer_region_coord_space(items: &[TextItem]) -> RegionCoordSpace {
+    // Rotated-page normalization currently maps y = -old_x, so most text items
+    // land at negative Y. Use this to keep `collect_text_in_region` behavior
+    // compatible for direct callers that do not have extractor metadata.
+    let negative_y = items.iter().filter(|item| item.y < 0.0).count();
+    if !items.is_empty() && negative_y * 2 >= items.len() {
+        RegionCoordSpace::Rotated90Ccw
+    } else {
+        RegionCoordSpace::Standard
     }
+}
 
-    lines.join("\n")
+fn region_bounds(
+    rx1: f32,
+    ry1: f32,
+    rx2: f32,
+    ry2: f32,
+    page_height: f32,
+    coord_space: RegionCoordSpace,
+) -> RegionBounds {
+    let tx_min = rx1.min(rx2);
+    let tx_max = rx1.max(rx2);
+    let ty_min = ry1.min(ry2);
+    let ty_max = ry1.max(ry2);
+    let by_min = page_height - ty_max;
+    let by_max = page_height - ty_min;
+    match coord_space {
+        RegionCoordSpace::Standard => RegionBounds {
+            x_min: tx_min,
+            y_min: by_min,
+            x_max: tx_max,
+            y_max: by_max,
+        },
+        RegionCoordSpace::Rotated90Ccw => RegionBounds {
+            x_min: by_min,
+            x_max: by_max,
+            y_min: -tx_max,
+            y_max: -tx_min,
+        },
+    }
+}
+
+fn region_overlaps_item(item: &TextItem, bounds: RegionBounds) -> bool {
+    const REGION_MARGIN: f32 = 1.5;
+    let item_x_min = item.x;
+    let item_x_max = item.x + text_utils::effective_width(item);
+    let item_y_min = item.y;
+    let item_y_max = item.y + item.height;
+
+    let x_overlap = (item_x_max.min(bounds.x_max + REGION_MARGIN)
+        - item_x_min.max(bounds.x_min - REGION_MARGIN))
+    .max(0.0);
+    let y_overlap = (item_y_max.min(bounds.y_max + REGION_MARGIN)
+        - item_y_min.max(bounds.y_min - REGION_MARGIN))
+    .max(0.0);
+    x_overlap > 0.0 && y_overlap > 0.0
 }
 
 // =========================================================================

--- a/src/python.rs
+++ b/src/python.rs
@@ -248,21 +248,34 @@ fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
         .collect()
 }
 
-fn parse_page_regions(page_regions: Vec<(u32, Vec<Vec<f64>>)>) -> Vec<(u32, Vec<[f32; 4]>)> {
+fn parse_page_regions(
+    page_regions: Vec<(u32, Vec<Vec<f64>>)>,
+) -> PyResult<Vec<(u32, Vec<[f32; 4]>)>> {
     page_regions
         .into_iter()
         .map(|(page, regions)| {
-            let bboxes: Vec<[f32; 4]> = regions
-                .iter()
-                .map(|r| {
-                    if r.len() != 4 {
-                        [0.0, 0.0, 0.0, 0.0]
-                    } else {
-                        [r[0] as f32, r[1] as f32, r[2] as f32, r[3] as f32]
-                    }
-                })
-                .collect();
-            (page, bboxes)
+            let mut bboxes: Vec<[f32; 4]> = Vec::with_capacity(regions.len());
+            for (idx, region) in regions.into_iter().enumerate() {
+                if region.len() != 4 {
+                    return Err(PyValueError::new_err(format!(
+                        "Invalid region at page {page}, index {idx}: expected [x1, y1, x2, y2], got {} values",
+                        region.len()
+                    )));
+                }
+                let [x1, y1, x2, y2] = [region[0], region[1], region[2], region[3]];
+                if !(x1.is_finite() && y1.is_finite() && x2.is_finite() && y2.is_finite()) {
+                    return Err(PyValueError::new_err(format!(
+                        "Invalid region at page {page}, index {idx}: coordinates must be finite numbers"
+                    )));
+                }
+                if x2 < x1 || y2 < y1 {
+                    return Err(PyValueError::new_err(format!(
+                        "Invalid region at page {page}, index {idx}: expected x2>=x1 and y2>=y1, got [{x1}, {y1}, {x2}, {y2}]"
+                    )));
+                }
+                bboxes.push([x1 as f32, y1 as f32, x2 as f32, y2 as f32]);
+            }
+            Ok((page, bboxes))
         })
         .collect()
 }
@@ -424,7 +437,7 @@ fn extract_text_in_regions_bytes(
     data: &[u8],
     page_regions: Vec<(u32, Vec<Vec<f64>>)>,
 ) -> PyResult<Vec<PyPageRegionTexts>> {
-    let regions = parse_page_regions(page_regions);
+    let regions = parse_page_regions(page_regions)?;
     let results = crate::extract_text_in_regions_mem(data, &regions).map_err(to_py_err)?;
     Ok(convert_region_results(results))
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1232,6 +1232,55 @@ fn test_extract_regions_mem_not_a_pdf() {
     assert!(result.is_err(), "Non-PDF input should return an error");
 }
 
+#[test]
+fn test_extract_regions_mem_rotated_page_not_false_empty() {
+    let buf = std::fs::read("tests/fixtures/tnagriculture_06_12.pdf").unwrap();
+    let regions =
+        extract_text_in_regions_mem(&buf, &[(0, vec![[0.0, 0.0, 1200.0, 1200.0]])]).unwrap();
+    assert_eq!(regions.len(), 1);
+    assert_eq!(regions[0].regions.len(), 1);
+    let region = &regions[0].regions[0];
+    assert!(
+        !region.text.trim().is_empty(),
+        "Rotated page full-region extraction should not be empty"
+    );
+    assert!(
+        !region.needs_ocr,
+        "Rotated page with native text should not be flagged for OCR fallback"
+    );
+    assert!(
+        region
+            .text
+            .contains("DISTRICT WISE PRODUCTION OF SPICES AND CONDIMENTS"),
+        "Expected known title from rotated fixture in extracted region text"
+    );
+}
+
+#[test]
+fn test_collect_text_in_region_keeps_partial_overlap_items() {
+    let item = make_text_item("EdgeWord", 100.0, 700.0, 12.0, 1);
+    // Region intersects only the left edge of the item. Center x=124 falls
+    // outside x=[95,120], so center-only containment would drop it.
+    let text = pdf_inspector::collect_text_in_region(&[item], 95.0, 80.0, 120.0, 110.0, 800.0);
+    assert!(
+        text.contains("EdgeWord"),
+        "Partially overlapping items should be retained in region extraction"
+    );
+}
+
+#[test]
+fn test_collect_text_in_region_uses_rtl_sorting() {
+    let items = vec![
+        make_text_item("بكم", 240.0, 700.0, 12.0, 1),
+        make_text_item("مرحبا", 300.0, 700.0, 12.0, 1),
+    ];
+    let text = pdf_inspector::collect_text_in_region(&items, 0.0, 0.0, 600.0, 800.0, 800.0);
+    assert_eq!(
+        text, "مرحبا بكم",
+        "Region path should reuse RTL-aware line sorting"
+    );
+}
+
 // =========================================================================
 // Fast vs normal extraction comparison
 // =========================================================================

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -262,6 +262,13 @@ class TestExtractTextInRegions:
         assert results[0].page == 0
         assert results[1].page == 1
 
+    def test_malformed_region_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid region"):
+            pdf_inspector.extract_text_in_regions(
+                fixture_path("thermo-freon12.pdf"),
+                [(0, [[0.0, 0.0, 600.0]])],
+            )
+
 
 # ---------------------------------------------------------------------------
 # Error handling


### PR DESCRIPTION
## Summary
- align region filtering with rotated-page coordinate normalization so rotated native text is matched in the same coordinate space and no longer falsely marked as OCR-only
- replace region-only ad hoc ordering/spacing with the shared line-grouping pipeline (`group_into_lines_with_thresholds`) to reuse adaptive spacing and RTL-aware sorting
- switch region membership from center-point containment to overlap-based inclusion with a small margin, and make Python region parsing fail fast with explicit `ValueError` messages for malformed boxes
- add regression tests for rotated-page region extraction, partial overlap retention, RTL ordering reuse, and malformed Python region input

## Test plan
- [x] `cargo test --test integration_tests test_extract_regions_mem_rotated_page_not_false_empty -- --exact`
- [x] `cargo test --test integration_tests test_collect_text_in_region_keeps_partial_overlap_items -- --exact`
- [x] `cargo test --test integration_tests test_collect_text_in_region_uses_rtl_sorting -- --exact`
- [x] `cargo test --test integration_tests test_extract_regions_fast_vs_normal_comparison -- --exact`
- [x] `python3 -m venv .venv && source .venv/bin/activate && python -m pip install maturin pytest && maturin develop && pytest tests/test_python.py -k malformed_region_raises_value_error`

Made with [Cursor](https://cursor.com)