### PR TITLE
chore(npm): publish legacy wrapper

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,12 @@ jobs:
 
           echo "scoped old=$SCOPED_OLD new=$SCOPED_NEW"
           echo "legacy old=$LEGACY_OLD new=$LEGACY_NEW"
+
+          if [ "$LEGACY_NEW" != "$SCOPED_NEW" ]; then
+            echo "Legacy package version ($LEGACY_NEW) must match scoped package version ($SCOPED_NEW)." >&2
+            exit 1
+          fi
+
           echo "scoped_version=$SCOPED_NEW" >> "$GITHUB_OUTPUT"
           echo "legacy_version=$LEGACY_NEW" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,10 @@ name: Publish npm package
 on:
   push:
     branches: [main]
-    paths: ['napi/package.json']
+    paths:
+      - '.github/workflows/publish.yml'
+      - 'napi/package.json'
+      - 'napi/legacy/**'
 
 permissions:
   contents: read
@@ -14,29 +17,54 @@ jobs:
     name: Check version change
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.check.outputs.changed }}
-      version: ${{ steps.check.outputs.version }}
+      scoped_changed: ${{ steps.check.outputs.scoped_changed }}
+      scoped_version: ${{ steps.check.outputs.scoped_version }}
+      legacy_changed: ${{ steps.check.outputs.legacy_changed }}
+      legacy_version: ${{ steps.check.outputs.legacy_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: Check if version changed
+      - name: Check if versions changed
         id: check
         run: |
-          NEW_VERSION=$(node -p "require('./napi/package.json').version")
-          OLD_VERSION=$(git show HEAD~1:napi/package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
-          echo "old=$OLD_VERSION new=$NEW_VERSION"
-          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          SCOPED_NEW=$(node -p "require('./napi/package.json').version")
+          if git show HEAD~1:napi/package.json >/tmp/scoped-package-old.json 2>/dev/null; then
+            SCOPED_OLD=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/scoped-package-old.json','utf8')).version")
           else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            SCOPED_OLD=""
+          fi
+
+          LEGACY_NEW=$(node -p "require('./napi/legacy/package.json').version")
+          if git show HEAD~1:napi/legacy/package.json >/tmp/legacy-package-old.json 2>/dev/null; then
+            LEGACY_OLD=$(node -p "JSON.parse(require('fs').readFileSync('/tmp/legacy-package-old.json','utf8')).version")
+          else
+            LEGACY_OLD=""
+          fi
+
+          echo "scoped old=$SCOPED_OLD new=$SCOPED_NEW"
+          echo "legacy old=$LEGACY_OLD new=$LEGACY_NEW"
+          echo "scoped_version=$SCOPED_NEW" >> "$GITHUB_OUTPUT"
+          echo "legacy_version=$LEGACY_NEW" >> "$GITHUB_OUTPUT"
+
+          if [ "$SCOPED_NEW" != "$SCOPED_OLD" ]; then
+            echo "scoped_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "scoped_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$LEGACY_NEW" != "$LEGACY_OLD" ]; then
+            echo "legacy_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "legacy_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:
     needs: check-version
-    if: needs.check-version.outputs.changed == 'true'
+    if: needs.check-version.outputs.scoped_changed == 'true'
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -99,6 +127,7 @@ jobs:
     name: Publish to npm
     needs: [check-version, build]
     runs-on: ubuntu-latest
+    if: ${{ always() && (needs.check-version.outputs.scoped_changed == 'true' || needs.check-version.outputs.legacy_changed == 'true') && (needs.check-version.outputs.scoped_changed != 'true' || needs.build.result == 'success') }}
     permissions:
       contents: read
       id-token: write
@@ -111,11 +140,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download all artifacts
+        if: needs.check-version.outputs.scoped_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           path: napi/artifacts
 
-      - name: Collect binaries and publish
+      - name: Collect binaries and publish scoped package
+        if: needs.check-version.outputs.scoped_changed == 'true'
         working-directory: napi
         run: |
           cp artifacts/bindings-*/*.node .
@@ -126,3 +157,20 @@ jobs:
           ls -la *.node index.js index.d.ts
 
           npm publish --provenance --access public
+
+      - name: Publish legacy package wrapper
+        if: needs.check-version.outputs.legacy_changed == 'true'
+        working-directory: napi/legacy
+        run: npm publish --provenance
+
+      - name: Deprecate legacy package
+        if: needs.check-version.outputs.legacy_changed == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is not configured; skipping npm deprecate."
+            exit 0
+          fi
+
+          npm deprecate firecrawl-pdf-inspector "Deprecated: this package has moved to @firecrawl/pdf-inspector. Please install @firecrawl/pdf-inspector instead."

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -19,3 +19,24 @@ The workflow uses `rust-lang/crates-io-auth-action@v1` to exchange GitHub's OIDC
 3. The publish workflow compares the new `Cargo.toml` version with `HEAD~1`, runs `cargo publish --dry-run`, then publishes if that version is not already on crates.io.
 
 If `Cargo.toml` changes without a package version bump, the workflow exits without publishing.
+
+## Legacy npm Package
+
+The unscoped `firecrawl-pdf-inspector` package is deprecated in favor of `@firecrawl/pdf-inspector`.
+
+The npm publish workflow publishes the compatibility wrapper in `napi/legacy` whenever `napi/legacy/package.json` has a version bump on `main`. The wrapper keeps older installs working while its README points users to the scoped package.
+
+Configure npm trusted publishing for both packages against `.github/workflows/publish.yml`:
+
+- `@firecrawl/pdf-inspector`
+- `firecrawl-pdf-inspector`
+
+To mark the legacy package as deprecated from CI, configure a GitHub Actions `NPM_TOKEN` secret with permission to manage `firecrawl-pdf-inspector`. Without that secret, the workflow still publishes the wrapper but skips `npm deprecate`.
+
+You can also deprecate the legacy package manually from an npm account that owns it:
+
+```bash
+npm deprecate firecrawl-pdf-inspector "Deprecated: this package has moved to @firecrawl/pdf-inspector. Please install @firecrawl/pdf-inspector instead."
+```
+
+If the account has two-factor auth enabled, append `--otp=<code>`.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -26,6 +26,8 @@ The unscoped `firecrawl-pdf-inspector` package is deprecated in favor of `@firec
 
 The npm publish workflow publishes the compatibility wrapper in `napi/legacy` whenever `napi/legacy/package.json` has a version bump on `main`. The wrapper keeps older installs working while its README points users to the scoped package.
 
+Keep `napi/legacy/package.json` on the same version as `napi/package.json`, and pin its `@firecrawl/pdf-inspector` dependency to that same version. The publish workflow fails fast if the package versions drift.
+
 Configure npm trusted publishing for both packages against `.github/workflows/publish.yml`:
 
 - `@firecrawl/pdf-inspector`

--- a/napi/legacy/README.md
+++ b/napi/legacy/README.md
@@ -1,0 +1,30 @@
+# firecrawl-pdf-inspector
+
+> Deprecated: this package has moved to [`@firecrawl/pdf-inspector`](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
+> Please install and import the scoped Firecrawl package instead.
+
+```bash
+npm install @firecrawl/pdf-inspector
+# or
+bun add @firecrawl/pdf-inspector
+```
+
+```typescript
+import { processPdf, classifyPdf } from '@firecrawl/pdf-inspector'
+import { readFileSync } from 'fs'
+
+const pdf = readFileSync('document.pdf')
+const result = processPdf(pdf)
+
+console.log(result.pdfType)
+console.log(result.markdown)
+```
+
+This package remains only as a compatibility wrapper for older installs:
+
+```typescript
+import { processPdf } from 'firecrawl-pdf-inspector'
+```
+
+New projects should use `@firecrawl/pdf-inspector` directly.
+

--- a/napi/legacy/bin/pdf-inspector.mjs
+++ b/napi/legacy/bin/pdf-inspector.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+import '@firecrawl/pdf-inspector/bin/pdf-inspector.mjs'
+

--- a/napi/legacy/index.d.ts
+++ b/napi/legacy/index.d.ts
@@ -1,0 +1,2 @@
+export * from '@firecrawl/pdf-inspector'
+

--- a/napi/legacy/index.js
+++ b/napi/legacy/index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const scoped = require('@firecrawl/pdf-inspector')
+
+module.exports = scoped
+module.exports.classifyPdf = scoped.classifyPdf
+module.exports.detectPdf = scoped.detectPdf
+module.exports.detectVectorGridInRegion = scoped.detectVectorGridInRegion
+module.exports.extractPagesMarkdown = scoped.extractPagesMarkdown
+module.exports.extractTablesInRegions = scoped.extractTablesInRegions
+module.exports.extractTablesWithStructure = scoped.extractTablesWithStructure
+module.exports.extractTablesWithStructureAuto = scoped.extractTablesWithStructureAuto
+module.exports.extractTablesWithStructureCells = scoped.extractTablesWithStructureCells
+module.exports.extractText = scoped.extractText
+module.exports.extractTextInRegions = scoped.extractTextInRegions
+module.exports.extractTextWithPositions = scoped.extractTextWithPositions
+module.exports.ItemType = scoped.ItemType
+module.exports.PdfType = scoped.PdfType
+module.exports.processPdf = scoped.processPdf
+

--- a/napi/legacy/package.json
+++ b/napi/legacy/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "firecrawl-pdf-inspector",
+  "version": "1.0.1",
+  "description": "Deprecated compatibility wrapper for @firecrawl/pdf-inspector.",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "bin": {
+    "pdf-inspector": "bin/pdf-inspector.mjs"
+  },
+  "license": "MIT",
+  "keywords": [
+    "pdf",
+    "pdf-extraction",
+    "pdf-parser",
+    "text-extraction",
+    "ocr",
+    "pdf-classification",
+    "firecrawl",
+    "deprecated"
+  ],
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "bin/",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/firecrawl/pdf-inspector"
+  },
+  "homepage": "https://github.com/firecrawl/pdf-inspector",
+  "dependencies": {
+    "@firecrawl/pdf-inspector": "^1.9.8"
+  }
+}

--- a/napi/legacy/package.json
+++ b/napi/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-pdf-inspector",
-  "version": "1.0.1",
+  "version": "1.9.8",
   "description": "Deprecated compatibility wrapper for @firecrawl/pdf-inspector.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/firecrawl/pdf-inspector",
   "dependencies": {
-    "@firecrawl/pdf-inspector": "^1.9.8"
+    "@firecrawl/pdf-inspector": "1.9.8"
   }
 }

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.9.6",
+  "version": "1.9.8",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Adds a deprecated compatibility wrapper for the old `firecrawl-pdf-inspector` npm package that forwards to `@firecrawl/pdf-inspector`, updates its README with the migration path, and documents the trusted-publishing/deprecation setup.

Updates the npm publish workflow so scoped and legacy package versions are checked independently. On merge, the workflow builds and publishes `@firecrawl/pdf-inspector` when its version changes, publishes `firecrawl-pdf-inspector` when its legacy wrapper version changes, and bumps the scoped package to `1.9.8` so the publish does not collide with the already-published `1.9.7`.
