### PR TITLE
chore(napi): bump @firecrawl/pdf-inspector to 1.10.1

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Bumps `@firecrawl/pdf-inspector` from `1.10.0` to `1.10.1` to publish the extraction-correctness fixes merged since the last npm release, including font, heading, table, and tracked/CJK letter-spacing handling.

This is a patch release because the range introduces no public Node API, CLI, or schema changes; it corrects existing extraction behavior and includes an internal refactor.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@firecrawl/pdf-inspector` to 1.10.1 to ship extraction-correctness fixes for fonts, headings, tables, and tracked/CJK letter-spacing. Patch release with no changes to public API, CLI, or schemas.

<sup>Written for commit 5efcfafa25ea276ed0eb22f77e3e424fde7612ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

