### PR TITLE
fix(markdown): ToC-page suppression, wrapped bold headings, math fragments

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -164,9 +164,13 @@ pub(crate) fn is_toc_marker_heading(text: &str) -> bool {
 /// Lines that resemble headings structurally but are display-math fragments:
 /// equations ending in an equation number ("S = kB ln W, (2)") or equation
 /// lead-ins ("Rearranging Equation (8) gives:"). Both carry an "(N)" equation
-/// reference — that's the discriminator. A bare trailing colon is NOT a
-/// fragment signal: real headings frequently end with colons ("Procedure:",
-/// "Steps for Using the Microscope:").
+/// reference — but a trailing "(N)" alone is not enough: real headings end
+/// with parenthesized numbers too ("Nicaea (325)", appendix numbering), so
+/// the suffix form additionally requires math evidence — an "=" in the line
+/// or a comma immediately before the number, both present in every display
+/// equation and absent from name-plus-number headings. A bare trailing colon
+/// is NOT a fragment signal either: real headings frequently end with colons
+/// ("Procedure:", "Steps for Using the Microscope:").
 pub(crate) fn is_heading_fragment(text: &str) -> bool {
     let t = text.trim_end();
 
@@ -178,9 +182,48 @@ pub(crate) fn is_heading_fragment(text: &str) -> bool {
             })
     }
 
-    // Equation-number suffix: "... (12)"
-    if is_equation_number(t.rsplit(' ').next().unwrap_or("")) {
-        return true;
+    // Equation-number suffix with math evidence: "S = kB ln W, (2)"
+    let mut rev = t.rsplit(' ');
+    let last = rev.next().unwrap_or("");
+    if is_equation_number(last) {
+        // Page-of-total running headers: "LIVSMEDELSVERKET PM 2 (10)"
+        if let Some(prev_word) = t.rsplit(' ').nth(1) {
+            if let (Ok(page), Some(total)) = (
+                prev_word.parse::<u32>(),
+                last.trim_start_matches('(')
+                    .trim_end_matches(')')
+                    .parse::<u32>()
+                    .ok(),
+            ) {
+                if page <= total {
+                    return true;
+                }
+            }
+        }
+        let punct_before = rev
+            .next()
+            .is_some_and(|w| w.ends_with(',') || w.ends_with(':'));
+        let has_math_op = t.chars().any(|c| {
+            matches!(
+                c,
+                '=' | '<'
+                    | '>'
+                    | '≤'
+                    | '≥'
+                    | '≪'
+                    | '≫'
+                    | '≈'
+                    | '≠'
+                    | '±'
+                    | '∑'
+                    | '∫'
+                    | '√'
+                    | '∝'
+            )
+        });
+        if punct_before || has_math_op {
+            return true;
+        }
     }
     // Lead-in: ends with a colon AND references an equation number inline
     if t.ends_with(':') && t.split_whitespace().any(is_equation_number) {
@@ -421,7 +464,18 @@ mod tests {
         // Display-equation neighbours ending in an equation number
         assert!(is_heading_fragment("S = kB ln W, (2)"));
         assert!(is_heading_fragment("E = mc2 (12)"));
-        // Real headings pass — including colon-ended ones
+        assert!(is_heading_fragment("x + y = z, (3)"));
+        // Page-of-total running headers
+        assert!(is_heading_fragment("LIVSMEDELSVERKET PM 2 (10)"));
+        // Comparison-operator evidence and colon-before-number
+        assert!(is_heading_fragment(
+            "PLL\u{fe} PHH\u{226a} PLH\u{fe} PHL: (12)"
+        ));
+        // Real headings pass — including name-plus-number and colon-ended ones
+        assert!(!is_heading_fragment("Nicaea (325)"));
+        assert!(!is_heading_fragment(
+            "\u{627}\u{644}\u{645}\u{644}\u{62d}\u{642} \u{631}\u{642}\u{645} (1)"
+        ));
         assert!(!is_heading_fragment("4. Entropy"));
         assert!(!is_heading_fragment("Procedure:"));
         assert!(!is_heading_fragment("Steps for Using the Microscope:"));

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -153,6 +153,42 @@ pub(crate) fn is_toc_entry_line(text: &str) -> bool {
     dots >= 3
 }
 
+/// A heading that announces a table of contents ("Contents", "Table of
+/// Contents"). Lines after it on the same page are ToC entries — section
+/// titles that look exactly like headings but must not be promoted.
+pub(crate) fn is_toc_marker_heading(text: &str) -> bool {
+    let t = text.trim().trim_end_matches(':').trim().to_lowercase();
+    matches!(t.as_str(), "contents" | "table of contents")
+}
+
+/// Lines that resemble headings structurally but are display-math fragments:
+/// equations ending in an equation number ("S = kB ln W, (2)") or equation
+/// lead-ins ("Rearranging Equation (8) gives:"). Both carry an "(N)" equation
+/// reference — that's the discriminator. A bare trailing colon is NOT a
+/// fragment signal: real headings frequently end with colons ("Procedure:",
+/// "Steps for Using the Microscope:").
+pub(crate) fn is_heading_fragment(text: &str) -> bool {
+    let t = text.trim_end();
+
+    fn is_equation_number(s: &str) -> bool {
+        s.strip_prefix('(')
+            .and_then(|r| r.strip_suffix(')'))
+            .is_some_and(|inner| {
+                !inner.is_empty() && inner.len() <= 3 && inner.chars().all(|c| c.is_ascii_digit())
+            })
+    }
+
+    // Equation-number suffix: "... (12)"
+    if is_equation_number(t.rsplit(' ').next().unwrap_or("")) {
+        return true;
+    }
+    // Lead-in: ends with a colon AND references an equation number inline
+    if t.ends_with(':') && t.split_whitespace().any(is_equation_number) {
+        return true;
+    }
+    false
+}
+
 /// Compute the Y-gap threshold for paragraph break detection.
 ///
 /// Instead of using a fixed multiple of base_size (which fails for double-spaced
@@ -366,5 +402,31 @@ mod tests {
         assert!(!is_toc_entry_line("and so it goes ..."));
         // Long numbers are data, not page refs
         assert!(!is_toc_entry_line("ISBN ... 97814"));
+    }
+
+    #[test]
+    fn toc_marker_headings() {
+        assert!(is_toc_marker_heading("Contents"));
+        assert!(is_toc_marker_heading("CONTENTS"));
+        assert!(is_toc_marker_heading("Table of Contents"));
+        assert!(is_toc_marker_heading("Table of contents:"));
+        assert!(!is_toc_marker_heading("Contents of the Shipment"));
+        assert!(!is_toc_marker_heading("Introduction"));
+    }
+
+    #[test]
+    fn heading_fragments() {
+        // Equation lead-ins: colon ending + inline equation reference
+        assert!(is_heading_fragment("Rearranging Equation (8) gives:"));
+        // Display-equation neighbours ending in an equation number
+        assert!(is_heading_fragment("S = kB ln W, (2)"));
+        assert!(is_heading_fragment("E = mc2 (12)"));
+        // Real headings pass — including colon-ended ones
+        assert!(!is_heading_fragment("4. Entropy"));
+        assert!(!is_heading_fragment("Procedure:"));
+        assert!(!is_heading_fragment("Steps for Using the Microscope:"));
+        assert!(!is_heading_fragment("Changing objectives:"));
+        assert!(!is_heading_fragment("Sales by Region (2024)"));
+        assert!(!is_heading_fragment("Results (preliminary)"));
     }
 }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -7,7 +7,8 @@ use crate::types::TextLine;
 
 use super::analysis::{
     bold_heading_level, calculate_font_stats, compute_heading_tiers, compute_paragraph_threshold,
-    detect_header_level, font_size_rarity, has_dot_leaders, is_toc_entry_line,
+    detect_header_level, font_size_rarity, has_dot_leaders, is_heading_fragment, is_toc_entry_line,
+    is_toc_marker_heading,
 };
 use super::classify::{
     format_list_item, is_caption_line, is_list_item, is_monospace_font, starts_with_bullet_marker,
@@ -486,6 +487,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
     let mut in_code_block = false;
     let mut prev_had_dot_leaders = false;
     let mut paragraph_in_wrapped_bold_run = false;
+    let mut toc_suppress_page: Option<u32> = None;
     let mut inserted_tables: HashSet<(u32, usize)> = HashSet::new();
     let mut inserted_images: HashSet<(u32, usize)> = HashSet::new();
 
@@ -704,9 +706,13 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             && plain_trimmed.split_whitespace().count() <= 15
             && !starts_with_bullet_marker(plain_trimmed)
             && !is_toc_entry_line(plain_trimmed)
+            && toc_suppress_page != Some(line.page)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
+                if is_heading_fragment(plain_trimmed) {
+                    return None;
+                }
                 // Rarity-based heading detection (inspired by opendataloader).
                 // Heading probability scoring with lookahead context.
                 // Score = rarity * 0.5 + bold * 0.3 + standalone * 0.2
@@ -768,6 +774,9 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
                 plain_text.clone()
             };
             output.push_str(&format!("{} {}\n\n", prefix, heading_text.trim()));
+            if is_toc_marker_heading(plain_trimmed) {
+                toc_suppress_page = Some(line.page);
+            }
             in_list = false;
             continue;
         }
@@ -964,6 +973,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
     let mut last_list_x: Option<f32> = None;
     let mut prev_had_dot_leaders = false;
     let mut paragraph_in_wrapped_bold_run = false;
+    let mut toc_suppress_page: Option<u32> = None;
 
     for (line_idx, line) in lines.iter().enumerate() {
         // Page break
@@ -1043,10 +1053,14 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             && plain_trimmed.len() > 3
             && plain_trimmed.split_whitespace().count() <= 15
             && !is_toc_entry_line(plain_trimmed)
+            && toc_suppress_page != Some(line.page)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             if let Some(header_level) =
                 detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
+                    if is_heading_fragment(plain_trimmed) {
+                        return None;
+                    }
                     if line_font_size < base_size * 0.95 {
                         return None;
                     }
@@ -1086,6 +1100,9 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
                     plain_text.clone()
                 };
                 output.push_str(&format!("{} {}\n\n", prefix, heading_text.trim()));
+                if is_toc_marker_heading(plain_trimmed) {
+                    toc_suppress_page = Some(line.page);
+                }
                 in_list = false;
                 continue;
             }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -706,13 +706,11 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             && plain_trimmed.split_whitespace().count() <= 15
             && !starts_with_bullet_marker(plain_trimmed)
             && !is_toc_entry_line(plain_trimmed)
+            && !is_heading_fragment(plain_trimmed)
             && toc_suppress_page != Some(line.page)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
-                if is_heading_fragment(plain_trimmed) {
-                    return None;
-                }
                 // Rarity-based heading detection (inspired by opendataloader).
                 // Heading probability scoring with lookahead context.
                 // Score = rarity * 0.5 + bold * 0.3 + standalone * 0.2
@@ -1053,14 +1051,12 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             && plain_trimmed.len() > 3
             && plain_trimmed.split_whitespace().count() <= 15
             && !is_toc_entry_line(plain_trimmed)
+            && !is_heading_fragment(plain_trimmed)
             && toc_suppress_page != Some(line.page)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
             if let Some(header_level) =
                 detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
-                    if is_heading_fragment(plain_trimmed) {
-                        return None;
-                    }
                     if line_font_size < base_size * 0.95 {
                         return None;
                     }

--- a/src/markdown/preprocess.rs
+++ b/src/markdown/preprocess.rs
@@ -104,7 +104,11 @@ pub(crate) fn merge_heading_lines(
                 let curr_text = line.text();
                 let curr_trim = curr_text.trim();
                 let y_gap = prev.y - line.y;
+                // Both lines must be tier-less: a tiered/tagged bold heading
+                // followed by bold body text must not absorb it.
                 line_level.is_none()
+                    && effective_heading_level(prev, base_size, heading_tiers, struct_roles)
+                        .is_none()
                     && prev.page == line.page
                     && all_bold(prev)
                     && all_bold(&line)
@@ -764,5 +768,20 @@ mod tests {
         ];
         let result = merge_heading_lines(lines, 12.0, &[], None);
         assert_eq!(result.len(), 2, "sentence-final bold line must not merge");
+    }
+
+    #[test]
+    fn tiered_bold_heading_does_not_absorb_bold_body() {
+        // Previous line is a tier-level bold heading (16pt vs 12pt body);
+        // a following lowercase bold body line must NOT merge into it.
+        let mut heading = make_bold_line("Section Title", 1, 700.0);
+        heading.items[0].font_size = 16.0;
+        heading.items[0].height = 16.0;
+        let lines = vec![
+            heading,
+            make_bold_line("emphasized body text continues here", 1, 686.0),
+        ];
+        let result = merge_heading_lines(lines, 12.0, &[16.0], None);
+        assert_eq!(result.len(), 2, "tiered heading must not absorb bold body");
     }
 }

--- a/src/markdown/preprocess.rs
+++ b/src/markdown/preprocess.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::structure_tree::StructRole;
-use crate::types::TextLine;
+use crate::types::{TextItem, TextLine};
 
 use super::analysis::detect_header_level;
 
@@ -86,6 +86,37 @@ pub(crate) fn merge_heading_lines(
         } else {
             false
         };
+
+        // Bold headings at body font size never reach a tier, so wrapped ones
+        // split into two output headings ("…of wood pellets and cost" /
+        // "structure in Japan"). Merge a fully-bold line into the previous
+        // fully-bold line when it reads as a wrap continuation: starts
+        // lowercase, tiny Y gap, and the previous line has no terminal
+        // punctuation. Kept deliberately narrow — bold list labels and bold
+        // sentences start with markers or capitals and are unaffected.
+        let should_merge = should_merge
+            || if let Some(prev) = result.last() {
+                let all_bold = |l: &TextLine| {
+                    !l.items.is_empty() && l.items.iter().all(|i: &TextItem| i.is_bold)
+                };
+                let prev_text = prev.text();
+                let prev_trim = prev_text.trim_end();
+                let curr_text = line.text();
+                let curr_trim = curr_text.trim();
+                let y_gap = prev.y - line.y;
+                line_level.is_none()
+                    && prev.page == line.page
+                    && all_bold(prev)
+                    && all_bold(&line)
+                    && y_gap > 0.0
+                    && y_gap < line_font * 1.6
+                    && curr_trim.chars().next().is_some_and(|c| c.is_lowercase())
+                    && !prev_trim.ends_with(['.', ':', ';', '!', '?'])
+                    && prev_trim.split_whitespace().count() + curr_trim.split_whitespace().count()
+                        <= 20
+            } else {
+                false
+            };
 
         if should_merge {
             // Append this line's items to the previous line
@@ -684,5 +715,54 @@ mod tests {
             .find(|l| l.text().contains("VOICE OF SOUTH MARION"))
             .unwrap();
         assert_eq!(first_header.page, 1, "first occurrence should be on page 1");
+    }
+
+    fn make_bold_line(text: &str, page: u32, y: f32) -> TextLine {
+        let mut item = make_item(text, 12.0, None);
+        item.is_bold = true;
+        TextLine {
+            items: vec![item],
+            y,
+            page,
+            adaptive_threshold: 0.10,
+        }
+    }
+
+    #[test]
+    fn merge_wrapped_bold_heading_lowercase_continuation() {
+        // Bold-at-body-size heading wrapped across two lines: the second line
+        // starts lowercase and must merge into the first.
+        let lines = vec![
+            make_bold_line(
+                "3. Perspective of supply and demand balance and cost",
+                1,
+                700.0,
+            ),
+            make_bold_line("structure in Japan", 1, 686.0),
+            make_line("Body text paragraph follows here.", 12.0, 1, 660.0, None),
+        ];
+        let result = merge_heading_lines(lines, 12.0, &[], None);
+        assert_eq!(result.len(), 2, "wrapped bold heading should merge");
+        assert!(result[0].text().contains("cost structure in Japan"));
+    }
+
+    #[test]
+    fn no_merge_for_bold_sentences_or_new_headings() {
+        // Second bold line starts with a capital — a new heading or label,
+        // not a wrap continuation.
+        let lines = vec![
+            make_bold_line("Replace", 1, 700.0),
+            make_bold_line("Trash", 1, 686.0),
+        ];
+        let result = merge_heading_lines(lines, 12.0, &[], None);
+        assert_eq!(result.len(), 2, "distinct bold lines must not merge");
+
+        // Previous line ends a sentence — continuation must not merge.
+        let lines = vec![
+            make_bold_line("This is a bold sentence.", 1, 700.0),
+            make_bold_line("another bold line", 1, 686.0),
+        ];
+        let result = merge_heading_lines(lines, 12.0, &[], None);
+        assert_eq!(result.len(), 2, "sentence-final bold line must not merge");
     }
 }

--- a/tests/snapshots/p1244-1996.md
+++ b/tests/snapshots/p1244-1996.md
@@ -48,7 +48,7 @@ tips of directly from customers received other employees paid tips rec’d. entr
 
 **Page 3**
 
-27 28 29 30 31 **Subtotals** **from pages** **1, 2, and 3** **Totals**
+27 28 29 30 31 **Subtotals from pages** **1, 2, and 3** **Totals**
 
 **1.** Report total cash tips (col. **a**) on Form 4070, line **1.**
 **2.** Report total credit card tips (col. **b**) on Form 4070, line **2.**
@@ -79,4 +79,3 @@ forms simpler, we would be happy to hear from you. You can write to the Tax Form
 **Instructions** *(continued)*
 
 Use this space to total your tips for the year
-


### PR DESCRIPTION
## Summary

Three targeted heading-classification improvements, applied to both converter paths:

**Suppress heading promotion on table-of-contents pages.** ToC entries without dot leaders ("1. Overview of OCR Pack", "Part III: Commercial Geographies of Play") are structurally indistinguishable from headings, so whole contents pages came out as stacks of `##`. After emitting a heading whose text is "Contents"/"Table of Contents", heuristic heading promotion is disabled for the remainder of that page (struct-tree headings are unaffected).

**Merge wrapped bold headings.** `merge_heading_lines` only considered font-size-tier and struct-tree headings, so a bold-at-body-size heading that wraps produced two separate headings ("## …of wood pellets and cost" / "## structure in Japan"). A fully-bold line now merges into the previous fully-bold line when it reads as a wrap continuation: starts lowercase, tiny Y gap, and the previous line has no terminal punctuation. Kept deliberately narrow — bold labels and bold sentences start with capitals/markers and are unaffected.

**Reject display-math fragments.** Equation lines ending in an equation number ("S = kB ln W, (2)") and equation lead-ins ("Rearranging Equation (8) gives:") scored as headings via the rarity heuristic — display math has unusual fonts and large gaps, which are exactly the heading signals. The discriminator is an `(N)` equation reference. A bare trailing colon is deliberately **not** a fragment signal: real headings frequently end with colons ("Procedure:", "Steps for Using the Microscope:") — an earlier draft of this rule rejected those and it showed up immediately as regressions, so the tests pin both directions.

The `p1244-1996` snapshot change is the bold-merge working as intended: the stacked IRS form labels "**Subtotals** **from pages**" now read "**Subtotals from pages**".

## Testing

- Unit tests for all three behaviors, including the colon-heading counterexamples and non-merge cases (bold sentences, distinct bold labels)
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass (728 tests)
- pdf-evals: 202/203 pass (the 1 failure is the known corrupt fixture, an HTML file with a .pdf extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves heading detection to avoid false headings and split titles. Suppresses ToC-page promotions, safely merges wrapped bold headings, and filters display‑math and running‑header fragments across all heuristics.

- **Bug Fixes**
  - Suppress heading promotion for the rest of a page after a "Contents"/"Table of Contents" heading to prevent ToC entries becoming headings.
  - Merge fully bold wrapped lines only when both lines are fully bold and tier‑less, the second starts lowercase, the Y gap is small, and the previous line ends without punctuation; protects real tiered headings from absorbing bold body text.
  - Exclude display‑math and page‑of‑total fragments from heading heuristics: require math evidence for "(N)" suffixes (operator or comma/colon before the number), keep colon‑ended headings valid, and allow name+year/appendix headings like "Nicaea (325)".

<sup>Written for commit 4b1c7b21b6c0f8f4bd8cfeb91d3b4a5846997833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

