### PR TITLE
feat(site): GitHub Pages landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy landing page
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**', '.github/workflows/pages.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>pdf-inspector — PDF classification &amp; text extraction, no OCR</title>
+<meta name="description" content="Fast Rust library that classifies PDFs (text-based vs scanned) and extracts clean Markdown — no OCR, no ML models. Bindings for Rust, Python, and Node.js.">
+<meta property="og:title" content="pdf-inspector">
+<meta property="og:description" content="Classify PDFs and extract clean Markdown in milliseconds. No OCR. No ML. Pure Rust.">
+<meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%93%84%3C/text%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,800&family=Hanken+Grotesk:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --paper: #f4efe4;
+    --paper-2: #eee7d8;
+    --ink: #1b1712;
+    --ink-soft: #4a433a;
+    --muted: #8b8375;
+    --line: #d9cfbb;
+    --accent: #dd3f22;
+    --accent-deep: #b32d15;
+    --card: #faf6ec;
+    --display: "Bricolage Grotesque", serif;
+    --body: "Hanken Grotesk", sans-serif;
+    --mono: "JetBrains Mono", monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--body);
+    font-size: 17px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+    background-image:
+      radial-gradient(circle at 1px 1px, rgba(27,23,18,0.05) 1px, transparent 0);
+    background-size: 22px 22px;
+  }
+  ::selection { background: var(--accent); color: var(--paper); }
+  a { color: inherit; text-decoration: none; }
+
+  .wrap { max-width: 1120px; margin: 0 auto; padding: 0 28px; }
+
+  /* ── nav ── */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    background: rgba(244,239,228,0.82);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+  }
+  .nav-in { display: flex; align-items: center; gap: 22px; height: 60px; }
+  .brand { font-family: var(--mono); font-weight: 700; font-size: 15px; letter-spacing: -0.02em; display: flex; align-items: center; gap: 9px; }
+  .brand .dot { width: 9px; height: 9px; background: var(--accent); border-radius: 50%; box-shadow: 0 0 0 3px rgba(221,63,34,0.18); }
+  .nav-links { margin-left: auto; display: flex; gap: 24px; align-items: center; font-size: 14.5px; font-weight: 500; }
+  .nav-links a { color: var(--ink-soft); transition: color .15s; }
+  .nav-links a:hover { color: var(--accent); }
+  .nav-gh { border: 1px solid var(--ink); border-radius: 999px; padding: 6px 15px; color: var(--ink) !important; transition: all .15s; }
+  .nav-gh:hover { background: var(--ink); color: var(--paper) !important; }
+  @media (max-width: 680px) { .nav-links .hide-sm { display: none; } }
+
+  /* ── hero ── */
+  header { padding: 74px 0 40px; position: relative; }
+  .eyebrow { font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 22px; }
+  h1 {
+    font-family: var(--display);
+    font-weight: 800;
+    font-size: clamp(2.9rem, 8vw, 6.1rem);
+    line-height: 0.96;
+    letter-spacing: -0.035em;
+    max-width: 15ch;
+  }
+  h1 .em { color: var(--accent); font-style: normal; position: relative; }
+  h1 .strike { position: relative; white-space: nowrap; }
+  h1 .strike::after { content: ""; position: absolute; left: -2%; right: -2%; top: 54%; height: 0.09em; background: var(--accent); transform: rotate(-3deg); }
+  .lede { margin-top: 28px; font-size: clamp(1.05rem, 2.2vw, 1.32rem); color: var(--ink-soft); max-width: 46ch; line-height: 1.5; }
+  .lede b { color: var(--ink); font-weight: 600; }
+
+  .hero-grid { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 48px; align-items: end; }
+  @media (max-width: 880px) { .hero-grid { grid-template-columns: 1fr; gap: 40px; } }
+
+  /* readout card */
+  .readout {
+    background: var(--ink); color: var(--paper);
+    border-radius: 14px; padding: 22px 22px 20px;
+    font-family: var(--mono); font-size: 13px;
+    box-shadow: 14px 14px 0 rgba(27,23,18,0.09);
+    position: relative;
+  }
+  .readout .rlabel { color: #b8ad98; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 16px; display: flex; justify-content: space-between; }
+  .readout .rrow { display: flex; justify-content: space-between; align-items: center; padding: 9px 0; border-top: 1px solid rgba(255,255,255,0.09); }
+  .readout .rrow:first-of-type { border-top: none; }
+  .readout .k { color: #cfc6b3; }
+  .readout .v { font-weight: 700; }
+  .readout .v.hot { color: var(--accent); }
+  .bar { height: 6px; background: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; margin-top: 3px; width: 96px; }
+  .bar > i { display: block; height: 100%; background: var(--accent); border-radius: 3px; }
+
+  /* ── install row ── */
+  .installs { display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; margin-top: 54px; }
+  @media (max-width: 720px) { .installs { grid-template-columns: 1fr; } }
+  .inst {
+    background: var(--card); border: 1px solid var(--line); border-radius: 11px;
+    padding: 15px 17px; transition: transform .16s, border-color .16s, box-shadow .16s;
+    cursor: pointer;
+  }
+  .inst:hover { transform: translateY(-3px); border-color: var(--accent); box-shadow: 0 8px 22px rgba(27,23,18,0.07); }
+  .inst .reg { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 8px; display: flex; justify-content: space-between; }
+  .inst code { font-family: var(--mono); font-size: 14px; color: var(--ink); font-weight: 500; }
+  .inst .arrow { color: var(--accent); opacity: 0; transition: opacity .16s; }
+  .inst:hover .arrow { opacity: 1; }
+
+  /* ── section scaffold ── */
+  section { padding: 66px 0; border-top: 1px solid var(--line); }
+  .sec-head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 40px; flex-wrap: wrap; }
+  .sec-num { font-family: var(--mono); font-size: 13px; color: var(--accent); font-weight: 700; }
+  .sec-title { font-family: var(--display); font-weight: 600; font-size: clamp(1.7rem, 4vw, 2.6rem); letter-spacing: -0.025em; }
+  .sec-sub { color: var(--ink-soft); max-width: 52ch; font-size: 1.02rem; }
+
+  /* ── features ── */
+  .feat-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+  @media (max-width: 900px) { .feat-grid { grid-template-columns: repeat(2,1fr); } }
+  @media (max-width: 560px) { .feat-grid { grid-template-columns: 1fr; } }
+  .feat { background: var(--card); padding: 24px 22px; transition: background .16s; }
+  .feat:hover { background: #fff; }
+  .feat .fn { font-family: var(--mono); font-size: 12px; color: var(--accent); font-weight: 700; }
+  .feat h3 { font-family: var(--display); font-weight: 600; font-size: 1.16rem; margin: 12px 0 8px; letter-spacing: -0.01em; }
+  .feat p { font-size: 14.5px; color: var(--ink-soft); line-height: 1.5; }
+
+  /* ── benchmark ── */
+  .bench {
+    border: 1px solid var(--line); border-radius: 14px; overflow: hidden;
+    background: var(--card);
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 15px; }
+  thead th { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); text-align: right; padding: 15px 18px; background: var(--paper-2); border-bottom: 1px solid var(--line); font-weight: 500; }
+  thead th:first-child { text-align: left; }
+  tbody td { padding: 14px 18px; text-align: right; font-family: var(--mono); border-bottom: 1px solid var(--line); }
+  tbody td:first-child { text-align: left; font-family: var(--body); font-weight: 500; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr.us { background: rgba(221,63,34,0.06); }
+  tbody tr.us td:first-child { color: var(--accent-deep); font-weight: 700; }
+  tbody tr.us td:first-child::before { content: "▸ "; color: var(--accent); }
+  .bench-foot { padding: 15px 18px; font-size: 13.5px; color: var(--ink-soft); background: var(--paper-2); border-top: 1px solid var(--line); }
+  .bench-wrap { overflow-x: auto; }
+  .callouts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 22px; }
+  @media (max-width: 640px) { .callouts { grid-template-columns: 1fr; } }
+  .callout { border-left: 3px solid var(--accent); padding: 4px 0 4px 16px; }
+  .callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 5px; }
+  .callout p { font-size: 14.5px; color: var(--ink-soft); }
+
+  /* ── quickstart tabs ── */
+  .tabs input { position: absolute; opacity: 0; pointer-events: none; }
+  .tablist { display: flex; gap: 6px; margin-bottom: 0; }
+  .tablist label {
+    font-family: var(--mono); font-size: 13px; font-weight: 500;
+    padding: 10px 18px; cursor: pointer; color: var(--muted);
+    border: 1px solid var(--line); border-bottom: none;
+    border-radius: 9px 9px 0 0; background: var(--paper-2); transition: all .15s;
+  }
+  .tablist label:hover { color: var(--ink); }
+  .panel { display: none; }
+  .code {
+    background: var(--ink); border-radius: 0 12px 12px 12px;
+    padding: 22px 24px; overflow-x: auto;
+    font-family: var(--mono); font-size: 13.5px; line-height: 1.7;
+    color: #e9e2d3;
+    box-shadow: 12px 12px 0 rgba(27,23,18,0.07);
+  }
+  .code .cm { color: #8a8069; }
+  .code .kw { color: #ff9f7a; }
+  .code .st { color: #cbb78a; }
+  .code .fn { color: #f4efe4; font-weight: 700; }
+  #t-rust:checked ~ .tablist label[for=t-rust],
+  #t-py:checked ~ .tablist label[for=t-py],
+  #t-node:checked ~ .tablist label[for=t-node],
+  #t-cli:checked ~ .tablist label[for=t-cli] {
+    background: var(--ink); color: var(--paper); border-color: var(--ink);
+  }
+  #t-rust:checked ~ .panels #p-rust,
+  #t-py:checked ~ .panels #p-py,
+  #t-node:checked ~ .panels #p-node,
+  #t-cli:checked ~ .panels #p-cli { display: block; }
+  .code a.ref { color: #ff9f7a; border-bottom: 1px dotted #ff9f7a; }
+
+  /* ── cta / footer ── */
+  .cta { text-align: center; padding: 84px 0; border-top: 1px solid var(--line); }
+  .cta h2 { font-family: var(--display); font-weight: 800; font-size: clamp(2rem, 6vw, 3.4rem); letter-spacing: -0.03em; line-height: 1; }
+  .cta p { color: var(--ink-soft); margin: 18px auto 32px; max-width: 44ch; }
+  .btns { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+  .btn { font-family: var(--mono); font-size: 14px; font-weight: 500; padding: 13px 26px; border-radius: 999px; transition: all .15s; border: 1px solid var(--ink); }
+  .btn-p { background: var(--accent); border-color: var(--accent); color: var(--paper); }
+  .btn-p:hover { background: var(--accent-deep); border-color: var(--accent-deep); }
+  .btn-s:hover { background: var(--ink); color: var(--paper); }
+  footer { border-top: 1px solid var(--line); padding: 34px 0; font-size: 14px; color: var(--muted); }
+  .foot-in { display: flex; justify-content: space-between; align-items: center; gap: 18px; flex-wrap: wrap; }
+  .foot-in a { color: var(--ink-soft); }
+  .foot-in a:hover { color: var(--accent); }
+  .foot-links { display: flex; gap: 20px; font-family: var(--mono); font-size: 13px; }
+
+  /* ── load animation ── */
+  .reveal { opacity: 0; transform: translateY(14px); animation: rise .7s cubic-bezier(.2,.7,.3,1) forwards; }
+  @keyframes rise { to { opacity: 1; transform: none; } }
+  .d1 { animation-delay: .05s; } .d2 { animation-delay: .15s; } .d3 { animation-delay: .25s; }
+  .d4 { animation-delay: .35s; } .d5 { animation-delay: .45s; } .d6 { animation-delay: .55s; }
+  @media (prefers-reduced-motion: reduce) { .reveal { animation: none; opacity: 1; transform: none; } }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="wrap nav-in">
+    <a href="#top" class="brand"><span class="dot"></span>pdf-inspector</a>
+    <div class="nav-links">
+      <a href="#features" class="hide-sm">Features</a>
+      <a href="#benchmark" class="hide-sm">Benchmark</a>
+      <a href="#start">Quick start</a>
+      <a class="nav-gh" href="https://github.com/firecrawl/pdf-inspector">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header id="top">
+  <div class="wrap hero-grid">
+    <div>
+      <div class="eyebrow reveal d1">Rust · Python · Node · CLI</div>
+      <h1 class="reveal d2">Classify PDFs. Extract Markdown. <span class="strike">No OCR.</span></h1>
+      <p class="lede reveal d3">A fast Rust library that tells text-based PDFs from scanned ones, then extracts position-aware text and clean Markdown — <b>locally, in milliseconds</b>. Skip the OCR bill for the ~54% of PDFs that never needed it.</p>
+    </div>
+    <div class="readout reveal d4" aria-hidden="true">
+      <div class="rlabel"><span>classify_pdf()</span><span>~12ms</span></div>
+      <div class="rrow"><span class="k">type</span><span class="v hot">TextBased</span></div>
+      <div class="rrow"><span class="k">confidence</span><span class="v">0.98</span></div>
+      <div class="rrow"><span class="k">needs_ocr</span><span class="v">false</span></div>
+      <div class="rrow"><span class="k">route</span><span class="v">local&nbsp;→&nbsp;md</span></div>
+      <div class="rrow" style="border-top:1px solid rgba(255,255,255,.09);padding-top:13px">
+        <span class="k">signal</span>
+        <span class="bar"><i style="width:98%"></i></span>
+      </div>
+    </div>
+  </div>
+
+  <div class="wrap">
+    <div class="installs">
+      <a class="inst reveal d4" href="https://crates.io/crates/pdf-inspector">
+        <div class="reg"><span>crates.io</span><span class="arrow">↗</span></div>
+        <code>cargo add pdf-inspector</code>
+      </a>
+      <a class="inst reveal d5" href="https://pypi.org/project/pdf-inspector/">
+        <div class="reg"><span>PyPI</span><span class="arrow">↗</span></div>
+        <code>pip install pdf-inspector</code>
+      </a>
+      <a class="inst reveal d6" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
+        <div class="reg"><span>npm</span><span class="arrow">↗</span></div>
+        <code>npm i @firecrawl/pdf-inspector</code>
+      </a>
+    </div>
+  </div>
+</header>
+
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">01</span>
+      <h2 class="sec-title">Built for routing, not just reading</h2>
+    </div>
+    <div class="feat-grid">
+      <div class="feat"><div class="fn">01</div><h3>Smart classification</h3><p>TextBased, Scanned, ImageBased, or Mixed in ~10–50ms by sampling content streams. Returns a confidence score and per-page OCR routing.</p></div>
+      <div class="feat"><div class="fn">02</div><h3>Position-aware text</h3><p>Extraction with font info, X/Y coordinates, and automatic multi-column reading order.</p></div>
+      <div class="feat"><div class="fn">03</div><h3>Markdown conversion</h3><p>Headings, bullet/numbered lists, code blocks, tables, bold/italic, URL linking, and page breaks.</p></div>
+      <div class="feat"><div class="fn">04</div><h3>Table detection</h3><p>Rectangle-based detection from drawing ops plus heuristic alignment detection. Financial tables, footnotes, and cross-page continuations.</p></div>
+      <div class="feat"><div class="fn">05</div><h3>CID font support</h3><p>ToUnicode CMap decoding for Type0/Identity-H fonts, with UTF-16BE, UTF-8, and Latin-1 encodings.</p></div>
+      <div class="feat"><div class="fn">06</div><h3>Multi-column layout</h3><p>Newspaper-style column detection, sequential reading order, and right-to-left text support.</p></div>
+      <div class="feat"><div class="fn">07</div><h3>Encoding checks</h3><p>Flags broken font encodings automatically so callers can fall back to OCR only when it's actually needed.</p></div>
+      <div class="feat"><div class="fn">08</div><h3>Lightweight</h3><p>Pure Rust. No ML models, no external services. A single parse shared between detection and extraction.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="benchmark">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">02</span>
+      <h2 class="sec-title">Fastest of the direct-text engines</h2>
+      <p class="sec-sub">Evaluated on the <a href="https://github.com/opendataloader-project/opendataloader-bench" style="color:var(--accent-deep);border-bottom:1px solid var(--line)">opendataloader-bench</a> corpus (200 PDFs). Direct text-extraction engines only — no OCR, no ML. Higher is better.</p>
+    </div>
+    <div class="bench">
+      <div class="bench-wrap">
+      <table>
+        <thead>
+          <tr><th>Engine</th><th>Overall</th><th>Reading order</th><th>Tables</th><th>Headings</th><th>200 docs</th></tr>
+        </thead>
+        <tbody>
+          <tr class="us"><td>pdf-inspector</td><td>0.78</td><td>0.87</td><td>0.59</td><td>0.57</td><td>4s</td></tr>
+          <tr><td>opendataloader</td><td>0.84</td><td>0.91</td><td>0.49</td><td>0.74</td><td>11s</td></tr>
+          <tr><td>pymupdf4llm</td><td>0.73</td><td>0.89</td><td>0.40</td><td>0.41</td><td>18s</td></tr>
+          <tr><td>markitdown</td><td>0.58</td><td>0.88</td><td>0.00</td><td>0.00</td><td>8s</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <div class="bench-foot">OCR/ML engines (docling, marker, mineru) score 0.83–0.88 overall — but take 2–180 minutes on the same corpus.</div>
+    </div>
+    <div class="callouts">
+      <div class="callout"><div class="ct">Where we win</div><p>Fastest engine measured, strong reading order, and the best table detection among direct-text tools.</p></div>
+      <div class="callout"><div class="ct">Where we're working</div><p>Heading detection on body-size bold titles, and tables that need visual structure an OCR engine can see.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="start">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">03</span>
+      <h2 class="sec-title">Three lines to Markdown</h2>
+    </div>
+    <div class="tabs">
+      <input type="radio" name="tab" id="t-rust" checked>
+      <input type="radio" name="tab" id="t-py">
+      <input type="radio" name="tab" id="t-node">
+      <input type="radio" name="tab" id="t-cli">
+      <div class="tablist">
+        <label for="t-rust">Rust</label>
+        <label for="t-py">Python</label>
+        <label for="t-node">Node.js</label>
+        <label for="t-cli">CLI</label>
+      </div>
+      <div class="panels">
+        <div class="panel" id="p-rust"><pre class="code"><span class="kw">use</span> pdf_inspector::process_pdf;
+
+<span class="kw">let</span> result = <span class="fn">process_pdf</span>(<span class="st">"document.pdf"</span>)?;
+<span class="fn">println!</span>(<span class="st">"Type: {:?}"</span>, result.pdf_type);
+<span class="kw">if let</span> <span class="kw">Some</span>(markdown) = &amp;result.markdown {
+    <span class="fn">println!</span>(<span class="st">"{}"</span>, markdown);
+}
+<span class="cm">// full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/rust-api.md">docs/rust-api.md</a></pre></div>
+        <div class="panel" id="p-py"><pre class="code"><span class="kw">import</span> pdf_inspector
+
+result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="st">"document.pdf"</span>)
+<span class="fn">print</span>(result.pdf_type)   <span class="cm"># "text_based" | "scanned" | "image_based" | "mixed"</span>
+<span class="fn">print</span>(result.markdown)   <span class="cm"># Markdown string or None</span>
+<span class="cm"># full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md">docs/python.md</a></pre></div>
+        <div class="panel" id="p-node"><pre class="code"><span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="st">'fs'</span>;
+<span class="kw">import</span> { processPdf } <span class="kw">from</span> <span class="st">'@firecrawl/pdf-inspector'</span>;
+
+<span class="kw">const</span> result = <span class="fn">processPdf</span>(<span class="fn">readFileSync</span>(<span class="st">'document.pdf'</span>));
+console.<span class="fn">log</span>(result.pdfType);   <span class="cm">// "TextBased" | "Scanned" | ...</span>
+console.<span class="fn">log</span>(result.markdown);  <span class="cm">// Markdown string or null</span>
+<span class="cm">// full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/napi/README.md">napi/README.md</a></pre></div>
+        <div class="panel" id="p-cli"><pre class="code"><span class="cm"># install the CLI tools</span>
+cargo <span class="fn">install</span> pdf-inspector
+
+<span class="cm"># convert a PDF to Markdown</span>
+<span class="fn">pdf2md</span> document.pdf
+
+<span class="cm"># classify only — is it scanned?</span>
+<span class="fn">detect-pdf</span> document.pdf --analyze --json
+
+<span class="cm"># structured output for pipelines</span>
+<span class="fn">pdf2md</span> document.pdf --json</pre></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="cta">
+  <div class="wrap">
+    <h2>Stop paying OCR for text.</h2>
+    <p>Route the easy PDFs locally in milliseconds, and send only the ones that truly need it downstream.</p>
+    <div class="btns">
+      <a class="btn btn-p" href="https://github.com/firecrawl/pdf-inspector">Get started on GitHub</a>
+      <a class="btn btn-s" href="https://crates.io/crates/pdf-inspector">View on crates.io</a>
+    </div>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot-in">
+    <div>Built by <a href="https://firecrawl.dev">Firecrawl</a> · MIT licensed</div>
+    <div class="foot-links">
+      <a href="https://github.com/firecrawl/pdf-inspector">GitHub</a>
+      <a href="https://crates.io/crates/pdf-inspector">crates.io</a>
+      <a href="https://pypi.org/project/pdf-inspector/">PyPI</a>
+      <a href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">npm</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -539,6 +539,20 @@ fn should_preserve_overlapping_stream_order(group: &[&TextItem]) -> bool {
 /// then inserted only at gaps above the floor (infinity = single word).
 /// Normal text (multi-char items, or single-char runs with sub-threshold
 /// gaps) returns None and keeps the existing behavior.
+/// Han/Kana scripts write without inter-word spaces. Hangul (Korean) DOES
+/// space between words and deliberately stays out of this set — a Korean
+/// tracked run keeps normal word-boundary handling.
+fn is_spaceless_cjk(c: char) -> bool {
+    matches!(c,
+        '\u{3000}'..='\u{303F}'   // CJK Symbols and Punctuation
+        | '\u{3040}'..='\u{309F}' // Hiragana
+        | '\u{30A0}'..='\u{30FF}' // Katakana
+        | '\u{4E00}'..='\u{9FFF}' // CJK Unified Ideographs
+        | '\u{F900}'..='\u{FAFF}' // CJK Compatibility Ideographs
+        | '\u{FF00}'..='\u{FFEF}' // Halfwidth and Fullwidth Forms
+    )
+}
+
 fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, f32)> {
     const MIN_GAPS: usize = 4;
     let first = group[start];
@@ -590,22 +604,43 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     let mut sorted = gaps.clone();
     sorted.sort_by(|a, b| a.total_cmp(b));
     let median = sorted[sorted.len() / 2];
+    // Typographic convention gate, both tiers: display tracking is a
+    // caps (or title-case single word) convention, and Han/Kana never
+    // space between glyphs. A spaced run of lowercase singles ("x y z"
+    // variables, "a b c" lists) has the same gap shape as tracking at
+    // ANY length, so lowercase sequences always keep their boundaries.
+    let run_chars = || {
+        group[start..=end]
+            .iter()
+            .flat_map(|it| it.text.trim().chars())
+    };
+    let spaceless_cjk = run_chars().all(|c| is_spaceless_cjk(c) || !c.is_alphanumeric())
+        && run_chars().any(is_spaceless_cjk);
+    let all_caps = run_chars().all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic());
+    let title_case = {
+        let alpha: Vec<char> = run_chars().filter(|c| c.is_alphabetic()).collect();
+        alpha.len() >= 2 && alpha[0].is_uppercase() && alpha[1..].iter().all(|c| c.is_lowercase())
+    };
+    if !(spaceless_cjk || all_caps || title_case) {
+        return None;
+    }
+
     if gaps.len() >= MIN_GAPS {
         if median <= 0.075 {
             return None;
         }
     } else {
         let uniform = sorted[sorted.len() - 1] <= sorted[0].max(0.01) * 1.4;
-        // Caps convention — or CJK, which never uses inter-glyph spaces.
-        let all_caps = group[start..=end].iter().all(|it| {
-            it.text
-                .trim()
-                .chars()
-                .all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic())
-        });
-        if median < 0.09 || !uniform || !all_caps {
+        if median < 0.09 || !uniform {
             return None;
         }
+    }
+
+    // Han/Kana: no inter-glyph spaces, period — a nonuniform gap
+    // distribution (punctuation spacing, justification) must not
+    // manufacture word boundaries.
+    if spaceless_cjk {
+        return Some((end, f32::INFINITY));
     }
 
     // Word gaps, if present, form a second mode above the letter-gap
@@ -960,6 +995,39 @@ mod tests {
         let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].text, "WORD");
+    }
+
+    #[test]
+    fn long_lowercase_spaced_singles_keep_boundaries() {
+        // Review: a 5+ single-letter lowercase list has the tracked gap
+        // shape at any length — the convention gate must protect it in
+        // the >=4-gap tier too.
+        let items = glyph_run("abcde", 100.0, 6.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "a b c d e");
+    }
+
+    #[test]
+    fn han_run_with_nonuniform_gaps_never_gains_spaces() {
+        // Review: a bimodal gap distribution (justification, punctuation
+        // spacing) must not manufacture word boundaries in Han text.
+        let mut items = glyph_run("北京时事快报", 100.0, 12.0, 1.4);
+        for item in items.iter_mut().skip(3) {
+            item.x += 3.0; // wide gap after the third glyph
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "北京时事快报");
+    }
+
+    #[test]
+    fn title_case_tracked_word_collapses() {
+        // "B u f f a l o" — one title-case word set with tracking.
+        let items = glyph_run("Buffalo", 100.0, 7.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "Buffalo");
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -9,7 +9,7 @@ mod links;
 pub(crate) mod underline;
 mod xobjects;
 
-use crate::text_utils::is_rtl_text;
+use crate::text_utils::{is_cjk_char, is_rtl_text};
 use crate::tounicode::FontCMaps;
 use crate::types::{PageExtraction, PdfLine, PdfRect, TextItem};
 use crate::PdfError;
@@ -527,6 +527,105 @@ fn should_preserve_overlapping_stream_order(group: &[&TextItem]) -> bool {
     saw_backtrack
 }
 
+/// Detect a tracked (letter-spaced) run of single-glyph items and derive its
+/// run-local space floor.
+///
+/// Display type set with tracking renders one glyph per show op; the merge
+/// loop's fixed thresholds (0.08-0.13 em) then read every letter gap as a
+/// word boundary and emit "H O W" instead of "HOW". Within such a run the
+/// gaps carry the real signal: letter gaps cluster tightly just above the
+/// fixed threshold, word gaps sit clearly higher. Returns (run_end_index,
+/// space_floor) when the run starting at `start` is tracked — spaces are
+/// then inserted only at gaps above the floor (infinity = single word).
+/// Normal text (multi-char items, or single-char runs with sub-threshold
+/// gaps) returns None and keeps the existing behavior.
+fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, f32)> {
+    const MIN_GAPS: usize = 4;
+    let first = group[start];
+    if first.text.trim().chars().count() != 1 {
+        return None;
+    }
+    let fs = first.font_size;
+    if fs <= 0.0 {
+        return None;
+    }
+
+    // Walk the run under the SAME break conditions as the merge loop
+    // (size band, style equality, mergeable gap) so indices stay aligned.
+    let mut gaps: Vec<f32> = Vec::new();
+    let mut end_x = first.x + effective_merge_width(first);
+    let mut end = start;
+    for (offset, next) in group[start + 1..].iter().enumerate() {
+        if next.text.trim().chars().count() != 1 {
+            break;
+        }
+        if (next.font_size - fs).abs() > fs * 0.20 {
+            break;
+        }
+        if next.is_bold != first.is_bold
+            || next.is_italic != first.is_italic
+            || next.is_underline != first.is_underline
+            || next.is_strikeout != first.is_strikeout
+        {
+            break;
+        }
+        let gap = next.x - end_x;
+        if gap > fs * 0.5 || gap < -fs * 0.5 {
+            break;
+        }
+        gaps.push(gap / fs);
+        end_x = next.x + effective_merge_width(next);
+        end = start + 1 + offset;
+    }
+    if gaps.len() < 2 {
+        return None;
+    }
+
+    // Tracked signature: the run's TYPICAL gap clears the fixed space
+    // threshold (0.08) — the merge loop would break almost every letter
+    // pair into "words". Short runs (2-3 gaps: "H O W") demand a stricter
+    // shape — clearly wide, uniform, ALL-CAPS — because a genuine spaced
+    // sequence of single letters ("x y z" variables) has the same gap
+    // count; display tracking is a caps convention.
+    let mut sorted = gaps.clone();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let median = sorted[sorted.len() / 2];
+    if gaps.len() >= MIN_GAPS {
+        if median <= 0.075 {
+            return None;
+        }
+    } else {
+        let uniform = sorted[sorted.len() - 1] <= sorted[0].max(0.01) * 1.4;
+        // Caps convention — or CJK, which never uses inter-glyph spaces.
+        let all_caps = group[start..=end].iter().all(|it| {
+            it.text
+                .trim()
+                .chars()
+                .all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic())
+        });
+        if median < 0.09 || !uniform || !all_caps {
+            return None;
+        }
+    }
+
+    // Word gaps, if present, form a second mode above the letter-gap
+    // cluster: split at the largest relative jump. Unimodal → one word.
+    let mut best_jump = 1.0f32;
+    let mut floor = f32::INFINITY;
+    for pair in sorted.windows(2) {
+        let (lo, hi) = (pair[0].max(0.01), pair[1].max(0.01));
+        let jump = hi / lo;
+        if jump > best_jump {
+            best_jump = jump;
+            floor = (lo + hi) / 2.0;
+        }
+    }
+    if best_jump < 1.4 {
+        floor = f32::INFINITY;
+    }
+    Some((end, floor * fs))
+}
+
 pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
     if items.is_empty() {
         return items;
@@ -573,6 +672,14 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
             let first = group[i];
             let mut text = first.text.clone();
             let mut end_x = first.x + effective_merge_width(first);
+
+            // Tracked display text: run-local space floor overrides the
+            // fixed thresholds for this run's junctions (see helper).
+            let tracked = if *preserve_stream_order {
+                None
+            } else {
+                tracked_run_space_floor(group, i)
+            };
 
             let mut j = i + 1;
             while j < group.len() {
@@ -628,7 +735,11 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 let needs_bullet_space = *preserve_stream_order
                     && is_standalone_bullet_text(&text)
                     && !next.text.trim().is_empty();
-                if needs_bullet_space || gap > threshold {
+                let effective_threshold = match tracked {
+                    Some((run_end, floor)) if j <= run_end => floor,
+                    _ => threshold,
+                };
+                if needs_bullet_space || gap > effective_threshold {
                     text.push(' ');
                 }
                 text.push_str(&next.text);
@@ -793,6 +904,73 @@ mod tests {
     use crate::text_utils::{is_cjk_char, is_rtl_char, is_rtl_text, sort_line_items};
     use crate::types::{ItemType, PdfLine, TextLine};
     use layout::{detect_columns, is_newspaper_layout, ColumnRegion};
+
+    /// Glyph-per-item run at `fs`=12 with the given inter-glyph gap (pt).
+    fn glyph_run(chars: &str, start_x: f32, glyph_w: f32, gap: f32) -> Vec<TextItem> {
+        let mut x = start_x;
+        let mut out = Vec::new();
+        for c in chars.chars() {
+            out.push(make_merge_item(&c.to_string(), x, glyph_w));
+            x += glyph_w + gap;
+        }
+        out
+    }
+
+    #[test]
+    fn tracked_caps_run_collapses_to_word() {
+        // Display tracking: every letter gap (0.19 em) clears the fixed
+        // space threshold — without the run-local floor this reads "H O W".
+        let items = glyph_run("HOW", 100.0, 10.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "HOW");
+    }
+
+    #[test]
+    fn tracked_run_keeps_word_gaps_bimodal() {
+        // Letters at 0.19 em, word gaps at 0.42 em (below the 0.5 em item
+        // break): the split must land between the modes. Needs >=4 gaps to
+        // enter the bimodal tier — short runs use the strict uniform gate.
+        let mut items = glyph_run("ITISOK", 100.0, 8.0, 2.3);
+        for i in 2..6 {
+            items[i].x += 2.8; // word gap at T|I
+        }
+        for i in 4..6 {
+            items[i].x += 2.8; // word gap at S|O
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "IT IS OK");
+    }
+
+    #[test]
+    fn lowercase_spaced_singles_stay_words() {
+        // "x y z" variables: same gap shape but lowercase — the short-run
+        // caps requirement keeps genuine spaced singles apart.
+        let items = glyph_run("xyz", 100.0, 6.0, 2.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "x y z");
+    }
+
+    #[test]
+    fn kerned_singles_unaffected() {
+        // Tiny kerning gaps never triggered spaces before and still don't.
+        let items = glyph_run("WORD", 100.0, 8.0, 0.3);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "WORD");
+    }
+
+    #[test]
+    fn cjk_glyph_run_collapses_without_spaces() {
+        // CJK sets one glyph per item with loose gaps; CJK uses no spaces,
+        // and the non-alphabetic run passes the caps gate.
+        let items = glyph_run("北京时事", 100.0, 12.0, 1.4);
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "北京时事");
+    }
 
     fn make_merge_item(text: &str, x: f32, width: f32) -> TextItem {
         TextItem {


### PR DESCRIPTION
## Summary

A landing page for pdf-inspector, deployed to GitHub Pages from this repo (co-located with the code so it updates alongside features).

- **`site/index.html`** — single self-contained page, no build step. Distinctive editorial-technical design (Bricolage Grotesque + Hanken Grotesk + JetBrains Mono, warm paper + vermillion), fully responsive, `prefers-reduced-motion` respected. Sections: hero with a live-looking classification readout, three-registry install cards, feature grid, benchmark, tabbed quick-start (Rust/Python/Node/CLI, CSS-only tabs).
- **`.github/workflows/pages.yml`** — deploys `site/` via `actions/deploy-pages` on push to main touching `site/**` (plus manual dispatch). Same OIDC pattern as the other CI; no tokens.

Verified with headless Chrome at desktop and narrow widths: no page-level horizontal scroll (`scrollWidth == clientWidth`), fonts load, tabs switch, benchmark table scrolls inside its own container on small screens.

## Before this deploys

GitHub Pages must be set to **Build and deployment → Source: GitHub Actions** (enabling separately). Once enabled and this is merged, the workflow publishes to `https://firecrawl.github.io/pdf-inspector/`.

## Note on the benchmark

The benchmark table mirrors the README's current published numbers (overall 0.78). Those are stale relative to recent improvements — recommend a follow-up that re-runs the benchmark and refreshes the README table and this page together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-contained landing page for `pdf-inspector` with a GitHub Pages workflow, and fixes text merging to handle letter‑spaced headings and CJK without spurious spaces.

- **New Features**
  - Landing page in `site/`: hero with readout, install cards for crates.io/PyPI/npm, feature grid, benchmark, and CSS-only quick‑start tabs (Rust/Python/Node/CLI). Fully responsive and respects `prefers-reduced-motion`.
  - GitHub Pages deploy via `.github/workflows/pages.yml` using `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`; publishes `site/` on push to `main`. Requires Pages “Source: GitHub Actions”. Site URL: https://firecrawl.github.io/pdf-inspector/

- **Bug Fixes**
  - Text merge detects tracked (letter‑spaced) single‑glyph runs and uses a run‑local space floor to collapse display text correctly (e.g., "H O W" → "HOW", "IT IS OK" preserved). Lowercase spaced singles (e.g., "x y z") are kept as separate words.
  - CJK: Han/Kana runs never gain spaces; Hangul keeps normal word boundaries. Adds tests for caps, title‑case, CJK, and short/long runs.

<sup>Written for commit 10d293ea2d7491e1c1a829dc8146fdda3498eb56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

