### PR TITLE
feat(npm): publish Windows binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -38,7 +38,8 @@
     "binaryName": "pdf-inspector",
     "targets": [
       "x86_64-unknown-linux-gnu",
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
     ],
     "package": {
       "name": "@firecrawl/pdf-inspector-js"


### PR DESCRIPTION
## Summary
- Add `x86_64-pc-windows-msvc` to the napi targets and CI build matrix so the published npm package ships native Windows binaries.
- Bump `@firecrawl/pdf-inspector` from 1.1.0 → 1.2.0.

## Test plan
- [ ] `Publish npm package` workflow builds Linux, macOS, and Windows artifacts on merge.
- [ ] Resulting 1.2.0 publish includes the Windows `.node` binary and loads correctly on a Windows machine via `npx pdf-inspector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)