### PR TITLE
ci: switch to Swatinem/rust-cache to fix macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --verbose
@@ -61,17 +51,9 @@ jobs:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+          key: clippy
 
       - name: Run clippy
         run: cargo clippy -- -D warnings
@@ -89,17 +71,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          key: build
 
       - name: Build
         run: cargo build --release --verbose


### PR DESCRIPTION
## Summary
- macOS Build job was failing with `error: unexpected argument 'build' found / Usage: rustup-init`
- Root cause: caching `~/.cargo/bin/` via `actions/cache@v4` mangled the `cargo` symlink so it resolved to `rustup-init` on restore
- Replaced all three hand-rolled cache blocks with `Swatinem/rust-cache@v2`, which skips `~/.cargo/bin/` and handles `target/` pruning + key derivation

Failing run for reference: https://github.com/firecrawl/pdf-inspector/actions/runs/25879583440

## Test plan
- [ ] CI passes on this PR (all four jobs: Test, Format, Clippy, Build matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)