### PR TITLE
fix(tables): reject row-stripe grids that swallow body text

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1477,6 +1477,10 @@ fn detect_row_stripe_table(
         debug!("  row-stripe rejected: sparse outline/prose continuation shape");
         return None;
     }
+    if has_dominant_prose_cell(&cells) {
+        debug!("  row-stripe rejected: dominant prose cell (chart/figure region over body text)");
+        return None;
+    }
 
     let column_centers: Vec<f32> = (0..num_cols)
         .map(|c| (col_edges[c] + col_edges[c + 1]) / 2.0)
@@ -1493,6 +1497,27 @@ fn detect_row_stripe_table(
     );
 
     Some(Table::new(column_centers, row_centers, cells, item_indices))
+}
+
+/// Detect a grid that swallowed body text instead of tabular data.
+///
+/// Charts (bar graphs, axis gridlines) emit fields of drawing rects that can
+/// pass the row-stripe shape test; the resulting "table" then captures the
+/// page's prose. The signature: one cell holds an entire paragraph — ≥60 words
+/// AND at least a third of all words in the table. Real tables never
+/// concentrate that much text in a single cell, even with a description
+/// column.
+fn has_dominant_prose_cell(cells: &[Vec<String>]) -> bool {
+    let mut total_words = 0usize;
+    let mut max_cell_words = 0usize;
+    for row in cells {
+        for cell in row {
+            let words = cell.split_whitespace().count();
+            total_words += words;
+            max_cell_words = max_cell_words.max(words);
+        }
+    }
+    max_cell_words >= 60 && max_cell_words * 3 >= total_words
 }
 
 fn row_stripe_is_sparse_prose_outline(cells: &[Vec<String>]) -> bool {
@@ -2396,6 +2421,45 @@ mod tests {
             item_type: ItemType::Text,
             mcid: None,
         }
+    }
+
+    // --- has_dominant_prose_cell ---
+
+    fn cells_of(rows: &[&[&str]]) -> Vec<Vec<String>> {
+        rows.iter()
+            .map(|r| r.iter().map(|c| c.to_string()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn dominant_prose_cell_rejects_swallowed_paragraph() {
+        // One cell holds a 70-word paragraph, rest are chart labels
+        let para = ["word"; 70].join(" ");
+        let cells = cells_of(&[
+            &[para.as_str(), "81", "76"],
+            &["21", "56", "9"],
+            &["2019", "2020", ""],
+        ]);
+        assert!(has_dominant_prose_cell(&cells));
+    }
+
+    #[test]
+    fn dominant_prose_cell_allows_description_column() {
+        // Long-ish description cells, but text is spread across the table
+        let desc = ["word"; 25].join(" ");
+        let cells = cells_of(&[
+            &["Item A", desc.as_str(), "100"],
+            &["Item B", desc.as_str(), "200"],
+            &["Item C", desc.as_str(), "300"],
+            &["Item D", desc.as_str(), "400"],
+        ]);
+        assert!(!has_dominant_prose_cell(&cells));
+    }
+
+    #[test]
+    fn dominant_prose_cell_allows_short_tables() {
+        let cells = cells_of(&[&["Name", "Value"], &["Total", "42"]]);
+        assert!(!has_dominant_prose_cell(&cells));
     }
 
     // --- rects_overlap ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -2319,6 +2319,12 @@ fn detect_merged_cluster_table(
         );
         return None;
     }
+    if has_dominant_prose_cell(&cells) {
+        debug!(
+            "  merged-cluster rejected: dominant prose cell (chart/figure region over body text)"
+        );
+        return None;
+    }
 
     // No empty columns
     for col in 0..num_cols {
@@ -2460,6 +2466,28 @@ mod tests {
     fn dominant_prose_cell_allows_short_tables() {
         let cells = cells_of(&[&["Name", "Value"], &["Total", "42"]]);
         assert!(!has_dominant_prose_cell(&cells));
+    }
+
+    #[test]
+    fn dominant_prose_cell_allows_data_table_with_long_note() {
+        // A real 4+ row table with one verbose remark cell: the note is ≥60
+        // words but the table's other content carries more than 2× its word
+        // count, so concentration stays below the 1/3 threshold. The
+        // denominator scales with table size — this is what keeps large
+        // legitimate tables safe where a bare length cap would not.
+        let note = ["word"; 60].join(" ");
+        let row_text = ["data"; 12].join(" ");
+        let mut rows: Vec<Vec<String>> = (0..11)
+            .map(|i| {
+                vec![
+                    format!("Item {i}"),
+                    row_text.clone(),
+                    format!("{}", i * 100),
+                ]
+            })
+            .collect();
+        rows.push(vec!["Note".into(), note, String::new()]);
+        assert!(!has_dominant_prose_cell(&rows));
     }
 
     // --- rects_overlap ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1504,9 +1504,16 @@ fn detect_row_stripe_table(
 /// Charts (bar graphs, axis gridlines) emit fields of drawing rects that can
 /// pass the row-stripe shape test; the resulting "table" then captures the
 /// page's prose. The signature: one cell holds an entire paragraph — ≥60 words
-/// AND at least a third of all words in the table. Real tables never
-/// concentrate that much text in a single cell, even with a description
-/// column.
+/// AND at least a third of all words in the table.
+///
+/// There is deliberately no row-count exemption. A small table whose single
+/// long cell dominates its word count is indistinguishable by content from a
+/// phantom grid over body text, and across the regression corpora every such
+/// grid observed has been swallowed prose, never a real note table. The costs
+/// are also asymmetric: rejecting a real table degrades it to readable prose,
+/// while accepting a phantom scrambles the page into Y-interleaved cells.
+/// Larger legitimate tables are safe because the one-third-of-total threshold
+/// scales with table size.
 fn has_dominant_prose_cell(cells: &[Vec<String>]) -> bool {
     let mut total_words = 0usize;
     let mut max_cell_words = 0usize;
@@ -2439,12 +2446,34 @@ mod tests {
 
     #[test]
     fn dominant_prose_cell_rejects_swallowed_paragraph() {
-        // One cell holds a 70-word paragraph, rest are chart labels
+        // Two cells hold paragraphs (the shape every observed phantom grid
+        // has: swallowed body text spans multiple cells), rest are chart labels
         let para = ["word"; 70].join(" ");
+        let para2 = ["word"; 35].join(" ");
         let cells = cells_of(&[
             &[para.as_str(), "81", "76"],
-            &["21", "56", "9"],
+            &[para2.as_str(), "56", "9"],
             &["2019", "2020", ""],
+        ]);
+        assert!(has_dominant_prose_cell(&cells));
+    }
+
+    #[test]
+    fn dominant_prose_cell_rejects_small_table_dominated_by_one_cell() {
+        // Boundary case, documented as INTENDED: a small grid whose single
+        // long cell dominates the word count is rejected even at 4+ rows.
+        // By content alone this shape is indistinguishable from a phantom
+        // grid over body text, and every observed instance in the regression
+        // corpora was swallowed prose (chart/figure regions), not a real
+        // note table. Rejection degrades gracefully — the text is still
+        // extracted as prose — while accepting a phantom scrambles reading
+        // order.
+        let note = ["word"; 70].join(" ");
+        let cells = cells_of(&[
+            &["Purpose", note.as_str()],
+            &["Owner", "Facilities team"],
+            &["Date", "2024-06-01"],
+            &["Status", "Active"],
         ]);
         assert!(has_dominant_prose_cell(&cells));
     }


### PR DESCRIPTION
## Summary

Pages containing bar charts or gridline-heavy figures emit large fields of drawing rects. These can pass `is_row_stripe_pattern`, and the resulting phantom table swallows the page's actual prose — paragraphs get scrambled into cells in Y-interleaved order, and any section headings inside the region are lost. Example of what a phantom looked like:

```
|be used as a good opportunity to learn from each other and increase the capacity of…|94 What works in other countries…|
|90 80 70 60 50 40 30 20 10|0|81 Events Diagram 4|76|21|…
```

The existing max-cell-length gate doesn't catch these because it only applies when the grid has fewer than 4 non-empty rows.

**Fix:** new `has_dominant_prose_cell` check — reject a row-stripe grid when a single cell holds ≥60 words *and* at least a third of the table's total words. That's the signature of a swallowed paragraph; real tables never concentrate that much text in one cell, even with a description column (which spreads long-ish cells across every row).

## Testing

- Unit tests: swallowed-paragraph rejection, description-column table allowed, short tables allowed
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass
- pdf-evals: 16 fixture PDFs change. Manually reviewed the highest-risk diffs against the Mistral reference: every removed region is a phantom (two of the docs contain no tables at all per reference; a third keeps its real table and only drops the garbled prose region). Affected pages now emit clean paragraphs and recover headings that were buried inside the phantom grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents phantom tables from swallowing body text on pages with chart/gridline rects. Rejects row‑stripe and merged‑cluster grids when a single cell dominates with prose to restore correct paragraphs and headings.

- **Bug Fixes**
  - Added `has_dominant_prose_cell`: reject if one cell has ≥60 words and ≥1/3 of table words; applied to row‑stripe and merged‑cluster paths; guard is unconditional (no row‑count exemption). Documented and tested, including small‑table dominated‑by‑one‑cell rejection, description‑column acceptance, short tables, and a 60‑word note case.
  - Affected PDFs no longer emit phantom tables; prose and headings are recovered.

<sup>Written for commit 46e23fb91004a61004c6cff5546f2df697cf9191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

