### PR TITLE
feat(extractor): run-local space floor for tracked (letter-spaced) glyph runs

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -539,6 +539,20 @@ fn should_preserve_overlapping_stream_order(group: &[&TextItem]) -> bool {
 /// then inserted only at gaps above the floor (infinity = single word).
 /// Normal text (multi-char items, or single-char runs with sub-threshold
 /// gaps) returns None and keeps the existing behavior.
+/// Han/Kana scripts write without inter-word spaces. Hangul (Korean) DOES
+/// space between words and deliberately stays out of this set — a Korean
+/// tracked run keeps normal word-boundary handling.
+fn is_spaceless_cjk(c: char) -> bool {
+    matches!(c,
+        '\u{3000}'..='\u{303F}'   // CJK Symbols and Punctuation
+        | '\u{3040}'..='\u{309F}' // Hiragana
+        | '\u{30A0}'..='\u{30FF}' // Katakana
+        | '\u{4E00}'..='\u{9FFF}' // CJK Unified Ideographs
+        | '\u{F900}'..='\u{FAFF}' // CJK Compatibility Ideographs
+        | '\u{FF00}'..='\u{FFEF}' // Halfwidth and Fullwidth Forms
+    )
+}
+
 fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, f32)> {
     const MIN_GAPS: usize = 4;
     let first = group[start];
@@ -590,22 +604,43 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     let mut sorted = gaps.clone();
     sorted.sort_by(|a, b| a.total_cmp(b));
     let median = sorted[sorted.len() / 2];
+    // Typographic convention gate, both tiers: display tracking is a
+    // caps (or title-case single word) convention, and Han/Kana never
+    // space between glyphs. A spaced run of lowercase singles ("x y z"
+    // variables, "a b c" lists) has the same gap shape as tracking at
+    // ANY length, so lowercase sequences always keep their boundaries.
+    let run_chars = || {
+        group[start..=end]
+            .iter()
+            .flat_map(|it| it.text.trim().chars())
+    };
+    let spaceless_cjk = run_chars().all(|c| is_spaceless_cjk(c) || !c.is_alphanumeric())
+        && run_chars().any(is_spaceless_cjk);
+    let all_caps = run_chars().all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic());
+    let title_case = {
+        let alpha: Vec<char> = run_chars().filter(|c| c.is_alphabetic()).collect();
+        alpha.len() >= 2 && alpha[0].is_uppercase() && alpha[1..].iter().all(|c| c.is_lowercase())
+    };
+    if !(spaceless_cjk || all_caps || title_case) {
+        return None;
+    }
+
     if gaps.len() >= MIN_GAPS {
         if median <= 0.075 {
             return None;
         }
     } else {
         let uniform = sorted[sorted.len() - 1] <= sorted[0].max(0.01) * 1.4;
-        // Caps convention — or CJK, which never uses inter-glyph spaces.
-        let all_caps = group[start..=end].iter().all(|it| {
-            it.text
-                .trim()
-                .chars()
-                .all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic())
-        });
-        if median < 0.09 || !uniform || !all_caps {
+        if median < 0.09 || !uniform {
             return None;
         }
+    }
+
+    // Han/Kana: no inter-glyph spaces, period — a nonuniform gap
+    // distribution (punctuation spacing, justification) must not
+    // manufacture word boundaries.
+    if spaceless_cjk {
+        return Some((end, f32::INFINITY));
     }
 
     // Word gaps, if present, form a second mode above the letter-gap
@@ -960,6 +995,39 @@ mod tests {
         let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].text, "WORD");
+    }
+
+    #[test]
+    fn long_lowercase_spaced_singles_keep_boundaries() {
+        // Review: a 5+ single-letter lowercase list has the tracked gap
+        // shape at any length — the convention gate must protect it in
+        // the >=4-gap tier too.
+        let items = glyph_run("abcde", 100.0, 6.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "a b c d e");
+    }
+
+    #[test]
+    fn han_run_with_nonuniform_gaps_never_gains_spaces() {
+        // Review: a bimodal gap distribution (justification, punctuation
+        // spacing) must not manufacture word boundaries in Han text.
+        let mut items = glyph_run("北京时事快报", 100.0, 12.0, 1.4);
+        for item in items.iter_mut().skip(3) {
+            item.x += 3.0; // wide gap after the third glyph
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "北京时事快报");
+    }
+
+    #[test]
+    fn title_case_tracked_word_collapses() {
+        // "B u f f a l o" — one title-case word set with tracking.
+        let items = glyph_run("Buffalo", 100.0, 7.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "Buffalo");
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -9,7 +9,7 @@ mod links;
 pub(crate) mod underline;
 mod xobjects;
 
-use crate::text_utils::is_rtl_text;
+use crate::text_utils::{is_cjk_char, is_rtl_text};
 use crate::tounicode::FontCMaps;
 use crate::types::{PageExtraction, PdfLine, PdfRect, TextItem};
 use crate::PdfError;
@@ -527,6 +527,105 @@ fn should_preserve_overlapping_stream_order(group: &[&TextItem]) -> bool {
     saw_backtrack
 }
 
+/// Detect a tracked (letter-spaced) run of single-glyph items and derive its
+/// run-local space floor.
+///
+/// Display type set with tracking renders one glyph per show op; the merge
+/// loop's fixed thresholds (0.08-0.13 em) then read every letter gap as a
+/// word boundary and emit "H O W" instead of "HOW". Within such a run the
+/// gaps carry the real signal: letter gaps cluster tightly just above the
+/// fixed threshold, word gaps sit clearly higher. Returns (run_end_index,
+/// space_floor) when the run starting at `start` is tracked — spaces are
+/// then inserted only at gaps above the floor (infinity = single word).
+/// Normal text (multi-char items, or single-char runs with sub-threshold
+/// gaps) returns None and keeps the existing behavior.
+fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, f32)> {
+    const MIN_GAPS: usize = 4;
+    let first = group[start];
+    if first.text.trim().chars().count() != 1 {
+        return None;
+    }
+    let fs = first.font_size;
+    if fs <= 0.0 {
+        return None;
+    }
+
+    // Walk the run under the SAME break conditions as the merge loop
+    // (size band, style equality, mergeable gap) so indices stay aligned.
+    let mut gaps: Vec<f32> = Vec::new();
+    let mut end_x = first.x + effective_merge_width(first);
+    let mut end = start;
+    for (offset, next) in group[start + 1..].iter().enumerate() {
+        if next.text.trim().chars().count() != 1 {
+            break;
+        }
+        if (next.font_size - fs).abs() > fs * 0.20 {
+            break;
+        }
+        if next.is_bold != first.is_bold
+            || next.is_italic != first.is_italic
+            || next.is_underline != first.is_underline
+            || next.is_strikeout != first.is_strikeout
+        {
+            break;
+        }
+        let gap = next.x - end_x;
+        if gap > fs * 0.5 || gap < -fs * 0.5 {
+            break;
+        }
+        gaps.push(gap / fs);
+        end_x = next.x + effective_merge_width(next);
+        end = start + 1 + offset;
+    }
+    if gaps.len() < 2 {
+        return None;
+    }
+
+    // Tracked signature: the run's TYPICAL gap clears the fixed space
+    // threshold (0.08) — the merge loop would break almost every letter
+    // pair into "words". Short runs (2-3 gaps: "H O W") demand a stricter
+    // shape — clearly wide, uniform, ALL-CAPS — because a genuine spaced
+    // sequence of single letters ("x y z" variables) has the same gap
+    // count; display tracking is a caps convention.
+    let mut sorted = gaps.clone();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let median = sorted[sorted.len() / 2];
+    if gaps.len() >= MIN_GAPS {
+        if median <= 0.075 {
+            return None;
+        }
+    } else {
+        let uniform = sorted[sorted.len() - 1] <= sorted[0].max(0.01) * 1.4;
+        // Caps convention — or CJK, which never uses inter-glyph spaces.
+        let all_caps = group[start..=end].iter().all(|it| {
+            it.text
+                .trim()
+                .chars()
+                .all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic())
+        });
+        if median < 0.09 || !uniform || !all_caps {
+            return None;
+        }
+    }
+
+    // Word gaps, if present, form a second mode above the letter-gap
+    // cluster: split at the largest relative jump. Unimodal → one word.
+    let mut best_jump = 1.0f32;
+    let mut floor = f32::INFINITY;
+    for pair in sorted.windows(2) {
+        let (lo, hi) = (pair[0].max(0.01), pair[1].max(0.01));
+        let jump = hi / lo;
+        if jump > best_jump {
+            best_jump = jump;
+            floor = (lo + hi) / 2.0;
+        }
+    }
+    if best_jump < 1.4 {
+        floor = f32::INFINITY;
+    }
+    Some((end, floor * fs))
+}
+
 pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
     if items.is_empty() {
         return items;
@@ -573,6 +672,14 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
             let first = group[i];
             let mut text = first.text.clone();
             let mut end_x = first.x + effective_merge_width(first);
+
+            // Tracked display text: run-local space floor overrides the
+            // fixed thresholds for this run's junctions (see helper).
+            let tracked = if *preserve_stream_order {
+                None
+            } else {
+                tracked_run_space_floor(group, i)
+            };
 
             let mut j = i + 1;
             while j < group.len() {
@@ -628,7 +735,11 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 let needs_bullet_space = *preserve_stream_order
                     && is_standalone_bullet_text(&text)
                     && !next.text.trim().is_empty();
-                if needs_bullet_space || gap > threshold {
+                let effective_threshold = match tracked {
+                    Some((run_end, floor)) if j <= run_end => floor,
+                    _ => threshold,
+                };
+                if needs_bullet_space || gap > effective_threshold {
                     text.push(' ');
                 }
                 text.push_str(&next.text);
@@ -793,6 +904,73 @@ mod tests {
     use crate::text_utils::{is_cjk_char, is_rtl_char, is_rtl_text, sort_line_items};
     use crate::types::{ItemType, PdfLine, TextLine};
     use layout::{detect_columns, is_newspaper_layout, ColumnRegion};
+
+    /// Glyph-per-item run at `fs`=12 with the given inter-glyph gap (pt).
+    fn glyph_run(chars: &str, start_x: f32, glyph_w: f32, gap: f32) -> Vec<TextItem> {
+        let mut x = start_x;
+        let mut out = Vec::new();
+        for c in chars.chars() {
+            out.push(make_merge_item(&c.to_string(), x, glyph_w));
+            x += glyph_w + gap;
+        }
+        out
+    }
+
+    #[test]
+    fn tracked_caps_run_collapses_to_word() {
+        // Display tracking: every letter gap (0.19 em) clears the fixed
+        // space threshold — without the run-local floor this reads "H O W".
+        let items = glyph_run("HOW", 100.0, 10.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "HOW");
+    }
+
+    #[test]
+    fn tracked_run_keeps_word_gaps_bimodal() {
+        // Letters at 0.19 em, word gaps at 0.42 em (below the 0.5 em item
+        // break): the split must land between the modes. Needs >=4 gaps to
+        // enter the bimodal tier — short runs use the strict uniform gate.
+        let mut items = glyph_run("ITISOK", 100.0, 8.0, 2.3);
+        for i in 2..6 {
+            items[i].x += 2.8; // word gap at T|I
+        }
+        for i in 4..6 {
+            items[i].x += 2.8; // word gap at S|O
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "IT IS OK");
+    }
+
+    #[test]
+    fn lowercase_spaced_singles_stay_words() {
+        // "x y z" variables: same gap shape but lowercase — the short-run
+        // caps requirement keeps genuine spaced singles apart.
+        let items = glyph_run("xyz", 100.0, 6.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "x y z");
+    }
+
+    #[test]
+    fn kerned_singles_unaffected() {
+        // Tiny kerning gaps never triggered spaces before and still don't.
+        let items = glyph_run("WORD", 100.0, 8.0, 0.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "WORD");
+    }
+
+    #[test]
+    fn cjk_glyph_run_collapses_without_spaces() {
+        // CJK sets one glyph per item with loose gaps; CJK uses no spaces,
+        // and the non-alphabetic run passes the caps gate.
+        let items = glyph_run("北京时事", 100.0, 12.0, 1.4);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "北京时事");
+    }
 
     fn make_merge_item(text: &str, x: f32, width: f32) -> TextItem {
         TextItem {

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -604,11 +604,11 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     let mut sorted = gaps.clone();
     sorted.sort_by(|a, b| a.total_cmp(b));
     let median = sorted[sorted.len() / 2];
-    // Typographic convention gate, both tiers: display tracking is a
-    // caps (or title-case single word) convention, and Han/Kana never
-    // space between glyphs. A spaced run of lowercase singles ("x y z"
-    // variables, "a b c" lists) has the same gap shape as tracking at
-    // ANY length, so lowercase sequences always keep their boundaries.
+    // Typographic convention gate, both tiers: display tracking is an
+    // all-caps convention, and Han/Kana never space between glyphs. Mixed-
+    // or lowercase Latin runs keep their boundaries because geometry alone
+    // cannot distinguish spaced singles ("A b c d e") from a tracked
+    // title-case word ("B u f f a l o").
     let run_chars = || {
         group[start..=end]
             .iter()
@@ -617,11 +617,7 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     let spaceless_cjk = run_chars().all(|c| is_spaceless_cjk(c) || !c.is_alphanumeric())
         && run_chars().any(is_spaceless_cjk);
     let all_caps = run_chars().all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic());
-    let title_case = {
-        let alpha: Vec<char> = run_chars().filter(|c| c.is_alphabetic()).collect();
-        alpha.len() >= 2 && alpha[0].is_uppercase() && alpha[1..].iter().all(|c| c.is_lowercase())
-    };
-    if !(spaceless_cjk || all_caps || title_case) {
+    if !(spaceless_cjk || all_caps) {
         return None;
     }
 
@@ -1022,12 +1018,13 @@ mod tests {
     }
 
     #[test]
-    fn title_case_tracked_word_collapses() {
-        // "B u f f a l o" — one title-case word set with tracking.
-        let items = glyph_run("Buffalo", 100.0, 7.0, 2.3);
+    fn uppercase_leading_spaced_singles_keep_boundaries() {
+        // "A b c d e" is indistinguishable from a title-case tracked word
+        // without reliable tracking metadata, so preserve its boundaries.
+        let items = glyph_run("Abcde", 100.0, 7.0, 2.3);
         let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1);
-        assert_eq!(merged[0].text, "Buffalo");
+        assert_eq!(merged[0].text, "A b c d e");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Display type set with tracking renders one glyph per show op; `merge_text_items`' fixed space thresholds (0.08–0.13 em) then read every letter gap as a word boundary: `H O W`, `F U R T H E R`, `I T I S I M P O R T A N T`. The page-level Canva fixer can't help — it needs ≥50% of the page letter-spaced, and these docs track only their display headings. Downstream this breaks heading text matching (opendataloader MHS) and markdown quality on poster/flyer docs.

## Fix

Pre-scan each run of consecutive single-glyph items (same size band, same style, mergeable gaps — mirroring the merge loop's own break conditions) and derive the run's space floor from its own gap distribution:

- **≥4 gaps**: tracked when the median gap clears the fixed threshold. Word gaps form a second mode — split at the largest relative jump (≥1.4×); unimodal → single word (`I T I S I M P O R T A N T` → `IT IS IMPORTANT`).
- **2–3 gaps** (`H O W`): additionally require uniform gaps and ALL-CAPS **or CJK** — a genuine spaced single-letter sequence (`x y z` variables) has the same gap count; display tracking is a caps convention, and CJK never wants inter-glyph spaces.

## Verification

- Corpus sweep, 708 PDFs (opendataloader + ParseBench text), this branch vs main: **12 docs change, zero collateral**. The changes: tracked display titles now read correctly (`HOW CAN YOU HELP?`, `LUNCHTIME MENU`, `FURTHER RESOURCES`, a tracked email `REBECCA.ALLEN@MSJ.EDU`), and CJK glyph-per-item docs lose their spurious inter-glyph spaces (`第 1 天` → `第1天`, `先 行 先 试` → `先行先试`) — ParseBench GT for those docs is unspaced CJK, and `should_join_items` already treats no-space CJK as correct on its path.
- 5 new unit tests (tracked caps run, bimodal word gaps, lowercase singles preserved, kerning untouched, CJK collapse); full suite 604 + 139 pass; clippy `-D warnings` clean.

Context: opendataloader MHS work (fire-pdf ENG-5029) — the letter-spaced class breaks heading text matching even when headings are correctly marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3U6BKYCS73DVA83odAfYB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false word splits in letter‑spaced display text by deriving a run‑local space floor for single‑glyph runs in `merge_text_items`. Also collapse inter‑glyph spaces for CJK while keeping real word gaps, improving heading matching for opendataloader MHS (ENG-5029).

- **Bug Fixes**
  - Pre-scan single‑glyph runs and compute a run‑local space floor from their gaps; only gaps above this floor become spaces.
  - Apply a convention gate on both tiers: require ALL‑CAPS or CJK; preserve mixed‑case and lowercase runs (e.g., "A b c d e", "a b c d e").
  - For ≥4 gaps split at the largest relative jump (≥1.4×); for 2–3 gaps also require uniform gaps.
  - Han/Kana: floor is infinite (never insert spaces); Hangul is excluded and keeps normal word spacing.
  - Adds tests for caps tracking, bimodal word gaps, lowercase and mixed‑case singles staying split, kerning, and CJK collapse/nonuniform gaps.

<sup>Written for commit 105a8ee288f42a7785d5c8b0cc8684eb9db83a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

