### PR TITLE
fix(fonts): recognize URW -Medi suffix as bold

### DIFF
--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -93,6 +93,9 @@ pub fn is_bold_font(font_name: &str) -> bool {
         || lower.contains("extrabold")
         || lower.contains("ultrabold")
         || lower.contains("medium") && !lower.contains("mediumitalic") // Some fonts use Medium for semi-bold
+        // URW Type 1 fonts abbreviate Medium as "Medi" (e.g. NimbusRomNo9L-Medi,
+        // the Times-Bold substitute in LaTeX documents; -MediItal is bold italic).
+        || lower.contains("-medi") && !lower.contains("mediumital")
 }
 
 /// Detect if a font name indicates italic/oblique style
@@ -761,6 +764,17 @@ pub(crate) fn should_join_items(
 mod tests {
     use super::*;
     use crate::types::ItemType;
+
+    #[test]
+    fn bold_font_urw_medi_abbreviation() {
+        // URW Type 1 fonts (LaTeX default Times) abbreviate Medium as "Medi"
+        assert!(is_bold_font("NROFIU+NimbusRomNo9L-Medi"));
+        assert!(is_bold_font("NimbusRomNo9L-MediItal"));
+        assert!(!is_bold_font("DSSZWN+NimbusRomNo9L-Regu"));
+        assert!(!is_bold_font("NimbusRomNo9L-ReguItal"));
+        // Medium-Italic exclusion still holds
+        assert!(!is_bold_font("Foo-MediumItalic"));
+    }
 
     #[test]
     fn strip_soft_hyphen() {


### PR DESCRIPTION
## Summary

`is_bold_font` matched the full word `medium` but not the abbreviated `-Medi` suffix used by URW Type 1 fonts. `NimbusRomNo9L-Medi` is the Times-Bold substitute embedded by most LaTeX toolchains, so bold text in LaTeX-produced PDFs went entirely undetected — no `**` emphasis in output, and bold-at-body-size section headings (the standard LaTeX paper style) lost the signal that heading detection relies on.

- Match `-medi` in `is_bold_font`, covering `NimbusRomNo9L-Medi` and `NimbusRomNo9L-MediItal` (bold italic)
- The existing `MediumItalic` exclusion is preserved

Example, before → after on a LaTeX paper (`NROFIU+NimbusRomNo9L-Medi` headings at body font size):

```
B.4 Instruction Tuning To enhance the steerability of LLMs, …   →   ## B.4 Instruction Tuning
                                                                     To enhance the steerability of LLMs, …
```

## Testing

- Unit tests for the URW names (bold, bold-italic, regular, regular-italic, MediumItalic exclusion)
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass
- pdf-evals: 202/203 pass; the one failure is a pre-existing corrupt fixture (HTML file with a .pdf extension) that fails identically on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes the URW `-Medi` suffix as bold in `is_bold_font`, restoring bold detection in LaTeX-produced PDFs and fixing missing emphasis and heading signals.

- **Bug Fixes**
  - Treat `-medi` as bold (including `-MediItal`); preserve `MediumItalic` exclusion.
  - Add unit tests for URW cases; all lint/tests pass.

<sup>Written for commit 9ab6e52eb3010481dca52fcd1487f705a3de9bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

