### PR TITLE
fix(extractor): reduce garbled OCR false positives

### DIFF
--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -755,9 +755,9 @@ pub(crate) fn extract_text_from_operand(
                                     return Some(ch.to_string());
                                 }
                             }
-                            // 4. Printable ASCII/Latin-1 fallback
+                            // 4. Printable single-byte fallback
                             if b >= 0x20 {
-                                return Some((b as char).to_string());
+                                return Some(decode_single_byte_fallback_char(b).to_string());
                             }
                             None
                         })
@@ -880,8 +880,9 @@ pub(crate) fn extract_text_from_operand(
                                 Some(ch)
                             } else if b >= 0x20 {
                                 // Base encoding fallback for printable bytes.
-                                // For codes 0x20-0x7E this matches all standard PDF encodings.
-                                Some(b as char)
+                                // Most PDFs with simple fonts use WinAnsi/PDFDocEncoding
+                                // semantics, not ISO-8859-1 C1 controls.
+                                Some(decode_single_byte_fallback_char(b))
                             } else {
                                 None // Skip unmapped control characters
                             }
@@ -937,6 +938,11 @@ pub(crate) fn extract_text_from_operand(
             // Try to decode using cached font encoding from lopdf
             if let Some(encoding) = encoding_cache.get(current_font) {
                 if let Ok(text) = Document::decode_text(encoding, bytes) {
+                    let text = if is_type0_cid_font {
+                        text
+                    } else {
+                        normalize_cp1252_controls(text)
+                    };
                     if text.contains('\u{FFFD}') {
                         debug!(
                             "decode_text produced replacement for font={} bytes_len={}",
@@ -973,16 +979,82 @@ pub(crate) fn extract_text_from_operand(
                 return Some(symbol_text);
             }
 
-            // Pure ASCII bytes round-trip safely (Latin-1 == ASCII for
-            // 0x00..=0x7F), and non-CID (Type1 / TrueType / Type3) fonts
-            // use single-byte encodings where Latin-1 fallback is the
-            // canonical interpretation.
-            Some(bytes.iter().map(|&b| b as char).collect())
+            // Non-CID (Type1 / TrueType / Type3) fonts use single-byte
+            // encodings. In practice the fallback should follow WinAnsi for
+            // 0x80..=0x9F so bytes like 0x92 become smart punctuation instead
+            // of C1 controls that look like CID mojibake.
+            Some(decode_single_byte_fallback(bytes))
         } else {
             None
         }
     })();
-    result.map(clean_symbol_pua)
+    result.map(|text| {
+        let text = clean_symbol_pua(text);
+        if is_type0_cid_font {
+            text
+        } else {
+            normalize_cp1252_controls(text)
+        }
+    })
+}
+
+fn decode_single_byte_fallback(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|&b| decode_single_byte_fallback_char(b))
+        .collect()
+}
+
+fn decode_single_byte_fallback_char(byte: u8) -> char {
+    match byte {
+        0x80 => '\u{20AC}',
+        0x82 => '\u{201A}',
+        0x83 => '\u{0192}',
+        0x84 => '\u{201E}',
+        0x85 => '\u{2026}',
+        0x86 => '\u{2020}',
+        0x87 => '\u{2021}',
+        0x88 => '\u{02C6}',
+        0x89 => '\u{2030}',
+        0x8A => '\u{0160}',
+        0x8B => '\u{2039}',
+        0x8C => '\u{0152}',
+        0x8E => '\u{017D}',
+        0x91 => '\u{2018}',
+        0x92 => '\u{2019}',
+        0x93 => '\u{201C}',
+        0x94 => '\u{201D}',
+        0x95 => '\u{2022}',
+        0x96 => '\u{2013}',
+        0x97 => '\u{2014}',
+        0x98 => '\u{02DC}',
+        0x99 => '\u{2122}',
+        0x9A => '\u{0161}',
+        0x9B => '\u{203A}',
+        0x9C => '\u{0153}',
+        0x9E => '\u{017E}',
+        0x9F => '\u{0178}',
+        _ => byte as char,
+    }
+}
+
+fn normalize_cp1252_controls(text: String) -> String {
+    if !text
+        .chars()
+        .any(|ch| ('\u{0080}'..='\u{009F}').contains(&ch))
+    {
+        return text;
+    }
+
+    text.chars()
+        .map(|ch| {
+            if ('\u{0080}'..='\u{009F}').contains(&ch) {
+                decode_single_byte_fallback_char(ch as u8)
+            } else {
+                ch
+            }
+        })
+        .collect()
 }
 
 /// Replace PUA characters in the F000-F0FF range with standard Unicode equivalents.
@@ -1279,15 +1351,15 @@ mod tests {
     }
 
     #[test]
-    fn simple_font_latin1_fallback_passes_high_bytes_through() {
+    fn simple_font_single_byte_fallback_passes_high_bytes_through() {
         // A Type1/TrueType simple font (is_cid=false) with a `/ToUnicode`
         // reference but no usable CMap and no `/Differences` map.
-        // Per-byte Latin-1 IS the canonical interpretation here — these
-        // bytes are character codes, not CIDs. The CID guard must NOT
-        // strip them. Reproduces the false positive that an earlier
-        // version of the guard introduced for fonts in PDFs like
-        // pdf-evals/Navigating-Artificial-Intelligence-..., where bytes
-        // like 0xB6 are legitimate Latin-1 character codes.
+        // Per-byte fallback is the canonical interpretation here — these
+        // bytes are character codes, not CIDs. The CID guard must NOT strip
+        // them. Reproduces the false positive that an earlier version of the
+        // guard introduced for fonts in PDFs like pdf-evals/Navigating-
+        // Artificial-Intelligence-..., where bytes like 0xB6 are legitimate
+        // single-byte character codes.
         let bytes = vec![0x24_u8, 0x47, 0xB6, 0x56]; // "$G¶V"
         let obj = Object::String(bytes, lopdf::StringFormat::Hexadecimal);
 
@@ -1319,5 +1391,41 @@ mod tests {
             !text.contains('\u{FFFD}'),
             "simple font fallback must not stamp FFFD over legitimate bytes: {text:?}"
         );
+    }
+
+    #[test]
+    fn simple_font_single_byte_fallback_maps_cp1252_punctuation() {
+        let bytes = vec![b'l', 0x92_u8, b'a', b'c', b'a', b'd'];
+        let obj = Object::String(bytes, lopdf::StringFormat::Hexadecimal);
+
+        let font_cmaps = FontCMaps::default();
+        let font_tounicode_refs: HashMap<String, u32> = HashMap::new();
+        let inline_cmaps = HashMap::new();
+        let font_encodings: PageFontEncodings = HashMap::new();
+        let encoding_cache: HashMap<String, Encoding<'_>> = HashMap::new();
+        let mut decisions = CMapDecisionCache::new();
+        let font_widths: PageFontWidths = HashMap::new();
+
+        let text = extract_text_from_operand(
+            &obj,
+            "F1",
+            None,
+            &font_cmaps,
+            &font_tounicode_refs,
+            &inline_cmaps,
+            &font_encodings,
+            &encoding_cache,
+            &mut decisions,
+            &font_widths,
+        )
+        .expect("simple font should decode CP1252 punctuation");
+
+        assert_eq!(text, "l’acad");
+    }
+
+    #[test]
+    fn cached_encoding_decode_normalizes_cp1252_controls() {
+        let text = normalize_cp1252_controls("d\u{92}un \u{96} test".to_string());
+        assert_eq!(text, "d’un – test");
     }
 }

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -526,6 +526,11 @@ pub(crate) fn parse_font_encoding(
     font_dict: &lopdf::Dictionary,
 ) -> Option<EncodingResult> {
     let encoding_obj = font_dict.get(b"Encoding").ok()?;
+    let base_font_name = font_dict
+        .get(b"BaseFont")
+        .ok()
+        .and_then(|o| o.as_name().ok())
+        .map(|n| String::from_utf8_lossy(n).to_string());
 
     // Encoding can be a name or a dictionary
     match encoding_obj {
@@ -538,12 +543,14 @@ pub(crate) fn parse_font_encoding(
         Object::Reference(obj_ref) => {
             // Reference to encoding dictionary
             if let Ok(enc_dict) = doc.get_dictionary(*obj_ref) {
-                parse_encoding_dictionary(doc, enc_dict)
+                parse_encoding_dictionary(doc, enc_dict, base_font_name.as_deref())
             } else {
                 None
             }
         }
-        Object::Dictionary(enc_dict) => parse_encoding_dictionary(doc, enc_dict),
+        Object::Dictionary(enc_dict) => {
+            parse_encoding_dictionary(doc, enc_dict, base_font_name.as_deref())
+        }
         _ => None,
     }
 }
@@ -562,6 +569,7 @@ pub(crate) struct EncodingResult {
 pub(crate) fn parse_encoding_dictionary(
     doc: &Document,
     enc_dict: &lopdf::Dictionary,
+    base_font_name: Option<&str>,
 ) -> Option<EncodingResult> {
     let differences = enc_dict.get(b"Differences").ok()?;
 
@@ -591,11 +599,9 @@ pub(crate) fn parse_encoding_dictionary(
             Object::Name(name) => {
                 // Map current code to glyph name -> Unicode
                 let glyph_name = String::from_utf8_lossy(&name).to_string();
-                if glyph_name == "fi"
-                    || glyph_name == "fl"
-                    || glyph_name == "ffi"
-                    || glyph_name == "ffl"
-                {
+                let mapped_char = glyph_to_char(&glyph_name)
+                    .or_else(|| private_glyph_to_char(&glyph_name, base_font_name));
+                if mapped_char.is_some_and(is_ligature_char) {
                     debug!(
                         "  Differences: code=0x{:02X} glyph={:?} (ligature)",
                         current_code, glyph_name
@@ -610,7 +616,7 @@ pub(crate) fn parse_encoding_dictionary(
                 {
                     gid_glyph_count += 1;
                 }
-                if let Some(ch) = glyph_to_char(&glyph_name) {
+                if let Some(ch) = mapped_char {
                     encoding_map.insert(current_code, ch);
                 } else {
                     debug!(
@@ -643,6 +649,31 @@ pub(crate) fn parse_encoding_dictionary(
         map: encoding_map,
         gid_glyph_count,
     })
+}
+
+fn private_glyph_to_char(glyph_name: &str, base_font_name: Option<&str>) -> Option<char> {
+    let base_font_name = strip_subset_prefix(base_font_name?);
+
+    // Aptos CFF subsets from Office PDFs can expose the ff ligature as /g431
+    // without a ToUnicode map. Keep this font-scoped because /gNNN names are private.
+    if base_font_name.eq_ignore_ascii_case("Aptos") && glyph_name == "g431" {
+        Some('\u{FB00}')
+    } else {
+        None
+    }
+}
+
+fn strip_subset_prefix(font_name: &str) -> &str {
+    font_name
+        .split_once('+')
+        .map_or(font_name, |(_, stripped)| stripped)
+}
+
+fn is_ligature_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{FB00}' | '\u{FB01}' | '\u{FB02}' | '\u{FB03}' | '\u{FB04}'
+    )
 }
 
 /// Get the CMap lookup key for an Identity-H/V CID font without ToUnicode.
@@ -1214,6 +1245,7 @@ fn score_text(text: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lopdf::dictionary;
 
     fn make_font_info(widths: &[(u16, u16)], default_width: u16, is_cid: bool) -> FontWidthInfo {
         FontWidthInfo {
@@ -1336,6 +1368,51 @@ mod tests {
         let good = "the quick brown fox and the lazy dog";
         let bad = "###!!!@@@$$$";
         assert!(score_text(good) > score_text(bad));
+    }
+
+    fn doc_with_private_differences() -> (Document, lopdf::ObjectId) {
+        let mut doc = Document::with_version("1.7");
+        let encoding_id = doc.add_object(dictionary! {
+            "Differences" => Object::Array(vec![
+                Object::Integer(0x88),
+                Object::Name(b"g431".to_vec()),
+                Object::Name(b"fi".to_vec()),
+                Object::Integer(0xAD),
+                Object::Name(b"fl".to_vec()),
+            ]),
+        });
+
+        (doc, encoding_id)
+    }
+
+    #[test]
+    fn aptos_private_g431_maps_to_ff_ligature() {
+        let (doc, encoding_id) = doc_with_private_differences();
+        let font_dict = dictionary! {
+            "BaseFont" => Object::Name(b"NJEQOD+Aptos".to_vec()),
+            "Encoding" => Object::Reference(encoding_id),
+        };
+
+        let result = parse_font_encoding(&doc, &font_dict).expect("encoding should parse");
+
+        assert_eq!(result.map.get(&0x88u8), Some(&'\u{FB00}'));
+        assert_eq!(result.map.get(&0x89u8), Some(&'\u{FB01}'));
+        assert_eq!(result.map.get(&0xADu8), Some(&'\u{FB02}'));
+    }
+
+    #[test]
+    fn private_g431_does_not_map_for_unrelated_fonts() {
+        let (doc, encoding_id) = doc_with_private_differences();
+        let font_dict = dictionary! {
+            "BaseFont" => Object::Name(b"ABCDEF+OtherFont".to_vec()),
+            "Encoding" => Object::Reference(encoding_id),
+        };
+
+        let result = parse_font_encoding(&doc, &font_dict).expect("encoding should parse");
+
+        assert!(!result.map.contains_key(&0x88u8));
+        assert_eq!(result.map.get(&0x89u8), Some(&'\u{FB01}'));
+        assert_eq!(result.map.get(&0xADu8), Some(&'\u{FB02}'));
     }
 
     #[test]

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -725,6 +725,8 @@ pub(crate) fn extract_text_from_operand(
     let is_type0_cid_font = font_widths
         .get(current_font)
         .is_some_and(|info| info.is_cid);
+    let use_cp1252_fallback =
+        should_use_cp1252_single_byte_fallback(base_font_name, is_type0_cid_font);
     let result = (|| -> Option<String> {
         if let Object::String(bytes, _) = obj {
             let mut decode_with_entry = |entry: &crate::tounicode::CMapEntry| -> Option<String> {
@@ -757,7 +759,10 @@ pub(crate) fn extract_text_from_operand(
                             }
                             // 4. Printable single-byte fallback
                             if b >= 0x20 {
-                                return Some(decode_single_byte_fallback_char(b).to_string());
+                                return Some(
+                                    decode_single_byte_fallback_char(b, use_cp1252_fallback)
+                                        .to_string(),
+                                );
                             }
                             None
                         })
@@ -882,7 +887,7 @@ pub(crate) fn extract_text_from_operand(
                                 // Base encoding fallback for printable bytes.
                                 // Most PDFs with simple fonts use WinAnsi/PDFDocEncoding
                                 // semantics, not ISO-8859-1 C1 controls.
-                                Some(decode_single_byte_fallback_char(b))
+                                Some(decode_single_byte_fallback_char(b, use_cp1252_fallback))
                             } else {
                                 None // Skip unmapped control characters
                             }
@@ -938,11 +943,7 @@ pub(crate) fn extract_text_from_operand(
             // Try to decode using cached font encoding from lopdf
             if let Some(encoding) = encoding_cache.get(current_font) {
                 if let Ok(text) = Document::decode_text(encoding, bytes) {
-                    let text = if is_type0_cid_font {
-                        text
-                    } else {
-                        normalize_cp1252_controls(text)
-                    };
+                    let text = normalize_cp1252_controls(text, use_cp1252_fallback);
                     if text.contains('\u{FFFD}') {
                         debug!(
                             "decode_text produced replacement for font={} bytes_len={}",
@@ -983,29 +984,29 @@ pub(crate) fn extract_text_from_operand(
             // encodings. In practice the fallback should follow WinAnsi for
             // 0x80..=0x9F so bytes like 0x92 become smart punctuation instead
             // of C1 controls that look like CID mojibake.
-            Some(decode_single_byte_fallback(bytes))
+            Some(decode_single_byte_fallback(bytes, use_cp1252_fallback))
         } else {
             None
         }
     })();
     result.map(|text| {
         let text = clean_symbol_pua(text);
-        if is_type0_cid_font {
-            text
-        } else {
-            normalize_cp1252_controls(text)
-        }
+        normalize_cp1252_controls(text, use_cp1252_fallback)
     })
 }
 
-fn decode_single_byte_fallback(bytes: &[u8]) -> String {
+fn decode_single_byte_fallback(bytes: &[u8], use_cp1252_fallback: bool) -> String {
     bytes
         .iter()
-        .map(|&b| decode_single_byte_fallback_char(b))
+        .map(|&b| decode_single_byte_fallback_char(b, use_cp1252_fallback))
         .collect()
 }
 
-fn decode_single_byte_fallback_char(byte: u8) -> char {
+fn decode_single_byte_fallback_char(byte: u8, use_cp1252_fallback: bool) -> char {
+    if !use_cp1252_fallback {
+        return byte as char;
+    }
+
     match byte {
         0x80 => '\u{20AC}',
         0x82 => '\u{201A}',
@@ -1038,7 +1039,10 @@ fn decode_single_byte_fallback_char(byte: u8) -> char {
     }
 }
 
-fn normalize_cp1252_controls(text: String) -> String {
+fn normalize_cp1252_controls(text: String, use_cp1252_fallback: bool) -> String {
+    if !use_cp1252_fallback {
+        return text;
+    }
     if !text
         .chars()
         .any(|ch| ('\u{0080}'..='\u{009F}').contains(&ch))
@@ -1049,12 +1053,46 @@ fn normalize_cp1252_controls(text: String) -> String {
     text.chars()
         .map(|ch| {
             if ('\u{0080}'..='\u{009F}').contains(&ch) {
-                decode_single_byte_fallback_char(ch as u8)
+                decode_single_byte_fallback_char(ch as u8, true)
             } else {
                 ch
             }
         })
         .collect()
+}
+
+fn should_use_cp1252_single_byte_fallback(
+    base_font_name: Option<&str>,
+    is_type0_cid_font: bool,
+) -> bool {
+    if is_type0_cid_font {
+        return false;
+    }
+
+    let Some(base_font_name) = base_font_name else {
+        return true;
+    };
+    let font_name = base_font_name
+        .rsplit_once('+')
+        .map_or(base_font_name, |(_, stripped)| stripped)
+        .to_ascii_lowercase();
+
+    // TeX/Computer Modern and math/symbol fonts often place ligatures or
+    // symbols in the C1 byte range. Treating those bytes as Windows-1252 makes
+    // words like "deficiente" become "de…ciente" and "fluid" become "‡uid".
+    let non_cp1252_prefixes = [
+        "cmr", "cmb", "cmmi", "cmsy", "cmex", "cmtt", "cmss", "cmti", "ecrm", "ecbx", "ecti",
+        "tcrm", "tctt", "msam", "msbm", "ttdc",
+    ];
+    if non_cp1252_prefixes
+        .iter()
+        .any(|prefix| font_name.starts_with(prefix))
+    {
+        return false;
+    }
+
+    let non_cp1252_names = ["math", "symbol", "dingbat", "emoji"];
+    !non_cp1252_names.iter().any(|name| font_name.contains(name))
 }
 
 /// Replace PUA characters in the F000-F0FF range with standard Unicode equivalents.
@@ -1425,7 +1463,29 @@ mod tests {
 
     #[test]
     fn cached_encoding_decode_normalizes_cp1252_controls() {
-        let text = normalize_cp1252_controls("d\u{92}un \u{96} test".to_string());
+        let text = normalize_cp1252_controls("d\u{92}un \u{96} test".to_string(), true);
         assert_eq!(text, "d’un – test");
+    }
+
+    #[test]
+    fn tex_font_decode_keeps_c1_ligature_bytes_unmodified() {
+        let text = normalize_cp1252_controls("de\u{85}ciente \u{87}uid".to_string(), false);
+        assert_eq!(text, "de\u{85}ciente \u{87}uid");
+        assert!(!should_use_cp1252_single_byte_fallback(
+            Some("TTdcr10"),
+            false
+        ));
+        assert!(!should_use_cp1252_single_byte_fallback(
+            Some("cmr10"),
+            false
+        ));
+    }
+
+    #[test]
+    fn winansi_text_font_uses_cp1252_fallback() {
+        assert!(should_use_cp1252_single_byte_fallback(
+            Some("BJPQNQ+Times-Roman"),
+            false
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3715,17 +3715,58 @@ struct TextQualityReport {
     reasons_by_page: BTreeMap<u32, Vec<String>>,
 }
 
+#[derive(Debug, Default)]
+struct PageTextQualityEvidence {
+    chars: usize,
+    replacement_chars: usize,
+    replacement_spans: usize,
+    longest_replacement_run: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextSpanIssueKind {
+    Replacement,
+    Strong,
+}
+
 fn analyze_text_quality(items: &[TextItem]) -> TextQualityReport {
     let mut reasons_by_page = BTreeMap::new();
+    let mut evidence_by_page = BTreeMap::<u32, PageTextQualityEvidence>::new();
 
     for item in items {
         if !matches!(item.item_type, crate::types::ItemType::Text) {
             continue;
         }
-        if text_span_has_decoding_issue(&item.text) {
+
+        let evidence = evidence_by_page.entry(item.page).or_default();
+        evidence.chars += item.text.chars().filter(|ch| !ch.is_whitespace()).count();
+
+        match text_span_decoding_issue_kind(&item.text) {
+            Some(TextSpanIssueKind::Strong) => {
+                add_ocr_reason(
+                    &mut reasons_by_page,
+                    item.page,
+                    OCR_REASON_SUSPECTED_GARBLED_TEXT,
+                );
+            }
+            Some(TextSpanIssueKind::Replacement) => {
+                let stats = replacement_text_stats(&item.text);
+                evidence.replacement_chars += stats.0;
+                evidence.replacement_spans += 1;
+                evidence.longest_replacement_run = evidence.longest_replacement_run.max(stats.1);
+            }
+            None => {}
+        }
+    }
+
+    for (page, evidence) in evidence_by_page {
+        if reasons_by_page.contains_key(&page) {
+            continue;
+        }
+        if page_replacement_evidence_needs_ocr(&evidence) {
             add_ocr_reason(
                 &mut reasons_by_page,
-                item.page,
+                page,
                 OCR_REASON_SUSPECTED_GARBLED_TEXT,
             );
         }
@@ -3783,19 +3824,31 @@ fn region_items_have_decoding_issue(items: &[TextItem]) -> bool {
 }
 
 fn text_span_has_decoding_issue(text: &str) -> bool {
+    text_span_decoding_issue_kind(text).is_some()
+}
+
+fn text_span_decoding_issue_kind(text: &str) -> Option<TextSpanIssueKind> {
     let text = text.trim();
     if text.is_empty() {
-        return false;
+        return None;
     }
 
-    has_replacement_text_run(text)
-        || has_dollar_as_space_pattern(text)
+    if has_dollar_as_space_pattern(text)
         || has_private_use_text_run(text)
         || is_cid_garbage(text)
         || has_cid_control_token(text)
+    {
+        return Some(TextSpanIssueKind::Strong);
+    }
+
+    if has_replacement_text_run(text) {
+        return Some(TextSpanIssueKind::Replacement);
+    }
+
+    None
 }
 
-fn has_replacement_text_run(text: &str) -> bool {
+fn replacement_text_stats(text: &str) -> (usize, usize) {
     let mut replacement = 0usize;
     let mut current_run = 0usize;
     let mut longest_run = 0usize;
@@ -3810,6 +3863,31 @@ fn has_replacement_text_run(text: &str) -> bool {
         }
     }
 
+    (replacement, longest_run)
+}
+
+fn page_replacement_evidence_needs_ocr(evidence: &PageTextQualityEvidence) -> bool {
+    if evidence.replacement_chars == 0 || evidence.chars == 0 {
+        return false;
+    }
+
+    // If the entire page is only a short broken text layer, even a short
+    // replacement run is enough evidence. On otherwise text-heavy pages,
+    // require density so math formulas do not force full-page OCR.
+    if evidence.chars <= 80 && evidence.longest_replacement_run >= 2 {
+        return true;
+    }
+
+    let replacement_density_bps = evidence.replacement_chars * 10_000 / evidence.chars;
+    let enough_bad_text = evidence.replacement_chars >= 12 && replacement_density_bps >= 500;
+    let repeated_bad_spans = evidence.replacement_spans >= 3 && replacement_density_bps >= 250;
+    let long_bad_run = evidence.longest_replacement_run >= 8 && replacement_density_bps >= 250;
+
+    enough_bad_text || repeated_bad_spans || long_bad_run
+}
+
+fn has_replacement_text_run(text: &str) -> bool {
+    let (replacement, longest_run) = replacement_text_stats(text);
     longest_run >= 2 || replacement >= 3
 }
 
@@ -3856,7 +3934,7 @@ fn token_has_cid_control(token: &str) -> bool {
         }
     }
 
-    total >= 5 && c1_control > 0 && c1_control * 20 >= total
+    total >= 5 && c1_control >= 2 && c1_control * 20 >= total
 }
 
 fn is_private_use_char(ch: char) -> bool {
@@ -3884,7 +3962,7 @@ fn is_garbage_text(markdown: &str) -> bool {
             run_end += 1;
         }
 
-        let is_decorative_leader = matches!(ch, '.' | '_') && run_end - i >= 3;
+        let is_decorative_leader = matches!(ch, '.' | '_' | '·') && run_end - i >= 3;
         if !is_decorative_leader {
             for &run_ch in &chars[i..run_end] {
                 if run_ch.is_whitespace() {
@@ -3928,6 +4006,9 @@ fn is_cid_garbage(text: &str) -> bool {
         }
         total += 1;
         // C1 control characters (U+0080–U+009F) — almost never in real text
+        if ch == '·' {
+            continue;
+        }
         if ('\u{0080}'..='\u{009F}').contains(&ch) {
             c1_control += 1;
         }
@@ -3942,7 +4023,7 @@ fn is_cid_garbage(text: &str) -> bool {
         return false;
     }
     // If ≥5% of non-whitespace chars are C1 controls, it's garbage
-    if c1_control * 20 >= total {
+    if c1_control >= 2 && c1_control * 20 >= total {
         return true;
     }
     // If ≥40% of non-whitespace chars are high Latin-1 AND the text has few
@@ -5960,6 +6041,54 @@ mod tests {
     }
 
     #[test]
+    fn test_text_quality_allows_formula_replacement_on_clean_page() {
+        let items = vec![
+            test_text_item_on_page(
+                1,
+                "The LCOE of a power plant can be decomposed into three parts and described in prose.",
+            ),
+            test_text_item_on_page(
+                1,
+                "This page has enough normal text that a damaged equation should not force OCR.",
+            ),
+            test_text_item_on_page(1, "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD} = x + y"),
+            test_text_item_on_page(1, "More normal explanatory text follows after the formula."),
+        ];
+
+        let quality = analyze_text_quality(&items);
+
+        assert!(!quality.has_encoding_issues);
+        assert!(quality.pages_needing_ocr.is_empty());
+    }
+
+    #[test]
+    fn test_text_quality_flags_dense_replacement_text_page() {
+        let items = vec![
+            test_text_item_on_page(1, "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD} broken layer"),
+            test_text_item_on_page(1, "more \u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD} broken text"),
+            test_text_item_on_page(1, "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}"),
+        ];
+
+        let quality = analyze_text_quality(&items);
+
+        assert_eq!(quality.pages_needing_ocr, vec![1]);
+        assert!(quality.has_encoding_issues);
+    }
+
+    #[test]
+    fn test_text_quality_allows_tex_ligature_c1_controls_in_words() {
+        let items = vec![test_text_item_on_page(
+            1,
+            "Especialmente de\u{85}ciente es nuestro conocimiento del control. The amniotic \u{87}uid is important.",
+        )];
+
+        let quality = analyze_text_quality(&items);
+
+        assert!(!quality.has_encoding_issues);
+        assert!(quality.pages_needing_ocr.is_empty());
+    }
+
+    #[test]
     fn test_region_text_quality_is_scoped_to_matched_items() {
         let clean_region = vec![
             test_text_item_on_page(1, "Clean native text"),
@@ -6016,6 +6145,18 @@ mod tests {
         assert!(
             !is_cid_garbage(japanese),
             "Valid Japanese text should not be flagged as garbage"
+        );
+
+        let japanese_toc = "第１章 市政経営方針の位置づけ ···································· 1";
+        assert!(
+            !is_cid_garbage(japanese_toc),
+            "Japanese TOC dot leaders should not be flagged as garbage"
+        );
+
+        let tex_ligature = "amniotic \u{87}uid volume regulation";
+        assert!(
+            !is_cid_garbage(tex_ligature),
+            "A single TeX ligature byte inside a word should not be CID garbage"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3684,6 +3684,10 @@ fn detect_encoding_issues(markdown: &str) -> bool {
     }
 
     // Heuristic 2: dollar-as-space pattern
+    has_dollar_as_space_pattern(markdown)
+}
+
+fn has_dollar_as_space_pattern(markdown: &str) -> bool {
     let total_dollars = markdown.matches('$').count();
     if total_dollars > 10 {
         let bytes = markdown.as_bytes();
@@ -3784,10 +3788,29 @@ fn text_span_has_decoding_issue(text: &str) -> bool {
         return false;
     }
 
-    detect_encoding_issues(text)
+    has_replacement_text_run(text)
+        || has_dollar_as_space_pattern(text)
         || has_private_use_text_run(text)
         || is_cid_garbage(text)
         || has_cid_control_token(text)
+}
+
+fn has_replacement_text_run(text: &str) -> bool {
+    let mut replacement = 0usize;
+    let mut current_run = 0usize;
+    let mut longest_run = 0usize;
+
+    for ch in text.chars() {
+        if ch == '\u{FFFD}' {
+            replacement += 1;
+            current_run += 1;
+            longest_run = longest_run.max(current_run);
+        } else {
+            current_run = 0;
+        }
+    }
+
+    longest_run >= 2 || replacement >= 3
 }
 
 fn has_private_use_text_run(text: &str) -> bool {
@@ -3851,20 +3874,36 @@ fn is_private_use_char(ch: char) -> bool {
 fn is_garbage_text(markdown: &str) -> bool {
     let mut alphanum = 0usize;
     let mut non_alphanum = 0usize;
-    for ch in markdown.chars() {
-        if ch.is_whitespace() {
-            continue;
+
+    let chars: Vec<char> = markdown.chars().collect();
+    let mut i = 0usize;
+    while i < chars.len() {
+        let ch = chars[i];
+        let mut run_end = i + 1;
+        while run_end < chars.len() && chars[run_end] == ch {
+            run_end += 1;
         }
-        // Skip markdown syntax chars that we add (not from the PDF)
-        if matches!(ch, '#' | '*' | '|' | '-' | '\n') {
-            continue;
+
+        let is_decorative_leader = matches!(ch, '.' | '_') && run_end - i >= 3;
+        if !is_decorative_leader {
+            for &run_ch in &chars[i..run_end] {
+                if run_ch.is_whitespace() {
+                    continue;
+                }
+                // Skip markdown syntax chars that we add (not from the PDF)
+                if matches!(run_ch, '#' | '*' | '|' | '-' | '\n') {
+                    continue;
+                }
+                if run_ch.is_alphanumeric() {
+                    alphanum += 1;
+                } else {
+                    non_alphanum += 1;
+                }
+            }
         }
-        if ch.is_alphanumeric() {
-            alphanum += 1;
-        } else {
-            non_alphanum += 1;
-        }
+        i = run_end;
     }
+
     let total = alphanum + non_alphanum;
     total >= 50 && alphanum * 2 < total
 }
@@ -3908,9 +3947,11 @@ fn is_cid_garbage(text: &str) -> bool {
     }
     // If ≥40% of non-whitespace chars are high Latin-1 AND the text has few
     // ASCII letters, it's likely CID-as-Latin-1 mojibake (Japanese/CJK PDFs
-    // where CID values 0x80-0xFF become accented Latin characters).
+    // where CID values 0x80-0xFF become accented Latin characters).  Keep a
+    // minimum length so short math tokens like "2×()×" do not route a clean
+    // page to OCR.
     let ascii_letters = text.chars().filter(|c| c.is_ascii_alphabetic()).count();
-    high_latin * 5 >= total * 2 && ascii_letters * 3 < total
+    total >= 20 && high_latin * 5 >= total * 2 && ascii_letters * 3 < total
 }
 
 /// Detect markdown tables with suspicious structure that suggest the heuristic
@@ -5855,7 +5896,7 @@ mod tests {
     #[test]
     fn test_text_quality_flags_replacement_and_private_use_runs() {
         let items = vec![
-            test_text_item_on_page(1, "broken \u{FFFD} text"),
+            test_text_item_on_page(1, "broken \u{FFFD}\u{FFFD} text"),
             test_text_item_on_page(3, "\u{E000}\u{E001}\u{E002}"),
         ];
 
@@ -5885,6 +5926,37 @@ mod tests {
         assert!(!quality.has_encoding_issues);
         assert!(quality.pages_needing_ocr.is_empty());
         assert!(quality.reasons_by_page.is_empty());
+    }
+
+    #[test]
+    fn test_text_quality_allows_toc_leaders_form_rules_and_short_math() {
+        let items = vec![
+            test_text_item_on_page(
+                1,
+                "Feature Overview ........................................................................................................ 1-5",
+            ),
+            test_text_item_on_page(1, "Signature __________________________________________"),
+            test_text_item_on_page(1, "__________________________________________________"),
+            test_text_item_on_page(1, "2×()×"),
+        ];
+
+        let quality = analyze_text_quality(&items);
+
+        assert!(!quality.has_encoding_issues);
+        assert!(quality.pages_needing_ocr.is_empty());
+    }
+
+    #[test]
+    fn test_text_quality_allows_isolated_replacement_character() {
+        let items = vec![
+            test_text_item_on_page(1, "\u{FFFD}2026 FINRA"),
+            test_text_item_on_page(1, "A mostly clean page should not be sent to OCR."),
+        ];
+
+        let quality = analyze_text_quality(&items);
+
+        assert!(!quality.has_encoding_issues);
+        assert!(quality.pages_needing_ocr.is_empty());
     }
 
     #[test]

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -616,9 +616,15 @@ fn hex_to_unicode_string(hex: &str) -> Option<String> {
 }
 
 fn normalize_tounicode_destination(text: String) -> String {
-    let is_multi_char = text.chars().count() > 1;
+    let is_multi_char = text.chars().nth(1).is_some();
 
-    if is_multi_char && text.chars().all(char::is_whitespace) {
+    // Some malformed producer CMaps put a list of alternative whitespace or
+    // hyphen codepoints into one destination. Keep ordinary multi-character
+    // mappings intact unless that malformed signature is present.
+    if is_multi_char
+        && text.chars().all(char::is_whitespace)
+        && text.chars().any(|ch| matches!(ch, '\t' | '\n' | '\r'))
+    {
         return if text.contains('\t') {
             "\t".to_string()
         } else {
@@ -627,6 +633,7 @@ fn normalize_tounicode_destination(text: String) -> String {
     }
 
     if is_multi_char
+        && text.contains('\u{00ad}')
         && text.chars().all(|ch| {
             matches!(
                 ch,
@@ -2722,6 +2729,27 @@ endbfchar
         assert_eq!(cmap.lookup(0x21), Some("\t".to_string()));
         assert_eq!(cmap.lookup(0x22), Some("-".to_string()));
         assert_eq!(cmap.lookup(0x23), Some("\u{00a0}".to_string()));
+    }
+
+    #[test]
+    fn test_parse_preserves_valid_multi_character_destinations() {
+        let cmap_content = r#"
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+4 beginbfchar
+<21> <002d002d>
+<22> <20132013>
+<23> <002000a0>
+<24> <00660069>
+endbfchar
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.lookup(0x21), Some("--".to_string()));
+        assert_eq!(cmap.lookup(0x22), Some("––".to_string()));
+        assert_eq!(cmap.lookup(0x23), Some(" \u{00a0}".to_string()));
+        assert_eq!(cmap.lookup(0x24), Some("fi".to_string()));
     }
 
     #[test]

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -329,7 +329,7 @@ impl ToUnicodeCMap {
                 if let (Some(start), Some(end), Some(base)) = (
                     parse_hex_u16(&start_hex),
                     parse_hex_u16(&end_hex),
-                    parse_hex_u32(&base_hex),
+                    hex_to_unicode_scalar(&base_hex),
                 ) {
                     self.ranges.push((start, end, base));
                 }
@@ -575,32 +575,79 @@ fn parse_hex_u16(hex: &str) -> Option<u16> {
     u16::from_str_radix(hex.trim(), 16).ok()
 }
 
-/// Parse a hex string to u32
-fn parse_hex_u32(hex: &str) -> Option<u32> {
-    u32::from_str_radix(hex.trim(), 16).ok()
-}
-
-/// Convert a hex string to a Unicode string
-/// Handles both 2-byte (BMP) and 4-byte (supplementary) codepoints
+/// Convert a ToUnicode destination hex string to Unicode.
+///
+/// PDF ToUnicode destinations are UTF-16BE strings. Supplementary-plane
+/// characters are encoded as surrogate pairs, so treating each 4-hex chunk as
+/// a scalar drops emoji like D83CDF1F.
 fn hex_to_unicode_string(hex: &str) -> Option<String> {
-    let hex = hex.trim();
-    let mut result = String::new();
-
-    // Process 4 hex digits at a time
-    let mut i = 0;
-    while i + 4 <= hex.len() {
-        if let Ok(cp) = u32::from_str_radix(&hex[i..i + 4], 16) {
-            if let Some(c) = char::from_u32(cp) {
-                result.push(c);
-            }
-        }
-        i += 4;
+    let hex: String = hex.chars().filter(|ch| !ch.is_ascii_whitespace()).collect();
+    if hex.is_empty() || !hex.len().is_multiple_of(2) {
+        return None;
     }
 
-    if result.is_empty() {
-        None
+    let bytes: Option<Vec<u8>> = (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+        .collect();
+    let bytes = bytes?;
+
+    if bytes.len().is_multiple_of(2) {
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        if let Ok(result) = String::from_utf16(&units) {
+            if !result.is_empty() {
+                return Some(normalize_tounicode_destination(result));
+            }
+        }
+    }
+
+    // Be permissive for non-standard one-byte destinations.
+    if bytes.len() == 1 {
+        let ch = bytes[0] as char;
+        if !ch.is_control() || ch == '\t' || ch == '\n' {
+            return Some(ch.to_string());
+        }
+    }
+
+    None
+}
+
+fn normalize_tounicode_destination(text: String) -> String {
+    let is_multi_char = text.chars().count() > 1;
+
+    if is_multi_char && text.chars().all(char::is_whitespace) {
+        return if text.contains('\t') {
+            "\t".to_string()
+        } else {
+            " ".to_string()
+        };
+    }
+
+    if is_multi_char
+        && text.chars().all(|ch| {
+            matches!(
+                ch,
+                '-' | '\u{00ad}' | '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2212}'
+            )
+        })
+    {
+        return "-".to_string();
+    }
+
+    text
+}
+
+fn hex_to_unicode_scalar(hex: &str) -> Option<u32> {
+    let text = hex_to_unicode_string(hex)?;
+    let mut chars = text.chars();
+    let ch = chars.next()?;
+    if chars.next().is_none() {
+        Some(ch as u32)
     } else {
-        Some(result)
+        None
     }
 }
 
@@ -2605,6 +2652,76 @@ endbfrange
         assert_eq!(cmap.lookup(0x0003), Some("A".to_string()));
         assert_eq!(cmap.lookup(0x0004), Some("B".to_string()));
         assert_eq!(cmap.lookup(0x0005), Some("C".to_string()));
+    }
+
+    #[test]
+    fn test_parse_bfchar_surrogate_pair_emoji() {
+        let cmap_content = r#"
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+2 beginbfchar
+<16> <D83CDF1F>
+<9D> <D83CDFAD>
+endbfchar
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.code_byte_length, 1);
+        assert_eq!(cmap.lookup(0x16), Some("🌟".to_string()));
+        assert_eq!(cmap.lookup(0x9D), Some("🎭".to_string()));
+    }
+
+    #[test]
+    fn test_parse_bfrange_surrogate_pair_base() {
+        let cmap_content = r#"
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfrange
+<C8> <C9> <D83CDFD8>
+endbfrange
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.code_byte_length, 1);
+        assert_eq!(cmap.lookup(0xC8), Some("🏘".to_string()));
+        assert_eq!(cmap.lookup(0xC9), Some("🏙".to_string()));
+    }
+
+    #[test]
+    fn test_parse_bfrange_preserves_single_hyphen_like_base() {
+        let cmap_content = r#"
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfrange
+<21> <22> <2013>
+endbfrange
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.lookup(0x21), Some("–".to_string()));
+        assert_eq!(cmap.lookup(0x22), Some("—".to_string()));
+    }
+
+    #[test]
+    fn test_parse_spaced_destination_hex_without_control_noise() {
+        let cmap_content = r#"
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+3 beginbfchar
+<21> < 0009 000d 0020 00a0 >
+<22> < 002d 00ad 2010 >
+<23> <00a0>
+endbfchar
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.lookup(0x21), Some("\t".to_string()));
+        assert_eq!(cmap.lookup(0x22), Some("-".to_string()));
+        assert_eq!(cmap.lookup(0x23), Some("\u{00a0}".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reduce false-positive OCR routing from the garbled-text signal by separating strong decoding failures from replacement-character noise. Page-level OCR now requires enough replacement-character density before routing otherwise clean text pages to OCR, while strong patterns such as CID/control garbage and private-use runs still emit the suspected-garbled-text signal immediately.

This also fixes ToUnicode destination decoding for UTF-16BE surrogate pairs and spaced destination hex strings. PDFs with valid ToUnicode maps for emoji, math symbols, or malformed multi-character whitespace/hyphen destinations now recover the intended text instead of emitting garbled fallback characters or unnecessarily routing to OCR.