### PR TITLE
feat(markdown): underline emission, Unicode scripts, style-preserving merges

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -568,6 +568,13 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 if (next.font_size - first.font_size).abs() > first.font_size * 0.20 {
                     break;
                 }
+                // Never merge across bold/italic boundaries: the merged item
+                // carries `first`'s flags, so absorbing a styled run into a
+                // plain neighbor (or vice versa) silently erases the styling
+                // that markdown emission and downstream inline-styling need.
+                if next.is_bold != first.is_bold || next.is_italic != first.is_italic {
+                    break;
+                }
                 let gap = next.x - end_x;
                 let x_gap_max = if *preserve_stream_order && is_standalone_bullet_text(&text) {
                     first.font_size * 1.2
@@ -710,7 +717,17 @@ pub(crate) fn merge_subscript_items(items: Vec<TextItem>) -> Vec<TextItem> {
                         let gap = item.x - parent_right;
                         // Subscripts must be tightly adjacent (within ~1pt)
                         if gap < parent.font_size * 0.2 && gap > -parent.font_size * 0.3 {
-                            parent.text.push_str(&item.text);
+                            // Preserve the script when absorbing it: map the
+                            // digits to Unicode sub/superscript forms so the
+                            // raised/lowered rendering survives in extracted
+                            // text ("H"+"2" → "H₂", "word"+"2" → "word²").
+                            // NFKC/NFKD normalization folds these back to
+                            // plain digits, so text matching downstream is
+                            // unaffected. Direction from the baseline offset
+                            // (y-up here): raised → superscript (footnote
+                            // refs), lowered/level → subscript (chemistry).
+                            let raised = item.y > parent.y + parent.font_size * 0.1;
+                            parent.text.push_str(&map_script_digits(&item.text, raised));
                             parent.width = (item.x + item.width) - parent.x;
                             continue;
                         }
@@ -723,6 +740,21 @@ pub(crate) fn merge_subscript_items(items: Vec<TextItem>) -> Vec<TextItem> {
     }
 
     result
+}
+
+/// Map ASCII digits to their Unicode superscript (`raised`) or subscript
+/// forms. Callers guarantee digit-only input (see `merge_subscript_items`);
+/// anything else passes through unchanged.
+fn map_script_digits(text: &str, raised: bool) -> String {
+    const SUP: [char; 10] = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'];
+    const SUB: [char; 10] = ['₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉'];
+    text.chars()
+        .map(|c| match c.to_digit(10) {
+            Some(d) if raised => SUP[d as usize],
+            Some(d) => SUB[d as usize],
+            None => c,
+        })
+        .collect()
 }
 
 /// Helper to get f32 from Object
@@ -1633,7 +1665,8 @@ mod tests {
         ];
         let merged = merge_subscript_items(items);
         assert_eq!(merged.len(), 2);
-        assert_eq!(merged[0].text, "NH3");
+        // Lowered baseline → Unicode subscript form (NFKC folds back to "NH3")
+        assert_eq!(merged[0].text, "NH₃");
         assert_eq!(merged[1].text, "Cl");
     }
 
@@ -1647,8 +1680,19 @@ mod tests {
         ];
         let merged = merge_subscript_items(items);
         assert_eq!(merged.len(), 2);
-        assert_eq!(merged[0].text, "H2");
+        assert_eq!(merged[0].text, "H₂");
         assert_eq!(merged[1].text, "O");
+    }
+
+    #[test]
+    fn test_merge_subscript_items_raised_marker_becomes_superscript() {
+        // Footnote reference: "word" followed by a RAISED small "2" → word²
+        let mut marker = make_item_fs("2", 90.0, 502.5, 2.3, 4.7);
+        marker.y = 502.5; // raised above the 499.0 parent baseline
+        let items = vec![make_item_fs("word", 78.0, 499.0, 12.0, 8.0), marker];
+        let merged = merge_subscript_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "word²");
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -559,7 +559,6 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
             let first = group[i];
             let mut text = first.text.clone();
             let mut end_x = first.x + effective_merge_width(first);
-            let mut is_underline = first.is_underline;
 
             let mut j = i + 1;
             while j < group.len() {
@@ -568,11 +567,16 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 if (next.font_size - first.font_size).abs() > first.font_size * 0.20 {
                     break;
                 }
-                // Never merge across bold/italic boundaries: the merged item
+                // Never merge across style boundaries: the merged item
                 // carries `first`'s flags, so absorbing a styled run into a
                 // plain neighbor (or vice versa) silently erases the styling
-                // that markdown emission and downstream inline-styling need.
-                if next.is_bold != first.is_bold || next.is_italic != first.is_italic {
+                // that markdown emission and downstream inline-styling need —
+                // and OR-ing underline instead would stretch `<u>` spans over
+                // neighboring plain text.
+                if next.is_bold != first.is_bold
+                    || next.is_italic != first.is_italic
+                    || next.is_underline != first.is_underline
+                {
                     break;
                 }
                 let gap = next.x - end_x;
@@ -613,7 +617,6 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                     text.push(' ');
                 }
                 text.push_str(&next.text);
-                is_underline |= next.is_underline;
                 let next_end = next.x + effective_merge_width(next);
                 end_x = if *preserve_stream_order {
                     end_x.max(next_end)
@@ -634,7 +637,7 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 page: first.page,
                 is_bold: first.is_bold,
                 is_italic: first.is_italic,
-                is_underline,
+                is_underline: first.is_underline,
                 item_type: first.item_type.clone(),
                 mcid: first.mcid,
             });
@@ -817,6 +820,28 @@ mod tests {
     }
 
     #[test]
+    fn merge_items_breaks_at_style_boundaries() {
+        // A styled run adjacent to plain text must stay a separate item —
+        // merging would erase the flags (italic) or stretch the span
+        // (underline) before markdown emission sees them.
+        let mut italic = make_merge_item("emphasis", 150.0, 40.0);
+        italic.is_italic = true;
+        let mut underlined = make_merge_item("term", 195.0, 20.0);
+        underlined.is_underline = true;
+        let items = vec![
+            make_merge_item("plain lead", 100.0, 48.0),
+            italic,
+            underlined,
+            make_merge_item("plain tail", 218.0, 45.0),
+        ];
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 4);
+        assert!(merged[1].is_italic && !merged[1].is_underline);
+        assert!(merged[2].is_underline && !merged[2].is_italic);
+        assert!(!merged[3].is_underline && !merged[3].is_italic);
+    }
+
+    #[test]
     fn merge_items_no_space_before_period() {
         // Simulate Tc/Tw-adjusted width: "date" width is smaller than the gap
         // to "." due to negative Tc, but period should still join without space.
@@ -856,6 +881,10 @@ mod tests {
 
     #[test]
     fn merge_items_preserves_underline_from_later_fragment() {
+        // Fragments with differing underline stay separate items — OR-merging
+        // would stretch the eventual `<u>` span over the plain fragment.
+        // Line-level text assembly still joins them without a space (tight
+        // gap), so the rendered word is unchanged: `pre<u>fix</u>`.
         let mut items = vec![
             make_merge_item("pre", 100.0, 18.0),
             make_merge_item("fix", 119.0, 18.0),
@@ -864,9 +893,11 @@ mod tests {
 
         let merged = merge_text_items(items);
 
-        assert_eq!(merged.len(), 1);
-        assert_eq!(merged[0].text, "prefix");
-        assert!(merged[0].is_underline);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].text, "pre");
+        assert!(!merged[0].is_underline);
+        assert_eq!(merged[1].text, "fix");
+        assert!(merged[1].is_underline);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1288,6 +1288,19 @@ mod vector_grid_tests {
         );
     }
 
+    #[test]
+    fn td9264_insurance_prose_not_rect_table() {
+        let tables = detect_rect_tables_in_fixture_page("tests/fixtures/td9264.pdf", 4);
+        assert!(
+            tables.is_empty(),
+            "expected no rect-detected tables for the insurance-company prose; got {:?}",
+            tables
+                .iter()
+                .map(|t| (t.rows.len(), t.columns.len(), t.cells.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
     /// Wireless table regression: decorative/text-region rects may provide row
     /// bands, but without a real rect-derived column scaffold they must not be
     /// accepted as a vector grid.

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -131,10 +131,11 @@ pub(crate) fn format_list_item(text: &str) -> String {
         if let Some(rest) = trimmed.strip_prefix(*bullet) {
             return format!("- {}", rest.trim_start());
         }
-        // Bullet inside a leading bold/italic run (e.g. "**● Label:** rest").
-        // The run wraps both the marker and the following label because both
-        // use a bold font in the PDF.
-        for wrapper in ["**", "*"] {
+        // Bullet inside a leading style run (e.g. "**● Label:** rest" or
+        // "<u>● Label</u>"). The run wraps both the marker and the following
+        // label because both carry the style in the PDF. The marker must move
+        // outside the wrapper so markdown still sees a list item.
+        for wrapper in ["**", "*", "<u>"] {
             if let Some(after_open) = trimmed.strip_prefix(wrapper) {
                 if let Some(rest) = after_open.strip_prefix(*bullet) {
                     return format!("- {}{}", wrapper, rest.trim_start());
@@ -233,6 +234,13 @@ mod tests {
     fn format_list_item_plain_bullet() {
         assert_eq!(format_list_item("● Item"), "- Item");
         assert_eq!(format_list_item("• Item"), "- Item");
+    }
+
+    #[test]
+    fn format_list_item_bullet_inside_underline() {
+        // Fully-underlined bullet line: the marker must move outside the
+        // <u> wrapper so markdown still renders a list item.
+        assert_eq!(format_list_item("<u>● Item text</u>"), "- <u>Item text</u>");
     }
 
     #[test]

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -625,7 +625,11 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         prev_x = line_x;
 
         // Get text with optional bold/italic formatting
-        let text = line.text_with_formatting(options.detect_bold, options.detect_italic);
+        let text = line.text_with_formatting(
+            options.detect_bold,
+            options.detect_italic,
+            options.detect_underline,
+        );
         let trimmed = text.trim();
 
         // Also get plain text for pattern matching (list detection, captions, etc.)
@@ -751,8 +755,14 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
                 paragraph_in_wrapped_bold_run = false;
             }
             let prefix = "#".repeat(level);
-            // Use plain text for headers to avoid redundant formatting
-            output.push_str(&format!("{} {}\n\n", prefix, plain_trimmed));
+            // Plain text for headers (no redundant bold/italic inside `#`),
+            // but underline is preserved: `<u>` carries meaning `#` doesn't.
+            let heading_text = if options.detect_underline {
+                line.text_with_formatting(false, false, true)
+            } else {
+                plain_text.clone()
+            };
+            output.push_str(&format!("{} {}\n\n", prefix, heading_text.trim()));
             in_list = false;
             continue;
         }
@@ -994,7 +1004,11 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         prev_y = line.y;
 
         // Get text with optional bold/italic formatting
-        let text = line.text_with_formatting(options.detect_bold, options.detect_italic);
+        let text = line.text_with_formatting(
+            options.detect_bold,
+            options.detect_italic,
+            options.detect_underline,
+        );
         let trimmed = text.trim();
 
         // Also get plain text for pattern matching
@@ -1057,8 +1071,13 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
                     paragraph_in_wrapped_bold_run = false;
                 }
                 let prefix = "#".repeat(header_level);
-                // Use plain text for headers to avoid redundant formatting
-                output.push_str(&format!("{} {}\n\n", prefix, plain_trimmed));
+                // Plain text for headers, except underline (see above).
+                let heading_text = if options.detect_underline {
+                    line.text_with_formatting(false, false, true)
+                } else {
+                    plain_text.clone()
+                };
+                output.push_str(&format!("{} {}\n\n", prefix, heading_text.trim()));
                 in_list = false;
                 continue;
             }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -400,6 +400,8 @@ pub struct MarkdownOptions {
     pub detect_bold: bool,
     /// Detect and format italic text from font names
     pub detect_italic: bool,
+    /// Emit `<u>` runs for text with a geometrically-detected underline
+    pub detect_underline: bool,
     /// Include image placeholders in output
     pub include_images: bool,
     /// Include extracted hyperlinks
@@ -422,6 +424,7 @@ impl Default for MarkdownOptions {
             fix_hyphenation: true,
             detect_bold: true,
             detect_italic: true,
+            detect_underline: true,
             // `include_images: false` is intentional. The content-stream walker
             // now emits `ItemType::Image` `TextItem`s for every Image XObject
             // it encounters (see `extractor/content_stream.rs`). If we rendered

--- a/src/markdown/postprocess.rs
+++ b/src/markdown/postprocess.rs
@@ -30,6 +30,7 @@ pub(crate) fn clean_markdown(mut text: String, options: &MarkdownOptions) -> Str
     // double spaces ("Vice  President" instead of "Vice President").
     collapse_consecutive_spaces(&mut text);
     remove_spaces_before_closing_brackets(&mut text);
+    remove_spaces_before_sentence_punctuation(&mut text);
 
     // Remove excessive newlines (more than 2 in a row)
     while text.contains("\n\n\n") {
@@ -80,6 +81,32 @@ fn remove_spaces_before_closing_brackets(text: &mut String) {
     for ch in text.chars() {
         if ch == ']' && result.ends_with(' ') {
             result.pop();
+        }
+        result.push(ch);
+    }
+    *text = result;
+}
+
+/// Remove a stray space before sentence punctuation ("word ." → "word.").
+/// Style-boundary item splits (bold/italic/underline runs) can strand a
+/// trailing period or comma in its own fragment, and several assembly paths
+/// join fragments with spaces. Only fires when the punctuation ends the
+/// token (followed by whitespace or end of text), so decimals ("3 .14" stays
+/// untouched — no such input exists, but the guard is cheap) and dot leaders
+/// (" ... ") are unaffected.
+fn remove_spaces_before_sentence_punctuation(text: &mut String) {
+    let chars: Vec<char> = text.chars().collect();
+    let mut result = String::with_capacity(text.len());
+    for (i, &ch) in chars.iter().enumerate() {
+        if matches!(ch, '.' | ',' | ';') && result.ends_with(' ') {
+            let next = chars.get(i + 1);
+            // `|` counts as a token end so table cells get the same fix.
+            let token_ends = next.is_none_or(|c| c.is_whitespace() || *c == '|');
+            // Never touch runs of dots (ellipsis / dot leaders).
+            let in_dot_run = ch == '.' && next == Some(&'.');
+            if token_ends && !in_dot_run {
+                result.pop();
+            }
         }
         result.push(ch);
     }
@@ -367,6 +394,36 @@ mod tests {
             input,
             "Density [kg/m3] and [linked text](https://example.com)"
         );
+    }
+
+    // --- remove_spaces_before_sentence_punctuation ---
+
+    #[test]
+    fn strips_space_before_trailing_period() {
+        let mut t = "Foreign insurance companies . The provisions".to_string();
+        remove_spaces_before_sentence_punctuation(&mut t);
+        assert_eq!(t, "Foreign insurance companies. The provisions");
+    }
+
+    #[test]
+    fn strips_space_before_period_at_cell_boundary() {
+        let mut t = "|Applicability date .|This section|".to_string();
+        remove_spaces_before_sentence_punctuation(&mut t);
+        assert_eq!(t, "|Applicability date.|This section|");
+    }
+
+    #[test]
+    fn keeps_dot_leaders_and_ellipses() {
+        let mut t = "Introduction ... 1".to_string();
+        remove_spaces_before_sentence_punctuation(&mut t);
+        assert_eq!(t, "Introduction ... 1");
+    }
+
+    #[test]
+    fn keeps_mid_token_periods() {
+        let mut t = "version 3 .14 released".to_string();
+        remove_spaces_before_sentence_punctuation(&mut t);
+        assert_eq!(t, "version 3 .14 released");
     }
 
     // --- fix_hyphenation ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1124,18 +1124,40 @@ pub(crate) fn assign_items_to_grid(
                             .unwrap_or(std::cmp::Ordering::Equal)
                     })
             });
-            let text: String = col_items
+            let text = col_items
                 .iter()
                 .map(|(_, item)| item.text.trim())
                 .filter(|t| !t.is_empty())
                 .collect::<Vec<_>>()
                 .join(" ");
+            let text = remove_inner_delimiter_spaces(&text);
             row_cells.push(text);
         }
         cells.push(row_cells);
     }
 
     (cells, indices)
+}
+
+fn remove_inner_delimiter_spaces(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut result = String::with_capacity(text.len());
+
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == ' ' {
+            let after_open =
+                result.ends_with('(') || result.ends_with('[') || result.ends_with('{');
+            let before_close = chars
+                .get(i + 1)
+                .is_some_and(|next| matches!(next, ')' | ']' | '}'));
+            if after_open || before_close {
+                continue;
+            }
+        }
+        result.push(ch);
+    }
+
+    result
 }
 
 /// Consolidate text in vertically-merged cells.
@@ -2522,6 +2544,21 @@ mod tests {
         assert_eq!(indices.len(), 2);
         assert!(cells[0][0].contains("Hello"));
         assert!(cells[0][0].contains("World"));
+    }
+
+    #[test]
+    fn test_assign_items_parenthetical_no_inner_spaces() {
+        let items = vec![
+            make_item("The first sentence", 15.0, 85.0, 10.0),
+            make_item("(", 90.0, 85.0, 10.0),
+            make_item("twice", 95.0, 85.0, 10.0),
+            make_item(")", 120.0, 85.0, 10.0),
+        ];
+        let col_edges = vec![10.0, 150.0];
+        let row_edges = vec![90.0, 70.0];
+        let (cells, indices) = assign_items_to_grid(&items, &col_edges, &row_edges, 1);
+        assert_eq!(indices.len(), 4);
+        assert_eq!(cells[0][0], "The first sentence (twice)");
     }
 
     #[test]

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1473,6 +1473,10 @@ fn detect_row_stripe_table(
         (col_edges, cells)
     };
     let num_cols = col_edges.len() - 1;
+    if row_stripe_is_sparse_prose_outline(&cells) {
+        debug!("  row-stripe rejected: sparse outline/prose continuation shape");
+        return None;
+    }
 
     let column_centers: Vec<f32> = (0..num_cols)
         .map(|c| (col_edges[c] + col_edges[c + 1]) / 2.0)
@@ -1489,6 +1493,57 @@ fn detect_row_stripe_table(
     );
 
     Some(Table::new(column_centers, row_centers, cells, item_indices))
+}
+
+fn row_stripe_is_sparse_prose_outline(cells: &[Vec<String>]) -> bool {
+    let Some(num_cols) = cells.first().map(|row| row.len()) else {
+        return false;
+    };
+    if num_cols != 2 || cells.len() < 4 {
+        return false;
+    }
+
+    let non_empty_rows = cells
+        .iter()
+        .filter(|row| row.iter().any(|cell| !cell.trim().is_empty()))
+        .count();
+    if non_empty_rows < 4 {
+        return false;
+    }
+
+    let mut col_counts = [0usize; 2];
+    for row in cells {
+        for (idx, cell) in row.iter().enumerate() {
+            if !cell.trim().is_empty() {
+                col_counts[idx] += 1;
+            }
+        }
+    }
+
+    let (sparse_col, dense_col) = if col_counts[0] <= col_counts[1] {
+        (0usize, 1usize)
+    } else {
+        (1usize, 0usize)
+    };
+    let sparse_count = col_counts[sparse_col];
+    let dense_count = col_counts[dense_col];
+    if sparse_count * 2 >= non_empty_rows || dense_count * 3 < non_empty_rows * 2 {
+        return false;
+    }
+
+    let blank_sparse_dense_rows = cells
+        .iter()
+        .filter(|row| row[sparse_col].trim().is_empty() && !row[dense_col].trim().is_empty())
+        .count();
+    if blank_sparse_dense_rows * 2 < non_empty_rows {
+        return false;
+    }
+
+    let long_dense_cells = cells
+        .iter()
+        .filter(|row| row[dense_col].split_whitespace().count() >= 6)
+        .count();
+    long_dense_cells * 2 >= dense_count
 }
 
 /// Detect a table from cell-background rects that failed grid detection.

--- a/src/tables/grid.rs
+++ b/src/tables/grid.rs
@@ -369,6 +369,10 @@ pub(crate) fn join_cell_items(items: &[&TextItem]) -> String {
             let prev_ends_with_hyphen = result.ends_with('-');
             let curr_is_hyphen = text == "-";
             let curr_starts_with_hyphen = text.starts_with('-');
+            let prev_ends_with_open_delimiter =
+                result.ends_with('(') || result.ends_with('[') || result.ends_with('{');
+            let curr_starts_with_close_delimiter =
+                text.starts_with(')') || text.starts_with(']') || text.starts_with('}');
 
             // Detect subscript/superscript: smaller font size and/or Y offset
             let font_ratio = item.font_size / prev_item.font_size;
@@ -385,6 +389,8 @@ pub(crate) fn join_cell_items(items: &[&TextItem]) -> String {
                 || curr_starts_with_hyphen
                 || is_sub_super
                 || was_sub_super
+                || prev_ends_with_open_delimiter
+                || curr_starts_with_close_delimiter
             {
                 result.push_str(text);
             } else {
@@ -726,6 +732,18 @@ mod tests {
         let b = make_item("-", 120.0, 500.0, 10.0);
         let c = make_item("fix", 130.0, 500.0, 10.0);
         assert_eq!(join_cell_items(&[&a, &b, &c]), "pre-fix");
+    }
+
+    #[test]
+    fn test_join_cell_items_parenthetical_no_inner_spaces() {
+        let a = make_item("The first sentence", 100.0, 500.0, 10.0);
+        let b = make_item("(", 190.0, 500.0, 10.0);
+        let c = make_item("twice", 195.0, 500.0, 10.0);
+        let d = make_item(")", 220.0, 500.0, 10.0);
+        assert_eq!(
+            join_cell_items(&[&a, &b, &c, &d]),
+            "The first sentence (twice)"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,12 +141,17 @@ pub struct TextLine {
 
 impl TextLine {
     pub fn text(&self) -> String {
-        self.text_with_formatting(false, false)
+        self.text_with_formatting(false, false, false)
     }
 
-    /// Get text with optional bold/italic markdown formatting
-    pub fn text_with_formatting(&self, format_bold: bool, format_italic: bool) -> String {
-        if !format_bold && !format_italic {
+    /// Get text with optional bold/italic/underline markdown formatting
+    pub fn text_with_formatting(
+        &self,
+        format_bold: bool,
+        format_italic: bool,
+        format_underline: bool,
+    ) -> String {
+        if !format_bold && !format_italic && !format_underline {
             return self.text_plain();
         }
 
@@ -155,6 +160,7 @@ impl TextLine {
         let mut result = String::new();
         let mut current_bold = false;
         let mut current_italic = false;
+        let mut current_underline = false;
 
         for (i, item) in self.items.iter().enumerate() {
             let text = item.text.as_str();
@@ -180,9 +186,13 @@ impl TextLine {
             // we push text_trimmed below (which strips it).
             let has_leading_space = text.starts_with(' ');
 
-            // Check for style changes
-            let item_bold = format_bold && item.is_bold;
-            let item_italic = format_italic && item.is_italic;
+            // Check for style changes. Underline is exclusive: `<u>` content
+            // stays free of `**`/`*` markers — consumers (and the eval
+            // harnesses this feeds) match the tag content literally, and
+            // mixed `<u>**x**</u>` nesting breaks that.
+            let item_underline = format_underline && item.is_underline;
+            let item_bold = format_bold && item.is_bold && !item_underline;
+            let item_italic = format_italic && item.is_italic && !item_underline;
 
             // Close previous styles if they change
             if current_italic && !item_italic {
@@ -193,6 +203,10 @@ impl TextLine {
                 result.push_str("**");
                 current_bold = false;
             }
+            if current_underline && !item_underline {
+                result.push_str("</u>");
+                current_underline = false;
+            }
 
             // Add space: either from spacing logic or preserved from item text
             if needs_space || (has_leading_space && !result.is_empty() && !result.ends_with(' ')) {
@@ -200,6 +214,10 @@ impl TextLine {
             }
 
             // Open new styles
+            if item_underline && !current_underline {
+                result.push_str("<u>");
+                current_underline = true;
+            }
             if item_bold && !current_bold {
                 result.push_str("**");
                 current_bold = true;
@@ -218,6 +236,9 @@ impl TextLine {
         }
         if current_bold {
             result.push_str("**");
+        }
+        if current_underline {
+            result.push_str("</u>");
         }
 
         result

--- a/tests/snapshots/2013-app2.md
+++ b/tests/snapshots/2013-app2.md
@@ -237,7 +237,7 @@
 |201|24/9|Procurement of vehicle x 2|SLTA|Abhaye Valabhji Pty Ltd|SR1000.000.00|
 ||OCT|||||
 |202|1/10|Proposed new traffic lane to 5th June Avenue|SLTA|Divy Constrution|SR2,864,589.00|
-|203|1/10||Proposed Walkway, Drain, rock armoring, road and Bridge widening at Anse Talbot( Ex-Golden Egg) - Variations SLTA|G & S Enterprise|SR200,448.00|
+|203|1/10||Proposed Walkway, Drain, rock armoring, road and Bridge widening at Anse Talbot(Ex-Golden Egg) - Variations SLTA|G & S Enterprise|SR200,448.00|
 |204|1/10|Proposed Reconstrcution of Burnt House-Au Cap|MLUH|Furui Construction|SR946,130.00|
 |205|1/10|Variation on the project associated with the procurement of seven 100m3/day containerised plant|PUC|Tornado Group (UAE)|USD172,500.00|
 |206|1/10|Works on the breaker system at Bel Omber desalination plant|PUC|United Concrete Products (Sey)Ltd|SR1,998,993.11|

--- a/tests/snapshots/2013-app2.md
+++ b/tests/snapshots/2013-app2.md
@@ -188,7 +188,7 @@
 |156|23/7|General renovation works to Block B at Belonie Secondary School|MOE|Belvedere Builders|SR869,505.75|
 |157|30/7|Procurement of Engine Block and Crankshaft for Engine A11|PUC|Ras Tek Pvt Ltd|Euro798,650.00|
 |158|30/7|procurement of Wartsila Engine spares|PUC|Wartsila Eastern Africa ltd|Euro158,424.00|
-|159|30/7|Proposed walkway, Drain, rock armoring , road and Bridge widening at Anse Talbot( Ex-Golden Egg)|SLTA|G&S Enterpise|SR1,113,010.00|
+|159|30/7|Proposed walkway, Drain, rock armoring, road and Bridge widening at Anse Talbot( Ex-Golden Egg)|SLTA|G&S Enterpise|SR1,113,010.00|
 |160|30/7|Procurement of transfer pump control panel|PUC|CA Engineering Consultancy Pte Ltd|SGD14,600.00|
 |161|30/7|Consultancy service for North to South Victoria Bye- Pass road and utilities organisation|MLUH|Sonnel Seychelles LTD|SR1,332,000.00|
 |162 AUG|30/7|Procurement of the supply of sodium cardonate|PUC|HPL Chemical LTD|USD42,600.00|
@@ -237,7 +237,7 @@
 |201|24/9|Procurement of vehicle x 2|SLTA|Abhaye Valabhji Pty Ltd|SR1000.000.00|
 ||OCT|||||
 |202|1/10|Proposed new traffic lane to 5th June Avenue|SLTA|Divy Constrution|SR2,864,589.00|
-|203|1/10||Proposed Walkway, Drain, rock armoring , road and Bridge widening at Anse Talbot( Ex-Golden Egg) - Variations SLTA|G & S Enterprise|SR200,448.00|
+|203|1/10||Proposed Walkway, Drain, rock armoring, road and Bridge widening at Anse Talbot( Ex-Golden Egg) - Variations SLTA|G & S Enterprise|SR200,448.00|
 |204|1/10|Proposed Reconstrcution of Burnt House-Au Cap|MLUH|Furui Construction|SR946,130.00|
 |205|1/10|Variation on the project associated with the procurement of seven 100m3/day containerised plant|PUC|Tornado Group (UAE)|USD172,500.00|
 |206|1/10|Works on the breaker system at Bel Omber desalination plant|PUC|United Concrete Products (Sey)Ltd|SR1,998,993.11|

--- a/tests/snapshots/p1244-1996.md
+++ b/tests/snapshots/p1244-1996.md
@@ -10,7 +10,7 @@ Department of the Treasury **Internal Revenue Service**
 
 ### This publication contains:
 
-**Form 4070A, Employee’s Daily Record of** Tips **Form 4070, Employee’s Report of Tips to** Employer
+**Form 4070A,** Employee’s Daily Record of Tips **Form 4070,** Employee’s Report of Tips to Employer
 
 For the period
 
@@ -22,7 +22,7 @@ Name and address of employee
 
 **Publication 1244 (Rev. 7-96)** Cat. No. 44472W
 
-**Instructions** You must keep sufficient proof to show the amount of your tip income for the year. A daily record of your tip income is considered sufficient proof. Keep a daily record for each workday showing the amount of cash and credit card tips received directly from customers or other employees. Also keep a record of the amount of tips, if any, you paid to other employees through tip sharing, tip pooling or other arrangements, and the names of employees to whom you paid tips. Show the date that each entry is made. This date should be on or near the date you received the tip income. You may use Form 4070A, Employee’s Daily Record of Tips, or any other daily record to record your tips. **Reporting Tips to Your Employer.—If you** receive tips that total $20 or more for any month while working for one employer, you must report the tips to your employer. Tips include cash left by customers, tips customers add to credit card charges, and tips you receive from other employees. You must report your tips for any one month by the 10th day of the next month. If the 10th day falls on a Saturday, Sunday, or legal holiday, you may give the report to your employer on the next business day that is not a Saturday, Sunday, or legal holiday. You must report tips that total $20 or more every month regardless of your total wages and tips for the year. You may use Form 4070, Employee’s Report of Tips to Employer, to report your tips to your employer. See the instructions on the back of Form 4070. You must include all tips, including tips not reported to your employer, as wages on your income tax return. You may use the last page of this publication to total your tips for the year. Your employer must withhold income, social security, and Medicare (or railroad retirement) taxes on tips you report. Your employer usually deducts the withholding due on tips from your regular wages.
+**Instructions** You must keep sufficient proof to show the amount of your tip income for the year. A daily record of your tip income is considered sufficient proof. Keep a daily record for each workday showing the amount of cash and credit card tips received directly from customers or other employees. Also keep a record of the amount of tips, if any, you paid to other employees through tip sharing, tip pooling or other arrangements, and the names of employees to whom you paid tips. Show the date that each entry is made. This date should be on or near the date you received the tip income. You may use **Form 4070A**, Employee’s Daily Record of Tips, or any other daily record to record your tips. **Reporting Tips to Your Employer.—**If you receive tips that total $20 or more for any month while working for one employer, you must report the tips to your employer. Tips include cash left by customers, tips customers add to credit card charges, and tips you receive from other employees. You must report your tips for any one month by the 10th day of the next month. If the 10th day falls on a Saturday, Sunday, or legal holiday, you may give the report to your employer on the next business day that is not a Saturday, Sunday, or legal holiday. You must report tips that total $20 or more every month regardless of your total wages and tips for the year. You may use **Form 4070**, Employee’s Report of Tips to Employer, to report your tips to your employer. See the instructions on the back of Form 4070. You must include all tips, including tips not reported to your employer, as wages on your income tax return. You may use the last page of this publication to total your tips for the year. Your employer must withhold income, social security, and Medicare (or railroad retirement) taxes on tips you report. Your employer usually deducts the withholding due on tips from your regular wages.
 
 *(continued on inside of back cover)*
 
@@ -30,14 +30,14 @@ Form **4070A** Employee’s Daily Record of Tips (Rev. July 1996) **This is a vo
 
 Establishment name (if different)
 
-Date Date **a. Tips received**
+Date Date **a.** Tips received
 
-**b. Credit card tips c. Tips paid out to d. Names of employees to whom you**
+**b.** Credit card tips **c.** Tips paid out to **d.** Names of employees to whom you
 tips of directly from customers received other employees paid tips rec’d. entry and other employees 1 2 3 4 5 **Subtotals** **For Paperwork Reduction Act Notice, see Instructions on the back of Form 4070. Page 1**
 
-Date Date **a. Tips received**
+Date Date **a.** Tips received
 
-**b. Credit card tips c. Tips paid out to d. Names of employees to whom you**
+**b.** Credit card tips **c.** Tips paid out to **d.** Names of employees to whom you
 tips of directly from customers received other employees paid tips rec’d. entry and other employees
 
 7 8 9 10 11 12 13 14 15 **Subtotals**
@@ -50,9 +50,9 @@ tips of directly from customers received other employees paid tips rec’d. entr
 
 27 28 29 30 31 **Subtotals** **from pages** **1, 2, and 3** **Totals**
 
-**1.** Report total cash tips (col. a) on Form 4070, line 1.
-**2.** Report total credit card tips (col. b) on Form 4070, line 2.
-**3.** Report total tips paid out (col. c) on Form 4070, line 3. **Page 4**
+**1.** Report total cash tips (col. **a**) on Form 4070, line **1.**
+**2.** Report total credit card tips (col. **b**) on Form 4070, line **2.**
+**3.** Report total tips paid out (col. **c**) on Form 4070, line **3.** **Page 4**
 
 Form Employee’s Report (Rev. July 1996)
 
@@ -66,17 +66,17 @@ Employer’s name and address (include establishment name, if different) **1** C
 
 **3** Tips paid out
 
-Month or shorter period in which tips were received **4** Net tips (lines 1 + 2 - 3) from, 19, to, 19 Signature Date
+Month or shorter period in which tips were received **4** Net tips (lines **1 + 2 - 3**) from, 19, to, 19 Signature Date
 
-**Paperwork Reduction Act Notice.—We ask for the** information on these forms to carry out the Internal Revenue laws of the United States. You are required to give us the information. We need it to ensure that you are complying with these laws and to allow us to figure and collect the right amount of tax. You are not required to provide the information requested on a form that is subject to the Paperwork Reduction Act unless the form displays a valid OMB control number. Books or records relating to a form or its instructions must be retained as long as their contents may become material in the administration of any Internal Revenue law. Generally, tax returns and return information are confidential, as required by Code section 6103. The time needed to complete Forms 4070 and 4070A will vary depending on individual circumstances. The estimated average times are: Recordkeeping—Form 4070, 7 min.; Form 4070A, 3 hr. and 23 min.; Learning **about the law—each form, 2 min.; Preparing Form 4070,** 13 min.; Form 4070A, 55 min.; and Copying and **providing Form 4070, 10 min.; Form 4070A, 14 min.** If you have comments concerning the accuracy of these time estimates or suggestions for making these
+**Paperwork Reduction Act Notice.—**We ask for the information on these forms to carry out the Internal Revenue laws of the United States. You are required to give us the information. We need it to ensure that you are complying with these laws and to allow us to figure and collect the right amount of tax. You are not required to provide the information requested on a form that is subject to the Paperwork Reduction Act unless the form displays a valid OMB control number. Books or records relating to a form or its instructions must be retained as long as their contents may become material in the administration of any Internal Revenue law. Generally, tax returns and return information are confidential, as required by Code section 6103. The time needed to complete Forms 4070 and 4070A will vary depending on individual circumstances. The estimated average times are: **Recordkeeping**—Form 4070, 7 min.; Form 4070A, 3 hr. and 23 min.; **Learning** **about the law**—each form, 2 min.; **Preparing** Form 4070, 13 min.; Form 4070A, 55 min.; and **Copying and** **providing** Form 4070, 10 min.; Form 4070A, 14 min. If you have comments concerning the accuracy of these time estimates or suggestions for making these
 
-forms simpler, we would be happy to hear from you. You can write to the Tax Forms Committee, Western Area Distribution Center, Rancho Cordova, CA 95743-0001. **Purpose.—Use this form to report tips you receive to** your employer. This includes cash tips, tips you receive from other employees, and credit card tips. You must report tips every month regardless of your total wages and tips for the year. However, you do not have to report tips to your employer for any month you received less than $20 in tips while working for that employer. Report tips by the 10th day of the month following the month that you receive them. If the 10th day is a Saturday, Sunday, or legal holiday, report tips by the next day that is not a Saturday, Sunday, or legal holiday. See Pub. 531, Reporting Tip Income, for more information. You can get additional copies of Pub. 1244, Employee’s Daily Record of Tips and Report to Employer, which contains both Forms 4070A and 4070, by calling 1-800-TAX-FORM (1-800-829-3676).
+forms simpler, we would be happy to hear from you. You can write to the Tax Forms Committee, Western Area Distribution Center, Rancho Cordova, CA 95743-0001. **Purpose.—**Use this form to report tips you receive to your employer. This includes cash tips, tips you receive from other employees, and credit card tips. You must report tips every month regardless of your total wages and tips for the year. However, you do not have to report tips to your employer for any month you received less than $20 in tips while working for that employer. Report tips by the 10th day of the month following the month that you receive them. If the 10th day is a Saturday, Sunday, or legal holiday, report tips by the next day that is not a Saturday, Sunday, or legal holiday. See **Pub. 531**, Reporting Tip Income, for more information. You can get additional copies of **Pub. 1244**, Employee’s Daily Record of Tips and Report to Employer, which contains both Forms 4070A and 4070, by calling 1-800-TAX-FORM (1-800-829-3676).
 
-**Instructions (continued)**
+**Instructions** *(continued)*
 
-**Unreported Tips.—If you received tips of $20 or** more for any month while working for one employer but did not report them to your employer, you must figure and pay social security and Medicare taxes on the unreported tips when you file your tax return. If you have unreported tips, you must use Form 1040 and Form 4137, Social Security and Medicare Tax on Unreported Tip Income, to report them. You may not use Form 1040A or 1040EZ. Employees subject to the Railroad Retirement Tax Act cannot use Form 4137 to pay railroad retirement tax on unreported tips. To get railroad retirement credit, you must report tips to your employer. If you do not report tips to your employer as required, you may be charged a penalty of 50% of the social security and Medicare taxes (or railroad retirement tax) due on the unreported tips unless there was reasonable cause for not reporting them. **Additional Information.—Get Pub. 531, Reporting** Tip Income, and Form 4137 for more information on tips. If you are an employee of certain large food or beverage establishments, see Pub. 531 for tip allocation rules. **Recordkeeping.—If you do not keep a daily** record of tips, you must keep other reliable proof of the tip income you received. This proof includes copies of restaurant bills and credit card charges that show amounts customers added as tips. Keep your tip income records for as long as the information on them may be needed in the administration of any Internal Revenue law.
+**Unreported Tips.—**If you received tips of $20 or more for any month while working for one employer but did not report them to your employer, you must figure and pay social security and Medicare taxes on the unreported tips when you file your tax return. If you have unreported tips, you **must** use Form 1040 and **Form 4137,** Social Security and Medicare Tax on Unreported Tip Income, to report them. You may **not** use Form 1040A or 1040EZ. Employees subject to the Railroad Retirement Tax Act **cannot** use Form 4137 to pay railroad retirement tax on unreported tips. To get railroad retirement credit, you must report tips to your employer. If you do not report tips to your employer as required, you may be charged a penalty of 50% of the social security and Medicare taxes (or railroad retirement tax) due on the unreported tips unless there was reasonable cause for not reporting them. **Additional Information.—**Get **Pub. 531,** Reporting Tip Income, and Form 4137 for more information on tips. If you are an employee of certain large food or beverage establishments, see Pub. 531 for tip allocation rules. **Recordkeeping.—**If you do not keep a daily record of tips, you must keep other reliable proof of the tip income you received. This proof includes copies of restaurant bills and credit card charges that show amounts customers added as tips. Keep your tip income records for as long as the information on them may be needed in the administration of any Internal Revenue law.
 
-### Instructions (continued)
+**Instructions** *(continued)*
 
 Use this space to total your tips for the year
 

--- a/tests/snapshots/real-estate-pricing.md
+++ b/tests/snapshots/real-estate-pricing.md
@@ -6,7 +6,7 @@
 
 8 4 Z E L L / L U R I E R E A L E S T A T E C E N T E R
 
-**Table I: Cap rate correlations** **Cap Rate Correlation With:*** **BBB Corp** **10-Year Bond Yield S&P Dividend** **Treasury (10-15 yr) Yield** Multifamily 0.187 0.771 0.068 Industrial-0.221 0.748-0.307 CBD Office-0.449 0.694-0.458 Retail-0.181 0.649-02.58
+**Table I:** Cap rate correlations **Cap Rate Correlation With:*** **BBB Corp** **10-Year Bond Yield S&P Dividend** **Treasury (10-15 yr) Yield** Multifamily 0.187 0.771 0.068 Industrial-0.221 0.748-0.307 CBD Office-0.449 0.694-0.458 Retail-0.181 0.649-02.58
 
 * Based on 25 years of data for the 10-yrT & S&P DivYld; and 14 years for BBB.
 **Figure 1:** NCREIF cap rates vs. 10-yearTreasury
@@ -20,7 +20,9 @@ R E V I E W 8 5
 
 **Figure 2:** Capratespreadsover10-yearTreasury
 
-**Basis Points -200** -400
+**Basis Points** -200
+
+-400
 
 -600
 
@@ -32,7 +34,7 @@ R E V I E W 8 5
 
 1982 1986 1990 1994 1998 2002 2006
 
-**Table II: Correlationsofspreadsbypropertytype** **Correlation of Cap Rate Spreads Over Treasury** **Multifamily Industrial CBD Office**
+**Table II:** Correlationsofspreadsbypropertytype **Correlation of Cap Rate Spreads Over Treasury** **Multifamily Industrial CBD Office**
 
 ||Multifamily|Industrial|CBD Office|
 |---|---|---|---|

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -1,8 +1,8 @@
 (e) [Reserved]. For further guidance, see §1.1563-3T(e)(1). Par. 50. Section 1.1563-3T is added to read as follows:
-<u>§1.1563-3T Rules for determining stock ownership (temporary).</u>
+<u>§1.1563-3T Rules for determining stock ownership (temporary)</u>.
 
 (a) through (d)(2)(iii) [Reserved]. For further guidance, see §1.1563-3(a)
-through (d)(2)(iii). <u>(iv) Statement.</u> If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include--
+through (d)(2)(iii). (iv) <u>Statement</u>. If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include--
 
 (A) A description of each of the controlled groups in which the corporation
 could be included. The description must include the name and employer identification number of each component member of each such group and the stock ownership of the component members of each such group; and
@@ -10,7 +10,7 @@ could be included. The description must include the name and employer identifica
 (B) The following representation: [INSERT NAME AND EMPLOYER
 IDENTIFICATION NUMBER OF CORPORATION] ELECTS TO BE TREATED AS A COMPONENT MEMBER OF THE [INSERT DESIGNATION OF GROUP].
 
-<u>(v) Election-- (A) Election filed. An election filed under paragraph (d)(2)(iv) of</u>
+(v) <u>Election</u>-- (A) <u>Election filed</u>. An election filed under paragraph (d)(2)(iv) of
 this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of §1.1563-3 applies or until a change in the stock ownership of the corporation results in
 
 |termination of membership in the controlled group in which such corporation has||
@@ -24,53 +24,54 @@ this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of
 |stock ownership of the corporation results in termination of membership in the||
 |controlled group in which such corporation has been included.||
 |(d)(3) [Reserved]. For further guidance, see §1.1563-3(d)(3).||
-|(e) Effective date-- (1) Applicability date.|This section applies to any original|
+|(e) Effective date-- (1) Applicability date .|This section applies to any original|
 
 Federal income tax return (including any amended return filed on or before the due date (including extensions) of such original return) timely filed on or after May 30,
 
 2006.
 (2) Expiration date. The applicability of this section will expire on May 26,
-2009. Par. 51. Section 1.6012-2 is amended by revising paragraph (c) and adding paragraph (k) to read as follows: <u>§1.6012-2 Corporations required to make returns of income.</u>
+2009. Par. 51. Section 1.6012-2 is amended by revising paragraph (c) and adding paragraph (k) to read as follows: <u>§1.6012-2 Corporations required to make returns of income</u>.
 * * * * *
 (c) [Reserved]. For further guidance, see §1.6012-2T(c).
 * * * * *
 (k) [Reserved]. For further guidance, see §1.6012-2T(k)(1).
 
-Par. 52. Section 1.6012-2T is added to read as follows: <u>§1.6012-2T Corporations required to make returns of income (temporary).</u>
+Par. 52. Section 1.6012-2T is added to read as follows: <u>§1.6012-2T Corporations required to make returns of income (temporary)</u>.
 
 (a) through (b) [Reserved]. For further guidance, see §1.6012-2(a) through
 (b).
 (c) Insurance companies-- (1) Domestic life insurance companies-- (i) In
-<u>general. A life insurance company subject to tax under section 801 shall make a</u> return on Form 1120L. Except as provided in paragraph (c)(4) of this section, such company shall file with its return--
+<u>general</u>. A life insurance company subject to tax under section 801 shall make a return on Form 1120L. Except as provided in paragraph (c)(4) of this section, such company shall file with its return--
 
 (A) A copy of its annual statement which shows the reserves used by the
 company in computing the taxable income reported on its return; and
 
 (B) A copy of Schedule A (real estate) and of Schedule D (bonds and stocks),
-or any successor thereto, of such annual statement. <u>(ii) Mutual savings banks. Mutual savings banks conducting life insurance</u> business and meeting the requirements of section 594 are subject to partial tax computed on Form 1120 and partial tax computed on Form 1120L. The Form 1120L is attached as a schedule to Form 1120, together with the annual statement and schedules required to be filed with Form 1120L.
+or any successor thereto, of such annual statement. (ii) <u>Mutual savings banks</u>. Mutual savings banks conducting life insurance business and meeting the requirements of section 594 are subject to partial tax computed on Form 1120 and partial tax computed on Form 1120L. The Form 1120L is attached as a schedule to Form 1120, together with the annual statement and schedules required to be filed with Form 1120L.
 
-<u>(2) Domestic nonlife insurance companies. Every domestic insurance</u>
+(2) <u>Domestic nonlife insurance companies</u>. Every domestic insurance
 company other than a life insurance company shall make a return on Form 1120PC. This includes organizations described in section 501(m)(1) that provide commercial- type insurance and organizations described in section 833. Except as provided in paragraph (c)(4) of this section, such company shall file with its return a copy of its
 
 annual statement (or a pro forma annual statement), including the underwriting and investment exhibit for the year covered by such return.
 
-<u>(3) Foreign insurance companies. The provisions of paragraphs (c)(1) and</u>
-(c)(2) of this section concerning the returns and statements of insurance companies subject to tax under section 801 or section 831 also apply to foreign insurance companies subject to tax under those sections, except that the copy of the annual statement required to be submitted with the return shall, in the case of a foreign insurance company that is not required to file an annual statement, be a copy of the pro forma annual statement relating to the United States business of such company.
-<u>(4) Exception for insurance companies filing their Federal income tax returns</u>
-<u>electronically. If an insurance company described in paragraph (c)(1), (c)(2), or</u>
+||(c)(2) of this section concerning the returns and statements of insurance companies|
+|---|---|
+||subject to tax under section 801 or section 831 also apply to foreign insurance companies subject to tax under those sections, except that the copy of the annual statement required to be submitted with the return shall, in the case of a foreign insurance company that is not required to file an annual statement, be a copy of the pro forma annual statement relating to the United States business of such|
+|company.||
+|electronically|. If an insurance company described in paragraph (c)(1), (c)(2), or (c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e). the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of|
 
-(c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e).
-<u>(5) Definition. For purposes of this section, the term annual statement means</u>
-the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of
+(3) Foreign insurance companies . The provisions of paragraphs (c)(1) and
+(4) Exception for insurance companies filing their Federal income tax returns
+(5) Definition . For purposes of this section, the term annual statement means
 
 Columbia. The term annual statement also includes a pro forma annual statement if the insurance company is not required to file the NAIC annual statement.
 
 (d) through (j) [Reserved]. For further guidance, see §1.6012-2(d) through (j).
-<u>(k) Effective date-- (1) Applicability date.</u> This section applies to any original
+(k) <u>Effective date</u>-- (1) <u>Applicability date</u>. This section applies to any original
 Federal income tax return (including any amended return filed on or before the due date (including extensions) of such original return) timely filed on or after May 30,
 
 2006.
-<u>(2) Expiration date. The applicability of this section will expire on May 26,</u>
+(2) <u>Expiration date</u>. The applicability of this section will expire on May 26,
 2009.
 
 |||Par. 53. For each entry in the “Location” column of the following table,|
@@ -165,7 +166,7 @@ section and paragraph
 PART 602--OMB CONTROL NUMBERS UNDER THE PAPERWORK REDUCTION ACT Par. 54. The authority citation for part 602 continues to read as follows: Authority: 26 U.S.C. 7805. Par. 55. In §602.101, paragraph (b) is amended to read as follows:
 
 1. The following entries to the table are removed:
-<u>§602.101 OMB Control numbers.</u>
+<u>§602.101 OMB Control numbers</u>.
 
 * * * * *
 (b) * * *
@@ -180,7 +181,7 @@ CFR part or section where Current OMB identified or described control No.
 1.1081-11………………………………………………………………. 1545-2019
 * * * * * **______________________________________________________________**
 2. The following entries are added in numerical order to the table:
-<u>§602.101 OMB Control numbers.</u>
+<u>§602.101 OMB Control numbers</u>.
 
 * * * * *
 (b) * * *

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -1,8 +1,8 @@
 (e) [Reserved]. For further guidance, see §1.1563-3T(e)(1). Par. 50. Section 1.1563-3T is added to read as follows:
-§1.1563-3T Rules for determining stock ownership (temporary).
+<u>§1.1563-3T Rules for determining stock ownership (temporary).</u>
 
 (a) through (d)(2)(iii) [Reserved]. For further guidance, see §1.1563-3(a)
-through (d)(2)(iii). (iv) Statement. If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include--
+through (d)(2)(iii). <u>(iv) Statement.</u> If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include--
 
 (A) A description of each of the controlled groups in which the corporation
 could be included. The description must include the name and employer identification number of each component member of each such group and the stock ownership of the component members of each such group; and
@@ -10,7 +10,7 @@ could be included. The description must include the name and employer identifica
 (B) The following representation: [INSERT NAME AND EMPLOYER
 IDENTIFICATION NUMBER OF CORPORATION] ELECTS TO BE TREATED AS A COMPONENT MEMBER OF THE [INSERT DESIGNATION OF GROUP].
 
-(v) Election-- (A) Election filed. An election filed under paragraph (d)(2)(iv) of
+<u>(v) Election-- (A) Election filed. An election filed under paragraph (d)(2)(iv) of</u>
 this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of §1.1563-3 applies or until a change in the stock ownership of the corporation results in
 
 |termination of membership in the controlled group in which such corporation has||
@@ -30,47 +30,47 @@ Federal income tax return (including any amended return filed on or before the d
 
 2006.
 (2) Expiration date. The applicability of this section will expire on May 26,
-2009. Par. 51. Section 1.6012-2 is amended by revising paragraph (c) and adding paragraph (k) to read as follows: §1.6012-2 Corporations required to make returns of income.
+2009. Par. 51. Section 1.6012-2 is amended by revising paragraph (c) and adding paragraph (k) to read as follows: <u>§1.6012-2 Corporations required to make returns of income.</u>
 * * * * *
 (c) [Reserved]. For further guidance, see §1.6012-2T(c).
 * * * * *
 (k) [Reserved]. For further guidance, see §1.6012-2T(k)(1).
 
-Par. 52. Section 1.6012-2T is added to read as follows: §1.6012-2T Corporations required to make returns of income (temporary).
+Par. 52. Section 1.6012-2T is added to read as follows: <u>§1.6012-2T Corporations required to make returns of income (temporary).</u>
 
 (a) through (b) [Reserved]. For further guidance, see §1.6012-2(a) through
 (b).
 (c) Insurance companies-- (1) Domestic life insurance companies-- (i) In
-general. A life insurance company subject to tax under section 801 shall make a return on Form 1120L. Except as provided in paragraph (c)(4) of this section, such company shall file with its return--
+<u>general. A life insurance company subject to tax under section 801 shall make a</u> return on Form 1120L. Except as provided in paragraph (c)(4) of this section, such company shall file with its return--
 
 (A) A copy of its annual statement which shows the reserves used by the
 company in computing the taxable income reported on its return; and
 
 (B) A copy of Schedule A (real estate) and of Schedule D (bonds and stocks),
-or any successor thereto, of such annual statement. (ii) Mutual savings banks. Mutual savings banks conducting life insurance business and meeting the requirements of section 594 are subject to partial tax computed on Form 1120 and partial tax computed on Form 1120L. The Form 1120L is attached as a schedule to Form 1120, together with the annual statement and schedules required to be filed with Form 1120L.
+or any successor thereto, of such annual statement. <u>(ii) Mutual savings banks. Mutual savings banks conducting life insurance</u> business and meeting the requirements of section 594 are subject to partial tax computed on Form 1120 and partial tax computed on Form 1120L. The Form 1120L is attached as a schedule to Form 1120, together with the annual statement and schedules required to be filed with Form 1120L.
 
-(2) Domestic nonlife insurance companies. Every domestic insurance
+<u>(2) Domestic nonlife insurance companies. Every domestic insurance</u>
 company other than a life insurance company shall make a return on Form 1120PC. This includes organizations described in section 501(m)(1) that provide commercial- type insurance and organizations described in section 833. Except as provided in paragraph (c)(4) of this section, such company shall file with its return a copy of its
 
 annual statement (or a pro forma annual statement), including the underwriting and investment exhibit for the year covered by such return.
 
-(3) Foreign insurance companies. The provisions of paragraphs (c)(1) and
+<u>(3) Foreign insurance companies. The provisions of paragraphs (c)(1) and</u>
 (c)(2) of this section concerning the returns and statements of insurance companies subject to tax under section 801 or section 831 also apply to foreign insurance companies subject to tax under those sections, except that the copy of the annual statement required to be submitted with the return shall, in the case of a foreign insurance company that is not required to file an annual statement, be a copy of the pro forma annual statement relating to the United States business of such company.
-(4) Exception for insurance companies filing their Federal income tax returns
-electronically. If an insurance company described in paragraph (c)(1), (c)(2), or
+<u>(4) Exception for insurance companies filing their Federal income tax returns</u>
+<u>electronically. If an insurance company described in paragraph (c)(1), (c)(2), or</u>
 
 (c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e).
-(5) Definition. For purposes of this section, the term annual statement means
+<u>(5) Definition. For purposes of this section, the term annual statement means</u>
 the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of
 
 Columbia. The term annual statement also includes a pro forma annual statement if the insurance company is not required to file the NAIC annual statement.
 
 (d) through (j) [Reserved]. For further guidance, see §1.6012-2(d) through (j).
-(k) Effective date-- (1) Applicability date. This section applies to any original
+<u>(k) Effective date-- (1) Applicability date.</u> This section applies to any original
 Federal income tax return (including any amended return filed on or before the due date (including extensions) of such original return) timely filed on or after May 30,
 
 2006.
-(2) Expiration date. The applicability of this section will expire on May 26,
+<u>(2) Expiration date. The applicability of this section will expire on May 26,</u>
 2009.
 
 |||Par. 53. For each entry in the “Location” column of the following table,|
@@ -160,12 +160,12 @@ section and paragraph
 |§1.1563-3(d)(2)(i)|(iv) of this subparagraph|(iii) of this section, and paragraph (d)(2)(iv) of §1.1563-3T|
 |The first sentence of|§1.332-6(b), 1.368-3(a),|§1.332-6T(a), §1.368-|
 |§1.6043-2(a)|or 1.1081-11|3T(a), or §1.1081-11T|
-|The first sentence of §301.6011-5T(a) (twice)|§1.6012-2|paragraphs (a), (b) and (d) through (j) of §1.6012- 2, and paragraph (c) of §1.6012-2T|
+|The first sentence of §301.6011-5T(a) ( twice )|§1.6012-2|paragraphs (a), (b) and (d) through (j) of §1.6012- 2, and paragraph (c) of §1.6012-2T|
 
 PART 602--OMB CONTROL NUMBERS UNDER THE PAPERWORK REDUCTION ACT Par. 54. The authority citation for part 602 continues to read as follows: Authority: 26 U.S.C. 7805. Par. 55. In §602.101, paragraph (b) is amended to read as follows:
 
 1. The following entries to the table are removed:
-§602.101 OMB Control numbers.
+<u>§602.101 OMB Control numbers.</u>
 
 * * * * *
 (b) * * *
@@ -180,7 +180,7 @@ CFR part or section where Current OMB identified or described control No.
 1.1081-11………………………………………………………………. 1545-2019
 * * * * * **______________________________________________________________**
 2. The following entries are added in numerical order to the table:
-§602.101 OMB Control numbers.
+<u>§602.101 OMB Control numbers.</u>
 
 * * * * *
 (b) * * *

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -24,7 +24,7 @@ this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of
 |stock ownership of the corporation results in termination of membership in the||
 |controlled group in which such corporation has been included.||
 |(d)(3) [Reserved]. For further guidance, see §1.1563-3(d)(3).||
-|(e) Effective date-- (1) Applicability date .|This section applies to any original|
+|(e) Effective date-- (1) Applicability date.|This section applies to any original|
 
 Federal income tax return (including any amended return filed on or before the due date (including extensions) of such original return) timely filed on or after May 30,
 
@@ -60,9 +60,9 @@ annual statement (or a pro forma annual statement), including the underwriting a
 |company.||
 |electronically|. If an insurance company described in paragraph (c)(1), (c)(2), or (c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e). the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of|
 
-(3) Foreign insurance companies . The provisions of paragraphs (c)(1) and
+(3) Foreign insurance companies. The provisions of paragraphs (c)(1) and
 (4) Exception for insurance companies filing their Federal income tax returns
-(5) Definition . For purposes of this section, the term annual statement means
+(5) Definition. For purposes of this section, the term annual statement means
 
 Columbia. The term annual statement also includes a pro forma annual statement if the insurance company is not required to file the NAIC annual statement.
 

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -54,15 +54,14 @@ company other than a life insurance company shall make a return on Form 1120PC. 
 
 annual statement (or a pro forma annual statement), including the underwriting and investment exhibit for the year covered by such return.
 
-||(c)(2) of this section concerning the returns and statements of insurance companies|
-|---|---|
-||subject to tax under section 801 or section 831 also apply to foreign insurance companies subject to tax under those sections, except that the copy of the annual statement required to be submitted with the return shall, in the case of a foreign insurance company that is not required to file an annual statement, be a copy of the pro forma annual statement relating to the United States business of such|
-|company.||
-|electronically|. If an insurance company described in paragraph (c)(1), (c)(2), or (c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e). the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of|
+(3) <u>Foreign insurance companies</u>. The provisions of paragraphs (c)(1) and
+(c)(2) of this section concerning the returns and statements of insurance companies subject to tax under section 801 or section 831 also apply to foreign insurance companies subject to tax under those sections, except that the copy of the annual statement required to be submitted with the return shall, in the case of a foreign insurance company that is not required to file an annual statement, be a copy of the pro forma annual statement relating to the United States business of such company.
+(4) <u>Exception for insurance companies filing their Federal income tax returns</u>
+<u>electronically</u>. If an insurance company described in paragraph (c)(1), (c)(2), or
 
-(3) Foreign insurance companies. The provisions of paragraphs (c)(1) and
-(4) Exception for insurance companies filing their Federal income tax returns
-(5) Definition. For purposes of this section, the term annual statement means
+(c)(3) of this section files its Federal income tax return electronically, it should not include on or with such return its annual statement (or pro forma annual statement), or any portion thereof. Such statement must be available at all times for inspection by authorized Internal Revenue Service officers or employees and retained for so long as such statements may be material in the administration of any internal revenue law. See §1.6001-1(e).
+(5) <u>Definition</u>. For purposes of this section, the term <u>annual statement</u> means
+the annual statement, the form of which is approved by the National Association of Insurance Commissioners (NAIC), which is filed by an insurance company for the year with the insurance departments of States, Territories, and the District of
 
 Columbia. The term annual statement also includes a pro forma annual statement if the insurance company is not required to file the NAIC annual statement.
 

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -161,7 +161,7 @@ section and paragraph
 |§1.1563-3(d)(2)(i)|(iv) of this subparagraph|(iii) of this section, and paragraph (d)(2)(iv) of §1.1563-3T|
 |The first sentence of|§1.332-6(b), 1.368-3(a),|§1.332-6T(a), §1.368-|
 |§1.6043-2(a)|or 1.1081-11|3T(a), or §1.1081-11T|
-|The first sentence of §301.6011-5T(a) ( twice )|§1.6012-2|paragraphs (a), (b) and (d) through (j) of §1.6012- 2, and paragraph (c) of §1.6012-2T|
+|The first sentence of §301.6011-5T(a) (twice)|§1.6012-2|paragraphs (a), (b) and (d) through (j) of §1.6012- 2, and paragraph (c) of §1.6012-2T|
 
 PART 602--OMB CONTROL NUMBERS UNDER THE PAPERWORK REDUCTION ACT Par. 54. The authority citation for part 602 continues to read as follows: Authority: 26 U.S.C. 7805. Par. 55. In §602.101, paragraph (b) is amended to read as follows:
 

--- a/tests/snapshots/thermo-freon12.md
+++ b/tests/snapshots/thermo-freon12.md
@@ -26,7 +26,7 @@ A.P., NIST Standard Reference in cubic meters per kilogram Database 23, NIST the
 
 ##### Physical Properties
 
-|Chemical Formula|CCl2F2|
+|Chemical Formula|CCl₂F₂|
 |---|---|
 |Molecular mass|120.91|
 |Boiling Point At one atmosphere|-29.75°C|
@@ -45,7 +45,7 @@ l
 
 |Temp|Pressure||Volume|||Density||Enthalpy|||Entropy|Temp|
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-|°C|[kPa]|[m3 Liquid v f|/kg]|Vapour v g|Liquid d f|[kg/m3] Vapour d g|Liquid H f|[kJ/kg] Latent H fg|Vapour H g|Liquid S f|[kJ/K-kg] Vapour S g|°C|
+|°C|[kPa]|[m³ Liquid v f|/kg]|Vapour v g|Liquid d f|[kg/m³] Vapour d g|Liquid H f|[kJ/kg] Latent H fg|Vapour H g|Liquid S f|[kJ/K-kg] Vapour S g|°C|
 
 |-100|1.2|0.0006|10.0000|1679.0|0.100|113.3|192.8|306.1|0.6077|1.7210|-100|
 |---|---|---|---|---|---|---|---|---|---|---|---|


### PR DESCRIPTION
## Summary

Round 2b of fire-pdf ENG-5015 — the measured residuals after 1.9.9 all lived in the direct-extraction markdown path:

- **`<u>` emission** in `text_with_formatting` (new `detect_underline` option, default on), consuming the geometric `is_underline` flag from #116. Underline runs are kept free of nested `**`/`*` (consumers match tag content literally). Heading lines still emit plain text for bold/italic but preserve `<u>` — the tag carries meaning the `#` prefix doesn't.
- **Unicode scripts at merge time**: `merge_subscript_items` absorbed "H"+"2"→"H2", erasing the script. It now maps digits to Unicode forms with direction from the baseline offset: `H₂`, `word²`, `m³`, `CCl₂F₂`. NFKC/NFKD folds them back to plain digits, so downstream text matching is unaffected.
- **Style-preserving merges**: `merge_text_items` merged adjacent items regardless of bold/italic, absorbing styled runs into plain neighbors (or vice versa) and erasing the flags. It now breaks merge runs at style boundaries. On eval docs this recovers 20–82 italic runs per document that previously emitted as plain text.

## Validation

- New/updated unit tests (script direction, style-boundary merge); full `cargo test` green (542 lib + 138 integration)
- 4 snapshots regenerated — every diff is a feature, reviewed by hand: `CCl₂F₂`/`m³` units, underlined legal section headings in td9264, finer-grained bold runs in p1244
- pdf-evals regression suite: 202/202 real PDFs pass (the one "failure" is a fixture that is literally an HTML error page saved as .pdf, correctly rejected)
- Real eval docs via napi build: underline-bearing docs now emit 4–8 `<u>` spans each on the direct path (was 0); italic-run docs emit 20–82 runs (was 0)

## Known limitations (documented, follow-ups not in this PR)

- Docs whose body renders inside detected pipe-tables (e.g. meeting minutes) lose styling in cell text — table formatting path, separate change
- Synthetic shear-matrix italics (no font flag) still undetected
- napi 1.9.9 → 1.9.10, publishes on merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds underline emission, Unicode sub/superscripts, and style-preserving merges to keep formatting in direct Markdown extraction. Cleans up spacing and rejects false-positive row-stripe tables; improves legal headings, scientific units, and lists; addresses ENG-5015 (round 2b).

- **New Features**
  - Emit `<u>` runs via `detect_underline` (default on) and break merges at style boundaries so bold/italic/underline spans stay tight; headers keep plain text for bold/italic but preserve underline.
  - Preserve scripts when merging: digits map to Unicode sub/superscripts based on baseline (e.g., H₂, word², m³); NFKC/NFKD keeps text matching stable.
  - Keep lists valid when underlined by moving bullets outside `<u>` wrappers.
  - Postprocess cleanup: remove a stray space before sentence punctuation and trim spaces next to parentheses/brackets in table cells (e.g., "( twice )" → "(twice)").
  - Table detection: reject sparse two‑column row‑stripe outlines to avoid misclassifying prose as tables.

- **Migration**
  - To disable underline output, set `detect_underline: false`.

<sup>Written for commit e16808c0c4013f4a5c59a2e9a8df47f7e09c7461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

