### PR TITLE
fix(markdown): one-word bold headings, block ToC entries from headings

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -130,6 +130,29 @@ pub(crate) fn has_dot_leaders(text: &str) -> bool {
     dot_groups >= 2
 }
 
+/// Detect a table-of-contents entry: a line ending in a page number preceded by
+/// a dot-leader group (e.g. "Measurement Lab worksheet ... 3"). `has_dot_leaders`
+/// misses single-group leaders ("..."), but a trailing "<dots> <number>" is a
+/// strong TOC signal on its own. Such lines must never be promoted to headings.
+pub(crate) fn is_toc_entry_line(text: &str) -> bool {
+    let trimmed = text.trim_end();
+    let digits = trimmed
+        .chars()
+        .rev()
+        .take_while(|c| c.is_ascii_digit())
+        .count();
+    if digits == 0 || digits > 4 {
+        return false;
+    }
+    let before_number = trimmed[..trimmed.len() - digits].trim_end();
+    let dots = before_number
+        .chars()
+        .rev()
+        .take_while(|c| *c == '.')
+        .count();
+    dots >= 3
+}
+
 /// Compute the Y-gap threshold for paragraph break detection.
 ///
 /// Instead of using a fixed multiple of base_size (which fails for double-spaced
@@ -318,5 +341,30 @@ pub(crate) fn detect_header_level(
         Some(3)
     } else {
         Some(4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toc_entry_with_single_dot_group() {
+        assert!(is_toc_entry_line("Measurement Lab worksheet ... 3"));
+        assert!(is_toc_entry_line("Results ........ 12"));
+        assert!(is_toc_entry_line("Appendix B...42"));
+    }
+
+    #[test]
+    fn non_toc_lines_pass() {
+        assert!(!is_toc_entry_line(
+            "6.2. Expectations for Re-Hiring Employees"
+        ));
+        assert!(!is_toc_entry_line("What happened in 2020"));
+        assert!(!is_toc_entry_line("IMPLEMENTATION"));
+        // Ellipsis without a trailing page number
+        assert!(!is_toc_entry_line("and so it goes ..."));
+        // Long numbers are data, not page refs
+        assert!(!is_toc_entry_line("ISBN ... 97814"));
     }
 }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -7,7 +7,7 @@ use crate::types::TextLine;
 
 use super::analysis::{
     bold_heading_level, calculate_font_stats, compute_heading_tiers, compute_paragraph_threshold,
-    detect_header_level, font_size_rarity, has_dot_leaders,
+    detect_header_level, font_size_rarity, has_dot_leaders, is_toc_entry_line,
 };
 use super::classify::{
     format_list_item, is_caption_line, is_list_item, is_monospace_font, starts_with_bullet_marker,
@@ -703,6 +703,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             && plain_trimmed.len() > 3
             && plain_trimmed.split_whitespace().count() <= 15
             && !starts_with_bullet_marker(plain_trimmed)
+            && !is_toc_entry_line(plain_trimmed)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
@@ -738,7 +739,11 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
                 // paragraph continuity and minor font-size variation
                 // inflates rarity scores.
                 let has_strong_signal = all_bold || isolated || (rarity >= 0.97 && word_count <= 8);
-                if score >= 0.5 && standalone && word_count >= 2 && has_strong_signal {
+                // Single-word headings ("IMPLEMENTATION", "CONTENTS") are common;
+                // accept them only with the strongest signal combination.
+                let enough_words =
+                    word_count >= 2 || (all_bold && isolated && plain_trimmed.len() >= 4);
+                if score >= 0.5 && standalone && enough_words && has_strong_signal {
                     Some(bold_heading_level(&heading_tiers))
                 } else {
                     None
@@ -1037,6 +1042,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         if options.detect_headers
             && plain_trimmed.len() > 3
             && plain_trimmed.split_whitespace().count() <= 15
+            && !is_toc_entry_line(plain_trimmed)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             if let Some(header_level) =
@@ -1059,7 +1065,9 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
                         + if all_bold { 0.3 } else { 0.0 }
                         + if standalone { 0.2 } else { 0.0 }
                         + if isolated { 0.3 } else { 0.0 };
-                    if score >= 0.5 && standalone && word_count >= 2 {
+                    let enough_words =
+                        word_count >= 2 || (all_bold && isolated && plain_trimmed.len() >= 4);
+                    if score >= 0.5 && standalone && enough_words {
                         return Some(bold_heading_level(&heading_tiers));
                     }
                     None


### PR DESCRIPTION
## Summary

Two targeted fixes to heuristic heading classification, applied to both classifier paths in `convert.rs`:

**Accept one-word bold headings.** The `word_count >= 2` gate unconditionally rejected single-word section headings — `IMPLEMENTATION`, `CONTENTS`, `References` — which are common in reports and policy documents. Now a one-word line qualifies when it carries the strongest signal combination: all-bold, isolated (paragraph break above and below), and ≥4 chars.

**Never promote table-of-contents entries.** New `is_toc_entry_line` detects a trailing dot-leader group + page number (`Measurement Lab worksheet ... 3`). The existing `has_dot_leaders` check needs 4+ consecutive dots or two dot groups, so ToC lines with a single short leader slipped through and whole contents pages came out as stacks of `##` headings.

## Testing

- Unit tests for `is_toc_entry_line` (single/multi-group leaders, ellipsis-without-number, long-number false positives) 
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass
- pdf-evals: 202/203 pass; the one failure is a pre-existing corrupt fixture (HTML file with a .pdf extension) that fails identically on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes heading classification by allowing real single-word bold headings and blocking table-of-contents lines from being promoted. This reduces false headings and improves section detection in generated Markdown.

- **Bug Fixes**
  - Added `is_toc_entry_line` and used it in both classifier paths to prevent lines ending with dot leaders + page number from becoming headings.
  - Accepted single-word headings when they are all-bold, isolated, and at least 4 characters, while keeping existing score and signal checks.

<sup>Written for commit 1470dc162a2bf2a3df04243283faf4b01a7ea272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

