### PR TITLE
extract_tables: reject partial extractions in needs_ocr gate

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,6 +772,10 @@ pub fn extract_tables_in_regions_mem(
                 })
                 .unwrap_or_default();
 
+            // Total length of text the page extractor saw inside this
+            // region, used by the captured-fragment guard below.
+            let region_text_chars: usize = matched.iter().map(|i| i.text.chars().count()).sum();
+
             let evaluate = |t: &tables::Table| -> Option<String> {
                 let md = tables::table_to_markdown(t);
                 let trimmed = md.trim();
@@ -783,10 +787,24 @@ pub fn extract_tables_in_regions_mem(
                     || detect_encoding_issues(&md)
                     || looks_like_partial_table_ex(&md, true)
                 {
-                    None
-                } else {
-                    Some(md)
+                    return None;
                 }
+                // Reject extractions that only captured a small fraction
+                // of the text actually in the region. Two recurring
+                // failure shapes this catches:
+                //   - "header-only": detector found the column-header band
+                //     cleanly but missed every data row below (financial
+                //     statements with multi-line column headers + many
+                //     data rows are the dominant case).
+                //   - "sparse": detector returned a couple of fragmentary
+                //     cells even though the region has many lines of text.
+                // The region floor (200 chars) keeps short legitimate
+                // tables (timestamps, units, axis labels) from being
+                // rejected as partial.
+                if captured_only_a_fragment(&md, region_text_chars) {
+                    return None;
+                }
+                Some(md)
             };
 
             let mut accepted_md: Option<String> = None;
@@ -3608,6 +3626,28 @@ fn is_cid_garbage(text: &str) -> bool {
 /// anymore, only "can we extract it correctly?". Paragraph and duplicate-
 /// header checks stay, since those indicate genuine extraction quality
 /// issues regardless of how the region was identified.
+/// Return true when the captured table markdown represents only a small
+/// fraction of the text the page extractor actually saw inside the
+/// region — typically a header-only band or a sparse fragment where
+/// the detector found valid grid structure but missed most of the
+/// data rows below.
+///
+/// Tuned at a 25% floor: tables that captured at least a quarter of
+/// the region's text are treated as complete-enough. Below 25%, the
+/// caller falls back to `needs_ocr = true` so GLM-OCR can take over.
+/// The 200-char region floor keeps short legitimate tables (units,
+/// axis labels, single-row stat blocks) from being mis-flagged.
+fn captured_only_a_fragment(markdown: &str, region_text_chars: usize) -> bool {
+    if region_text_chars <= 200 {
+        return false;
+    }
+    let captured_text_chars: usize = markdown
+        .chars()
+        .filter(|c| !matches!(c, '|' | '-' | '\n'))
+        .count();
+    captured_text_chars * 4 < region_text_chars
+}
+
 fn looks_like_partial_table_ex(markdown: &str, layout_assisted: bool) -> bool {
     let lines: Vec<&str> = markdown.lines().filter(|l| l.starts_with('|')).collect();
     if lines.len() < 2 {
@@ -3759,6 +3799,57 @@ fn looks_like_partial_table_ex(markdown: &str, layout_assisted: bool) -> bool {
 #[cfg(test)]
 fn looks_like_partial_table(markdown: &str) -> bool {
     looks_like_partial_table_ex(markdown, false)
+}
+
+#[cfg(test)]
+mod captured_only_a_fragment_tests {
+    use super::captured_only_a_fragment;
+
+    #[test]
+    fn small_region_skips_check() {
+        // Short legitimate tables (axis labels, unit blocks) shouldn't be
+        // flagged even when the captured markdown is tiny.
+        let md = "|Year|Value|\n|---|---|\n|2024|10|";
+        assert!(!captured_only_a_fragment(md, 50));
+    }
+
+    #[test]
+    fn full_table_passes() {
+        // Captured markdown matches the region text — full extraction.
+        let md =
+            "|Name|Year|Country|\n|---|---|---|\n|Alice|2020|US|\n|Bob|2021|UK|\n|Carol|2019|FR|";
+        // Region had ~50 chars of text (rough estimate of just the data words).
+        assert!(!captured_only_a_fragment(md, 50));
+        // Even a much larger region matched by the markdown content passes.
+        assert!(!captured_only_a_fragment(md, md.len()));
+    }
+
+    #[test]
+    fn header_only_extraction_rejected() {
+        // Captured the column-header band (~30 chars) while the region
+        // actually has many rows of data (~1500 chars).
+        let md = "|Description|Year|Amount|\n|---|---|---|";
+        assert!(captured_only_a_fragment(md, 1500));
+    }
+
+    #[test]
+    fn sparse_fragment_rejected() {
+        // A couple of fragment cells captured from a content-rich region.
+        let md = "|percent|for|\n|---|---|\n|sites|15|";
+        assert!(captured_only_a_fragment(md, 2000));
+    }
+
+    #[test]
+    fn boundary_at_25_percent_floor() {
+        // Right at the 25% line: 250 captured chars of 1000 region chars.
+        // The check rejects when captured*4 < region, so 250*4=1000 is NOT
+        // less than 1000 — boundary is treated as acceptable.
+        let md = "x".repeat(250);
+        assert!(!captured_only_a_fragment(&md, 1000));
+        // Just under 25%: 249*4=996 < 1000 — flagged.
+        let md_under = "x".repeat(249);
+        assert!(captured_only_a_fragment(&md_under, 1000));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

After turning on the vector-grid detectors for the public extract path (#85) and broadening detection coverage (#83/#84/#86), one residual failure shape remained: detectors finding a valid grid but only capturing a small fraction of the region's text. Customers flipping `__nativeTableExtraction=true` would have received those partials as the served output.

Two recurring sub-shapes from shadow data:

- **Header-only**: detector captured the column-header band (multi-line year/units rows) cleanly, missed every data row below. Common in financial statements, securities tables, budget appendices.
- **Sparse**: detector returned a few fragmentary cells from a content-rich region.

Both passed the existing `needs_ocr` quality gates because the captured cells look like well-formed markdown — but content-wise they're a 2-row fragment of a 50-row table.

## The guard

Add `captured_only_a_fragment(md, region_text_chars)`: rejects when the captured non-delimiter character count is less than 25% of the text the page extractor saw inside the region. Wired into the existing `evaluate` closure alongside `is_garbage_text` / `is_cid_garbage` / `detect_encoding_issues` / `looks_like_partial_table_ex`.

Region floor (200 chars) prevents short legitimate tables (units, axis labels, small stat blocks) from being mis-flagged.

## Validation

End-to-end against three representative residual cases pulled from shadow logs:

| Case | Before | After |
|---|---|---|
| Multi-line financial header + many data rows | `needs_ocr=false`, 78 chars | `needs_ocr=true`, 0 chars (→ GLM) |
| Securities table column header only | `needs_ocr=false`, 80 chars | `needs_ocr=true`, 0 chars (→ GLM) |
| ESIA-style sparse fragmentary cells | `needs_ocr=false`, 65 chars | `needs_ocr=true`, 0 chars (→ GLM) |

Previously-passing fixtures still pass through with full content:

| Case | Before | After |
|---|---|---|
| Full-page A4 governmental ledger | 6520 chars | 6520 chars |
| Multi-row key/value layout (paragraph values) | 1733 chars | 1733 chars |
| Archival-catalog horizontal-segment grid | 1754 chars | 1754 chars |

## Test plan

- [x] Added `captured_only_a_fragment_tests` module (5 tests covering small-region skip, full-table pass, header-only reject, sparse reject, 25% boundary)
- [x] `cargo test --release` passes (443 + 134 + 2 tests)
- [x] End-to-end probe confirms all three residual cases flip to `needs_ocr=true`
- [x] End-to-end probe confirms three full-table fixtures still produce same output
- [x] Bump 1.8.11 → 1.8.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)