### PR TITLE
fix: reduce false OCR recommendations for text PDFs with figures

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-pdf-inspector",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -223,7 +223,15 @@ pub(crate) fn detect_from_document(
             if analysis.has_images {
                 pages_with_images += 1;
             }
-            if analysis.has_template_image {
+            // Only count as a template-image page if it looks like a scan
+            // (single full-page image) rather than a text page with figures.
+            // Scanned-with-OCR PDFs have 1 large image per page + OCR text overlay;
+            // text PDFs with figures have multiple smaller images alongside real text.
+            if analysis.has_template_image
+                && (analysis.image_count <= 1
+                    || analysis.text_operator_count < 50
+                    || analysis.unique_alphanum_chars < 10)
+            {
                 pages_with_template_images += 1;
             }
             if analysis.has_vector_text {
@@ -350,7 +358,12 @@ pub(crate) fn detect_from_document(
                 } else {
                     continue;
                 };
-                if analysis.has_template_image
+                // Template images only need OCR when it looks like a scan
+                // (single full-page image) rather than figures alongside text.
+                let looks_like_scan = analysis.image_count <= 1
+                    || analysis.text_operator_count < 50
+                    || analysis.unique_alphanum_chars < 10;
+                if (analysis.has_template_image && looks_like_scan)
                     || analysis.has_vector_text
                     || (analysis.text_operator_count < config.min_text_ops_per_page
                         && analysis.has_images)
@@ -865,10 +878,17 @@ fn scan_content_for_text_operators(
                 }
             } else if next == b'f' {
                 // Tf = set font operator
+                // Some PDFs concatenate Tf with the next operator without
+                // whitespace (e.g. "25 Tf[<01>..." or "25 Tf(<text>..."),
+                // so also accept '[', '(', '<', '/' as valid followers.
                 if i + 2 >= content.len()
                     || content[i + 2].is_ascii_whitespace()
                     || content[i + 2] == b'\n'
                     || content[i + 2] == b'\r'
+                    || content[i + 2] == b'['
+                    || content[i + 2] == b'('
+                    || content[i + 2] == b'<'
+                    || content[i + 2] == b'/'
                 {
                     font_changes += 1;
                 }
@@ -1611,6 +1631,39 @@ mod tests {
         let (ops, _, _, fonts) = scan_content_for_text_operators(content, &mut uchars);
         assert_eq!(ops, 2);
         assert_eq!(fonts, 2);
+    }
+
+    #[test]
+    fn test_tf_without_trailing_whitespace() {
+        // Some PDFs concatenate Tf directly with the next operator's operand,
+        // e.g. "25 Tf[<01>..." or "25 Tf(<text>..."
+        let mut uchars = HashSet::new();
+
+        // Tf followed by '[' (TJ array start)
+        let content = b"BT /F1 25 Tf[<01>1<02>-1] TJ ET";
+        let (ops, _, _, fonts) = scan_content_for_text_operators(content, &mut uchars);
+        assert_eq!(fonts, 1, "Tf followed by '[' should be counted");
+        assert_eq!(ops, 1);
+
+        // Tf followed by '(' (literal string)
+        uchars.clear();
+        let content2 = b"BT /F1 12 Tf(Hello) Tj ET";
+        let (ops2, _, _, fonts2) = scan_content_for_text_operators(content2, &mut uchars);
+        assert_eq!(fonts2, 1, "Tf followed by '(' should be counted");
+        assert_eq!(ops2, 1);
+
+        // Tf followed by '<' (hex string)
+        uchars.clear();
+        let content3 = b"BT /F1 12 Tf<0102> Tj ET";
+        let (ops3, _, _, fonts3) = scan_content_for_text_operators(content3, &mut uchars);
+        assert_eq!(fonts3, 1, "Tf followed by '<' should be counted");
+        assert_eq!(ops3, 1);
+
+        // Tf followed by '/' (next font name)
+        uchars.clear();
+        let content4 = b"BT /F1 12 Tf/F2 10 Tf (x) Tj ET";
+        let (_, _, _, fonts4) = scan_content_for_text_operators(content4, &mut uchars);
+        assert_eq!(fonts4, 2, "Tf followed by '/' should be counted");
     }
 
     #[test]

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -185,7 +185,6 @@ pub(crate) fn detect_from_document(
 
     let mut pages_with_text = 0u32;
     let mut pages_with_images = 0u32;
-    let mut pages_with_template_images = 0u32;
     let mut pages_with_vector_text = 0u32;
     let mut total_text_ops = 0u32;
     // Cache Phase 1 results to avoid re-analyzing sampled pages in Phase 2
@@ -223,17 +222,13 @@ pub(crate) fn detect_from_document(
             if analysis.has_images {
                 pages_with_images += 1;
             }
-            // Only count as a template-image page if it looks like a scan
-            // (single full-page image) rather than a text page with figures.
-            // Scanned-with-OCR PDFs have 1 large image per page + OCR text overlay;
-            // text PDFs with figures have multiple smaller images alongside real text.
-            if analysis.has_template_image
-                && (analysis.image_count <= 1
-                    || analysis.text_operator_count < 50
-                    || analysis.unique_alphanum_chars < 10)
-            {
-                pages_with_template_images += 1;
-            }
+            // Template images (large background/figure images) no longer
+            // influence page classification. In the region-based pipeline,
+            // text regions are extracted independently from image regions,
+            // and per-region `needs_ocr` quality checks handle garbage text
+            // from scanned-with-OCR pages. Counting template images here
+            // caused false OCR recommendations for text PDFs with figures
+            // (e.g. academic papers, reports with charts).
             if analysis.has_vector_text {
                 pages_with_vector_text += 1;
             }
@@ -260,26 +255,13 @@ pub(crate) fn detect_from_document(
         0.0
     };
 
-    // Check if this is a template-based PDF (images provide essential context)
-    // Template PDFs have text AND large background images on most pages
-    let has_template_images = pages_with_template_images > 0;
-    let template_ratio = if pages_sampled > 0 {
-        pages_with_template_images as f32 / pages_sampled as f32
-    } else {
-        0.0
-    };
-
-    // OCR is recommended when:
-    // 1. Template images are present (text alone is insufficient), OR
-    // 2. PDF is scanned/image-based
+    // Classification logic.
+    // Template images no longer influence classification — in the region-based
+    // pipeline, text regions are extracted independently and per-region
+    // `needs_ocr` quality checks handle scanned-with-OCR garbage text.
     let ocr_recommended: bool;
 
-    // Classification logic
-    let (pdf_type, confidence) = if has_template_images && pages_with_text > 0 {
-        ocr_recommended = true;
-        // Template-based PDF: has text but images provide essential context
-        (PdfType::Mixed, 0.5 + (0.3 * (1.0 - template_ratio)))
-    } else if text_ratio >= config.text_page_ratio_threshold {
+    let (pdf_type, confidence) = if text_ratio >= config.text_page_ratio_threshold {
         ocr_recommended = false;
         (PdfType::TextBased, text_ratio)
     } else if pages_with_text == 0 && (pages_with_images > 0 || pages_with_vector_text > 0) {
@@ -358,13 +340,9 @@ pub(crate) fn detect_from_document(
                 } else {
                     continue;
                 };
-                // Template images only need OCR when it looks like a scan
-                // (single full-page image) rather than figures alongside text.
-                let looks_like_scan = analysis.image_count <= 1
-                    || analysis.text_operator_count < 50
-                    || analysis.unique_alphanum_chars < 10;
-                if (analysis.has_template_image && looks_like_scan)
-                    || analysis.has_vector_text
+                // Template images no longer trigger OCR — per-region
+                // quality checks handle scanned-with-OCR garbage text.
+                if analysis.has_vector_text
                     || (analysis.text_operator_count < config.min_text_ops_per_page
                         && analysis.has_images)
                 {

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -185,6 +185,7 @@ pub(crate) fn detect_from_document(
 
     let mut pages_with_text = 0u32;
     let mut pages_with_images = 0u32;
+    let mut pages_with_template_images = 0u32;
     let mut pages_with_vector_text = 0u32;
     let mut total_text_ops = 0u32;
     // Cache Phase 1 results to avoid re-analyzing sampled pages in Phase 2
@@ -222,13 +223,17 @@ pub(crate) fn detect_from_document(
             if analysis.has_images {
                 pages_with_images += 1;
             }
-            // Template images (large background/figure images) no longer
-            // influence page classification. In the region-based pipeline,
-            // text regions are extracted independently from image regions,
-            // and per-region `needs_ocr` quality checks handle garbage text
-            // from scanned-with-OCR pages. Counting template images here
-            // caused false OCR recommendations for text PDFs with figures
-            // (e.g. academic papers, reports with charts).
+            // Only count as a template-image page if it looks like a scan
+            // (single full-page image) rather than a text page with figures.
+            // Scanned-with-OCR PDFs have 1 large image per page + OCR text overlay;
+            // text PDFs with figures have multiple smaller images alongside real text.
+            if analysis.has_template_image
+                && (analysis.image_count <= 1
+                    || analysis.text_operator_count < 50
+                    || analysis.unique_alphanum_chars < 10)
+            {
+                pages_with_template_images += 1;
+            }
             if analysis.has_vector_text {
                 pages_with_vector_text += 1;
             }
@@ -255,13 +260,26 @@ pub(crate) fn detect_from_document(
         0.0
     };
 
-    // Classification logic.
-    // Template images no longer influence classification — in the region-based
-    // pipeline, text regions are extracted independently and per-region
-    // `needs_ocr` quality checks handle scanned-with-OCR garbage text.
+    // Check if this is a template-based PDF (images provide essential context)
+    // Template PDFs have text AND large background images on most pages
+    let has_template_images = pages_with_template_images > 0;
+    let template_ratio = if pages_sampled > 0 {
+        pages_with_template_images as f32 / pages_sampled as f32
+    } else {
+        0.0
+    };
+
+    // OCR is recommended when:
+    // 1. Template images are present (text alone is insufficient), OR
+    // 2. PDF is scanned/image-based
     let ocr_recommended: bool;
 
-    let (pdf_type, confidence) = if text_ratio >= config.text_page_ratio_threshold {
+    // Classification logic
+    let (pdf_type, confidence) = if has_template_images && pages_with_text > 0 {
+        ocr_recommended = true;
+        // Template-based PDF: has text but images provide essential context
+        (PdfType::Mixed, 0.5 + (0.3 * (1.0 - template_ratio)))
+    } else if text_ratio >= config.text_page_ratio_threshold {
         ocr_recommended = false;
         (PdfType::TextBased, text_ratio)
     } else if pages_with_text == 0 && (pages_with_images > 0 || pages_with_vector_text > 0) {
@@ -340,9 +358,13 @@ pub(crate) fn detect_from_document(
                 } else {
                     continue;
                 };
-                // Template images no longer trigger OCR — per-region
-                // quality checks handle scanned-with-OCR garbage text.
-                if analysis.has_vector_text
+                // Template images only need OCR when it looks like a scan
+                // (single full-page image) rather than figures alongside text.
+                let looks_like_scan = analysis.image_count <= 1
+                    || analysis.text_operator_count < 50
+                    || analysis.unique_alphanum_chars < 10;
+                if (analysis.has_template_image && looks_like_scan)
+                    || analysis.has_vector_text
                     || (analysis.text_operator_count < config.min_text_ops_per_page
                         && analysis.has_images)
                 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,31 +1023,27 @@ fn process_document(
             options.page_filter.as_ref(),
         );
 
-        // For Mixed/template PDFs: if normal extraction produces garbage text
-        // (mostly non-alphanumeric), retry with invisible (Tr=3) text included.
-        // This unlocks OCR text layers behind scanned images.
-        if pdf_type == PdfType::Mixed {
-            if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
-                let sample: String = items.iter().take(200).map(|i| i.text.as_str()).collect();
-                if is_garbage_text(&sample) || sample.trim().is_empty() {
-                    extractor::extract_positioned_text_include_invisible(
-                        &doc,
-                        &font_cmaps,
-                        options.page_filter.as_ref(),
-                    )
-                } else {
-                    result
-                }
-            } else {
-                // Normal extraction failed — try invisible as fallback
+        // If normal extraction produces garbage text or is empty, retry with
+        // invisible (Tr=3) text included. This unlocks OCR text layers behind
+        // scanned images regardless of PDF type classification.
+        if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
+            let sample: String = items.iter().take(200).map(|i| i.text.as_str()).collect();
+            if is_garbage_text(&sample) || sample.trim().is_empty() {
                 extractor::extract_positioned_text_include_invisible(
                     &doc,
                     &font_cmaps,
                     options.page_filter.as_ref(),
                 )
+            } else {
+                result
             }
         } else {
-            result
+            // Normal extraction failed — try invisible as fallback
+            extractor::extract_positioned_text_include_invisible(
+                &doc,
+                &font_cmaps,
+                options.page_filter.as_ref(),
+            )
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,27 +1023,31 @@ fn process_document(
             options.page_filter.as_ref(),
         );
 
-        // If normal extraction produces garbage text or is empty, retry with
-        // invisible (Tr=3) text included. This unlocks OCR text layers behind
-        // scanned images regardless of PDF type classification.
-        if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
-            let sample: String = items.iter().take(200).map(|i| i.text.as_str()).collect();
-            if is_garbage_text(&sample) || sample.trim().is_empty() {
+        // For Mixed/template PDFs: if normal extraction produces garbage text
+        // (mostly non-alphanumeric), retry with invisible (Tr=3) text included.
+        // This unlocks OCR text layers behind scanned images.
+        if pdf_type == PdfType::Mixed {
+            if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
+                let sample: String = items.iter().take(200).map(|i| i.text.as_str()).collect();
+                if is_garbage_text(&sample) || sample.trim().is_empty() {
+                    extractor::extract_positioned_text_include_invisible(
+                        &doc,
+                        &font_cmaps,
+                        options.page_filter.as_ref(),
+                    )
+                } else {
+                    result
+                }
+            } else {
+                // Normal extraction failed — try invisible as fallback
                 extractor::extract_positioned_text_include_invisible(
                     &doc,
                     &font_cmaps,
                     options.page_filter.as_ref(),
                 )
-            } else {
-                result
             }
         } else {
-            // Normal extraction failed — try invisible as fallback
-            extractor::extract_positioned_text_include_invisible(
-                &doc,
-                &font_cmaps,
-                options.page_filter.as_ref(),
-            )
+            result
         }
     };
 


### PR DESCRIPTION
## Summary

- **Fix Tf operator parsing**: Some PDFs (e.g. arXiv papers) concatenate `Tf` directly with the next operator without whitespace (`25 Tf[<01>...`). The scanner now accepts `[`, `(`, `<`, `/` as valid followers, fixing `font_changes` being reported as 0.
- **Distinguish text-with-figures from scanned-with-OCR**: Pages with multiple images (`image_count > 1`) and strong text signals (`text_ops >= 50`, `alphanum >= 10`) are now recognized as text pages with inline figures — not scanned templates needing OCR. Scanned PDFs characteristically have exactly 1 full-page image per page.

### Impact


In pdf-evals, many PDFs benefit — e.g. a 492-page book goes from all pages needing OCR to just 23. No new regressions (5 pre-existing failures unchanged).

## Test plan

- [x] `cargo test` — all pass (new test for Tf parsing added)
- [x] `cargo clippy -- -D warnings` — clean
- [x] pdf-evals — no new regressions, many detection improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)