### PR TITLE
chore(napi): bump @firecrawl/pdf-inspector to 1.10.0

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.9.11",
+  "version": "1.10.0",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Releases #125: `isStrikeout` on TextItem, descriptor/embedded-font bold+italic recall for subset fonts (FontDescriptor flags, ttf-parser OS/2+post, bare-CFF Name INDEX), `'` operator advance width, `Ts` text-rise handling, ActualText rise/position fixes, document-scoped font style cache.

Minor bump: new `isStrikeout` field on the TextItem API.

Merging triggers the npm publish workflow (version change in `napi/package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3U6BKYCS73DVA83odAfYB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@firecrawl/pdf-inspector` to 1.10.0 to ship `isStrikeout` on TextItem, improved text-rise and ActualText positioning, subset-font bold/italic recall, and a document-scoped font style cache. Merging publishes the new version.

<sup>Written for commit 308fc3eac2d50d115ff7facded0fc8fc6be8602a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

