### PR TITLE
Stage 1 exclusive item-to-cell assignment

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,24 +931,73 @@ pub fn extract_tables_with_structure_cells_mem(
 
         normalize_cell_bands(&mut cells);
 
-        // Stage 1: strict text fill — each cell gets the items whose centers
-        // fall inside its (normalized) bbox or whose >=60% overlap rule fires.
-        // Track which item indices any cell claimed so the orphan pass below
-        // doesn't double-assign.
+        // Stage 1: exclusive per-item assignment. For each PDF text item,
+        // find the cell(s) whose (band-clamped) bbox satisfies the strict
+        // membership rule (`tsr_region_contains_item`: center inside OR
+        // >=60% overlap on both axes). If multiple cells qualify, assign
+        // the item to the cell whose center is geometrically closest. If
+        // exactly one qualifies, assign to that. If none, the item is an
+        // orphan and stage 2 below tries to recover it.
+        //
+        // The exclusivity (one item → one cell) prevents the cell-overlap
+        // bug where SLANet emits cells whose y-extents overlap between
+        // rows: under the previous "for each cell, gather items" approach,
+        // an item whose center fell in two cells' overlap got duplicated
+        // into both. Closest-center disambiguation routes it to the
+        // correct row.
         let mut claimed: std::collections::HashSet<usize> = std::collections::HashSet::new();
-        for cell in &mut cells {
-            let [x1, y1, x2, y2] = cell.page_pt_bbox;
-            let bounds = region_bounds(x1, y1, x2, y2, page_h, coords);
-            let mut matched: Vec<TextItem> = Vec::new();
-            for (i, item) in items.iter().enumerate() {
-                if tsr_region_contains_item(item, bounds) {
-                    claimed.insert(i);
-                    matched.push(item.clone());
+        let mut item_to_cell: std::collections::HashMap<usize, usize> =
+            std::collections::HashMap::new();
+
+        // Pre-compute each cell's bounds + center (in PDF-pt-flipped space)
+        // so we don't redo the work per item.
+        let cell_meta: Vec<Option<(RegionBounds, f32, f32)>> = cells
+            .iter()
+            .map(|cell| {
+                let [x1, y1, x2, y2] = cell.page_pt_bbox;
+                if x1 >= x2 || y1 >= y2 {
+                    return None;
+                }
+                let bounds = region_bounds(x1, y1, x2, y2, page_h, coords);
+                let cx = (bounds.x_min + bounds.x_max) * 0.5;
+                let cy = (bounds.y_min + bounds.y_max) * 0.5;
+                Some((bounds, cx, cy))
+            })
+            .collect();
+
+        for (item_idx, item) in items.iter().enumerate() {
+            let item_w = text_utils::effective_width(item);
+            let item_cx = item.x + item_w * 0.5;
+            let item_cy = item.y + item.height * 0.5;
+            let mut best: Option<(usize, f32)> = None;
+            for (cell_idx, meta) in cell_meta.iter().enumerate() {
+                let Some((bounds, ccx, ccy)) = meta else {
+                    continue;
+                };
+                if !tsr_region_contains_item(item, *bounds) {
+                    continue;
+                }
+                let dx = item_cx - ccx;
+                let dy = item_cy - ccy;
+                let dist_sq = dx * dx + dy * dy;
+                if best.is_none_or(|(_, d)| dist_sq < d) {
+                    best = Some((cell_idx, dist_sq));
                 }
             }
-            // Markdown cells must be one line — collapse line breaks produced
-            // by the line-grouping pass.
-            cell.text = collect_text_from_matched_items(matched, adaptive_threshold)
+            if let Some((ci, _)) = best {
+                claimed.insert(item_idx);
+                item_to_cell.insert(item_idx, ci);
+            }
+        }
+
+        // Build per-cell text from the assigned items. Markdown cells must
+        // be one line — collapse line breaks from the line-grouping pass.
+        let mut per_cell_items: Vec<Vec<TextItem>> = vec![Vec::new(); cells.len()];
+        for (&item_idx, &cell_idx) in &item_to_cell {
+            per_cell_items[cell_idx].push(items[item_idx].clone());
+        }
+        for (cell_idx, matched) in per_cell_items.into_iter().enumerate() {
+            cells[cell_idx].text = collect_text_from_matched_items(matched, adaptive_threshold)
                 .replace(['\n', '\r'], " ");
         }
 


### PR DESCRIPTION
## Summary

Closes the row-merge pattern observed against the FNBO branch list at the College/Fairway boundary. Bumps `@firecrawl/pdf-inspector` to **1.6.4**.

## Cause (from local diagnostics)

The `tsr-table-extraction` flow uses local pod calls + `extractTablesWithStructureCells` to dump the actual cell list for FNBO. The College/Fairway boundary shows:

- SLANet emits cells whose y-extents **overlap between consecutive rows** (cell heights ~18-20pt on a row pitch of ~16.8pt).
- An item whose center falls in the overlap region was getting matched into BOTH cells under the previous "for each cell, gather items inside" loop.
- `normalize_cell_bands` reduces overlap, but its midpoint clamp uses cell-mean-center, which is biased when SLANet bboxes are taller than their text content (cell center ≠ text baseline). The clamped boundary lands on the wrong side of the text, items still match two cells, and the duplication produces "Kansas Kansas" / concatenated addresses.

## Fix

Invert the matching in stage 1. For each PDF text item:

1. Find candidate cells (those satisfying `tsr_region_contains_item` — center inside OR ≥60% overlap on both axes).
2. Assign the item to the cell whose **center is geometrically closest** (Euclidean distance, item center vs cell center).
3. Build per-cell text from the assigned items.

Stage 2 (orphan recovery, added in 1.6.2/1.6.3) is unchanged.

`normalize_cell_bands` stays — it tightens cells before matching so fewer cells are ambiguous candidates — but is no longer load-bearing for correctness of the cell-overlap case.

## Local verification

`api/scripts/local-tsr-replay.ts` exercises the full flow (layout pod → table pod → pdf-inspector) with my locally-built napi binary, no deploy needed.

**Before** (1.6.3 deployed):
```
|LITH West|Illinois Illinois|11700 S. IL Route 47, Huntley IL... 4520 W Algonquin Rd, Lake in the Hills...|8711.15|
|College|||0534.03|
|Fairway|Kansas Kansas|4650 College Blvd, Overland Park KS... 2828 Shawnee Mission Pkwy, Fairway KS...|0532.01|
```

**After** (this change):
```
|Huntley|Illinois|11700 S. IL Route 47, Huntley IL, 60142|8711.15|
|LITH West|Illinois|4520 W Algonquin Rd, Lake in the Hills IL, 60156|8711.11|
|College|Kansas|4650 College Blvd, Overland Park KS, 66211|0532.01|
|Fairway|Kansas|2828 Shawnee Mission Pkwy, Fairway KS, 66205|0500.00|
|Metcalf|Kansas|9700 Metcalf, Overland Park KS, 66212|0518.03|
```

## Known-residual

One row (Shawnee in the Kansas section) can still get dropped under SLANet detection variance — the model occasionally under-detects rows and emits N structure rows for N+1 PDF rows. The squeezed row's text gets routed to the structurally-nearest existing cell. This is a SLANet limitation, not addressable in pdf-inspector without synthesizing rows from PDF text geometry. Deferred to a separate investigation.

## Test plan

- [x] `cargo test --release` — 416 lib + 120 integration + 2 doctests pass
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Local replay against FNBO via `api/scripts/local-tsr-replay.ts` shows expected fixes
- [ ] After publish + dep bump in fire-pdf, re-run the FNBO A/B and confirm Huntley/LITH and College/Fairway clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)