### PR TITLE
Add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in pdf-inspector, please
+report it privately so we can fix it before public disclosure.
+
+**Preferred:** Email **help@firecrawl.dev** with:
+
+- A description of the issue and its impact
+- Steps to reproduce (a minimal PDF or input that triggers the bug is ideal)
+- The version or commit hash of pdf-inspector you tested against
+
+**Alternative:** Use GitHub's private vulnerability reporting under the
+[Security tab](https://github.com/firecrawl/pdf-inspector/security/advisories/new).
+
+We'll acknowledge your report in a timely manner and keep you updated on
+remediation progress. Please do not open a public GitHub issue for security
+bugs.
+
+## Scope
+
+In scope:
+- Memory-safety issues (panics, OOB reads, UB) reachable from a crafted PDF
+- Denial-of-service vectors (unbounded allocation, infinite loops) on
+  reasonably-sized inputs
+- Bugs in the `pdf2md` / `detect-pdf` binaries or the `pdf-inspector` crate
+  that affect downstream consumers
+
+Out of scope:
+- Bugs in upstream dependencies (`lopdf`, etc.) — please report those upstream
+- Extraction quality issues (wrong text, missing tables) — open a regular
+  GitHub issue instead


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` so researchers have a clear, private channel to report vulnerabilities instead of opening public GitHub issues.
- Directs reports to **help@firecrawl.dev** (preferred) or GitHub's private advisory flow.
- Defines basic scope: memory-safety bugs, DoS via crafted PDFs, and bugs in the `pdf2md` / `detect-pdf` binaries are in scope; upstream dep bugs and extraction-quality issues are out of scope.

Replaces #88, which was closed because it shipped placeholder template text and didn't include a reporting channel.

## Test plan

- [x] File renders correctly on GitHub
- [x] Link to GitHub's private advisory flow resolves
- [ ] Confirm `help@firecrawl.dev` is the correct contact alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)