### PR TITLE
feat: Add WebAssembly (WASM) compiler target and browser CDN support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,8 @@ crate-type = ["lib", "cdylib"]
 # Python bindings
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
 
-# PDF parsing
-lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1ce522391d6beab8a1284", features = ["rayon"] }
-
 # Error handling
 thiserror = "2.0"
-
-# Parallel processing
-rayon = "1.10"
 
 # Logging
 log = "0.4"
@@ -36,6 +30,20 @@ unicode-normalization = "0.1"
 
 # TrueType font parsing (for Identity-H CID font cmap extraction)
 ttf-parser = "0.25"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Parallel processing
+rayon = "1.10"
+# PDF parsing with threading
+lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1ce522391d6beab8a1284", features = ["rayon"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# PDF parsing without threading for WASM
+lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1ce522391d6beab8a1284" }
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1.7"
+getrandom = { version = "0.4", features = ["wasm_js"] }
+js-sys = "0.3"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1c
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # PDF parsing without threading for WASM
-lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1ce522391d6beab8a1284" }
+lopdf = { git = "https://github.com/J-F-Liu/lopdf", rev = "7a05512d831415b1f2b1ce522391d6beab8a1284", default-features = false, features = ["chrono", "jiff", "time"] }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub mod text_utils;
 pub mod tounicode;
 pub mod types;
 
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
 pub use detector::{
     detect_pdf_type, detect_pdf_type_mem, detect_pdf_type_mem_with_config,
     detect_pdf_type_with_config, DetectionConfig, PdfType, PdfTypeResult, ScanStrategy,
@@ -85,6 +88,23 @@ pub struct PdfProcessResult {
     /// `true` when broken font encodings are detected (garbled text,
     /// replacement characters). Clients should fall back to OCR.
     pub has_encoding_issues: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type CompatInstant = std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy)]
+pub struct CompatInstant(f64);
+
+#[cfg(target_arch = "wasm32")]
+impl CompatInstant {
+    pub fn now() -> Self {
+        CompatInstant(js_sys::Date::now())
+    }
+    pub fn elapsed(&self) -> std::time::Duration {
+        std::time::Duration::from_millis((js_sys::Date::now() - self.0) as u64)
+    }
 }
 
 // =========================================================================
@@ -190,7 +210,7 @@ pub fn process_pdf_with_options<P: AsRef<Path>>(
     path: P,
     options: PdfOptions,
 ) -> Result<PdfProcessResult, PdfError> {
-    let start = std::time::Instant::now();
+    let start = CompatInstant::now();
     validate_pdf_file(&path)?;
 
     // Load the document once — shared by detection AND extraction.
@@ -216,7 +236,7 @@ pub fn process_pdf_mem_with_options(
     buffer: &[u8],
     options: PdfOptions,
 ) -> Result<PdfProcessResult, PdfError> {
-    let start = std::time::Instant::now();
+    let start = CompatInstant::now();
     validate_pdf_bytes(buffer)?;
 
     let (doc, page_count) = load_document_from_mem(buffer)?;
@@ -1818,7 +1838,7 @@ fn process_document(
     doc: Document,
     page_count: u32,
     options: PdfOptions,
-    start: std::time::Instant,
+    start: CompatInstant,
 ) -> Result<PdfProcessResult, PdfError> {
     // Step 1 — Detection (cheap: scans content streams for text operators)
     let detection = detector::detect_from_document(&doc, page_count, &options.detection)?;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,16 @@
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn process_pdf_bytes(data: &[u8]) -> Result<String, JsValue> {
+    console_error_panic_hook::set_once();
+
+    let result = crate::process_pdf_mem(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    
+    if let Some(markdown) = result.markdown {
+        Ok(markdown)
+    } else {
+        Ok(String::new())
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,13 +1,11 @@
-#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn process_pdf_bytes(data: &[u8]) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
 
     let result = crate::process_pdf_mem(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    
+
     if let Some(markdown) = result.markdown {
         Ok(markdown)
     } else {

--- a/wasm-demo/index.html
+++ b/wasm-demo/index.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF Inspector WebAssembly Demo</title>
+    <style>
+        :root {
+            --primary: #ff4f00;
+            --primary-hover: #e04500;
+            --bg-color: #fafafa;
+            --text-main: #111827;
+            --text-muted: #6b7280;
+            --border-color: #e5e7eb;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-main);
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+        }
+
+        .header {
+            background-color: #ffffff;
+            width: 100%;
+            padding: 1.5rem 0;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+
+        .header h1 {
+            margin: 0;
+            font-size: 1.75rem;
+            font-weight: 700;
+        }
+
+        .header span {
+            color: var(--primary);
+        }
+
+        .container {
+            width: 100%;
+            max-width: 900px;
+            padding: 0 1.5rem;
+            box-sizing: border-box;
+        }
+
+        p.description {
+            text-align: center;
+            color: var(--text-muted);
+            margin-bottom: 2.5rem;
+            font-size: 1.1rem;
+        }
+
+        a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .drop-zone {
+            border: 2px dashed #cbd5e1;
+            padding: 3rem 2rem;
+            text-align: center;
+            border-radius: 12px;
+            background: #ffffff;
+            cursor: pointer;
+            transition: all 0.2s ease-in-out;
+            margin-bottom: 24px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+
+        .drop-zone:hover {
+            background: #fff5f2;
+            border-color: var(--primary);
+        }
+
+        .drop-zone svg {
+            width: 48px;
+            height: 48px;
+            color: var(--primary);
+            opacity: 0.8;
+        }
+
+        .drop-zone .title {
+            font-weight: 600;
+            font-size: 1.25rem;
+            color: var(--text-main);
+        }
+
+        .drop-zone .subtitle {
+            font-size: 0.95rem;
+            color: var(--text-muted);
+        }
+
+        .output-container {
+            background: #1e1e2f;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+            margin-bottom: 3rem;
+        }
+
+        .output-header {
+            background: #2a2a3f;
+            padding: 0.75rem 1.5rem;
+            color: #e2e8f0;
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        #output {
+            width: 100%;
+            height: 500px;
+            padding: 1.5rem;
+            border: none;
+            font-family: "JetBrains Mono", "Fira Code", Consolas, monospace;
+            font-size: 0.95rem;
+            line-height: 1.5;
+            color: #f8f8f2;
+            white-space: pre-wrap;
+            overflow-y: auto;
+            background-color: transparent;
+            box-sizing: border-box;
+        }
+
+        /* Custom scrollbar for dark theme */
+        #output::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        #output::-webkit-scrollbar-track {
+            background: #1e1e2f;
+        }
+
+        #output::-webkit-scrollbar-thumb {
+            background: #474761;
+            border-radius: 4px;
+        }
+
+        #output::-webkit-scrollbar-thumb:hover {
+            background: #626284;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="header">
+        <h1>📄 PDF Inspector <span>WASM</span></h1>
+    </div>
+
+    <div class="container">
+        <p class="description">
+            This runs the <a href="https://github.com/firecrawl/pdf-inspector" target="_blank">Firecrawl
+                pdf-inspector</a> Rust engine
+            <strong>directly inside your browser</strong>. <br>No backend servers, no OCR delays, pure Native WASM
+            speed.
+        </p>
+
+        <div class="drop-zone" id="dropZone" onclick="document.getElementById('fileInput').click()">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+            </svg>
+            <div class="title">Click or drop a PDF here</div>
+            <div class="subtitle">Extracts text and complex tables to Markdown instantly</div>
+            <input type="file" id="fileInput" accept="application/pdf" style="display: none;"
+                onchange="handleFileSelect(event)">
+        </div>
+
+        <div class="output-container">
+            <div class="output-header">
+                <span>Markdown Output</span>
+                <span id="timing"></span>
+            </div>
+            <div id="output">Waiting for file...</div>
+        </div>
+    </div>
+
+    <!-- 
+      Once the package is published to NPM and CDNs, you will use something like:
+      import init, { process_pdf_bytes } from 'https://unpkg.com/firecrawl-pdf-inspector-web/pkg/pdf_inspector.js';
+      
+      For local tests after compiling with `wasm-pack build --target web`:
+    -->
+    <script type="module">
+        window.wasmParserReady = false;
+        let process_pdf_bytes_fn = null;
+
+        window.handleFileSelect = async function (event) {
+            if (!window.wasmParserReady) {
+                alert("WASM is not loaded or compiled yet! Make sure to run 'wasm-pack build --target web' first.");
+                return;
+            }
+
+            const file = event.target.files[0];
+            if (!file) return;
+
+            document.getElementById('timing').textContent = "";
+            document.getElementById('output').textContent = "Processing...";
+
+            const reader = new FileReader();
+            reader.onload = async function (e) {
+                const arrayBuffer = e.target.result;
+                const bytes = new Uint8Array(arrayBuffer);
+
+                const startTime = performance.now();
+
+                try {
+                    const markdown = process_pdf_bytes_fn(bytes);
+                    const endTime = performance.now();
+                    const duration = (endTime - startTime).toFixed(2);
+
+                    document.getElementById('timing').textContent = `Processed in ${duration}ms`;
+                    document.getElementById('output').textContent = markdown;
+
+                } catch (err) {
+                    document.getElementById('output').textContent = "Error parsing PDF:\n" + err;
+                }
+            };
+            reader.readAsArrayBuffer(file);
+        };
+
+        async function setup() {
+            try {
+                document.getElementById('output').textContent = "Attempting to load WASM package...\n(If it fails, run 'wasm-pack build --target web' in the project root)";
+
+                const wasmModule = await import('../pkg/pdf_inspector.js');
+                await wasmModule.default();
+                process_pdf_bytes_fn = wasmModule.process_pdf_bytes;
+
+                window.wasmParserReady = true;
+                document.getElementById('output').textContent = "✅ WASM Loaded successfully!\n\nYou can drop a PDF above.";
+            } catch (err) {
+                console.error("Failed to initialize WASM", err);
+                document.getElementById('output').textContent = "❌ Error loading WASM component (check if the pkg/ folder exists).\nDetails: " + err;
+            }
+        }
+
+        setup();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR introduces the foundation for adapting `pdf-inspector` to run fully client-side on browsers via WebAssembly (WASM).

**Changes:**
- Conditionally disabled the `rayon` threading dependency strictly for `wasm32` environments (as WebAssembly forbids multi-threading/OS threads by default).
- Implemented a mocked `CompatInstant` fallback using `js_sys::Date::now()` to resolve the `RuntimeError: unreachable` fatal error occurring during WASM compilation from `std::time::Instant::now()`.
- Explicitly enabled the `wasm_js` feature for the `getrandom` crate exclusively for `cfg(target_arch = "wasm32")`.
- Exported the core `process_pdf_mem` logic through the `wasm-bindgen` API in a new `src/wasm.rs` module.
- Added a full demo client `wasm-demo/index.html` showcasing the direct conversion happening purely client-side without OCR delays.

### Demo (WASM running pure client-side processing)
<img width="800" height="457" alt="firecrawl-wasm-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/4d2c0361-0446-4514-9711-965d50803132" />