### PR TITLE
Fix double-load issue in detect_pdf_type function

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -97,26 +97,16 @@ pub fn detect_pdf_type_with_config<P: AsRef<Path>>(
 ) -> Result<PdfTypeResult, PdfError> {
     crate::validate_pdf_file(&path)?;
 
-    // First, load metadata only (fast operation)
-    let metadata = match Document::load_metadata(&path) {
-        Ok(m) => m,
-        Err(ref e) if crate::is_encrypted_lopdf_error(e) => {
-            Document::load_metadata_with_password(&path, "")?
-        }
-        Err(e) => return Err(e.into()),
-    };
-
-    // Then load the full document for content inspection
-    // We use filtered loading to skip heavy objects we don't need
-    let doc = match Document::load(&path) {
+    let buffer = std::fs::read(&path)?;
+    let doc = match Document::load_mem(&buffer) {
         Ok(d) => d,
         Err(ref e) if crate::is_encrypted_lopdf_error(e) => {
-            Document::load_with_password(&path, "")?
+            Document::load_mem_with_options(&buffer, lopdf::LoadOptions::with_password(""))?
         }
         Err(e) => return Err(e.into()),
     };
-
-    detect_from_document(&doc, metadata.page_count, &config)
+    let page_count = doc.get_pages().len() as u32;
+    detect_from_document(&doc, page_count, &config)
 }
 
 /// Detect PDF type from memory buffer
@@ -131,15 +121,6 @@ pub fn detect_pdf_type_mem_with_config(
 ) -> Result<PdfTypeResult, PdfError> {
     crate::validate_pdf_bytes(buffer)?;
 
-    // Load metadata first (fast)
-    let metadata = match Document::load_metadata_mem(buffer) {
-        Ok(m) => m,
-        Err(ref e) if crate::is_encrypted_lopdf_error(e) => {
-            Document::load_metadata_mem_with_password(buffer, "")?
-        }
-        Err(e) => return Err(e.into()),
-    };
-
     // Load document for inspection
     let doc = match Document::load_mem(buffer) {
         Ok(d) => d,
@@ -148,13 +129,13 @@ pub fn detect_pdf_type_mem_with_config(
         }
         Err(e) => return Err(e.into()),
     };
-
-    detect_from_document(&doc, metadata.page_count, &config)
+    let page_count = doc.get_pages().len() as u32;
+    detect_from_document(&doc, page_count, &config)
 }
 
 /// Detection logic on a pre-loaded document.
 ///
-/// `page_count` should come from `Document::load_metadata()`.
+/// `page_count` should come from `doc.get_pages().len()`.
 pub(crate) fn detect_from_document(
     doc: &Document,
     page_count: u32,

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -105,6 +105,12 @@ pub fn detect_pdf_type_with_config<P: AsRef<Path>>(
         }
         Err(e) => return Err(e.into()),
     };
+
+    // Note: unlike load_document_from_mem in lib.rs, this path does not apply
+    // structure_tree::fix_bare_struct_names preprocessing. Detection doesn't inspect
+    // struct tree roles, so this asymmetry has no practical effect.
+    //
+    // See: <https://github.com/firecrawl/pdf-inspector/pull/34#pullrequestreview-4117304193>
     let page_count = doc.get_pages().len() as u32;
     detect_from_document(&doc, page_count, &config)
 }


### PR DESCRIPTION
Hi, this is a relatively small PR to simplify and streamline how PDF files are loaded and their page counts are determined. Previously `Document::load_metadata()` would read the file once and then `Document::load()` would read it again and thus yielding *two* file reads. Note that `Document::load()` on a path handles file reading internally. I've made it so that `std::fs::read()` reads it once and `Document::load_mem()` parses it from memory. This aligns `detect_pdf_type_with_config` with `load_document_from_path` in `lib.rs`, which already used this pattern.

This should eliminate one redundant parse for the same buffer, which I think is more semantically correct. Though, one *potential* correctness issue is `metadata.page_count` (from PDF's `/Count` key) vs `doc.get_pages().len()` (via lopdf's parsed page count). If a PDF has a malformed page tree, these could differ. The original code used the PDF's claimed count; my code uses lopdf's successfully-parsed count. I have not verified this specific edge case personally, but my tests yield appropriate *and faster* results. One test fixture (`2013-app2.pdf`) has lopdf parse errors and previously reported 9 pages from `/Count` vs 8 from `get_pages().len()`. The new behavior seems more correct. Integration tests also continue to pass. In short, the behavioral difference is that my version:

1. Is faster (on account of having eliminated redundant I/O/parsing)
2. Has slightly different page count semantics that actually seems more correct

This should reduce code complexity and potential redundancy a little bit. It's also faster! On my system total avg time went down from 8.95ms to 7.56ms, and the 9-page PDF parsing got down from 4.99ms to 4.00ms. I'd say ~15-20% operations are pretty neat :)

---

Worth nothing that I haven't tested the library in my own code yet; I'm currently on a memory-constrained system, and the project I'm tryin to use pdf-inspector on OOMs :(