### PR TITLE
docs: refresh benchmark table with current numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Evaluated on the [opendataloader-bench](https://github.com/opendataloader-projec
 
 | Engine | Overall | Reading Order (NID) | Tables (TEDS) | Headings (MHS) | Speed (200 docs) |
 |---|---|---|---|---|---|
-| pdf-inspector | 0.78 | 0.87 | 0.59 | 0.57 | 4s |
+| pdf-inspector | 0.83 | 0.88 | 0.66 | 0.74 | 4s |
 | opendataloader | 0.84 | 0.91 | 0.49 | 0.74 | 11s |
 | pymupdf4llm | 0.73 | 0.89 | 0.40 | 0.41 | 18s |
 | markitdown | 0.58 | 0.88 | 0.00 | 0.00 | 8s |
 
-For context, engines that use OCR/ML (docling, marker, mineru) score 0.83-0.88 overall but take 2-180 minutes on the same corpus.
+For context, engines that use OCR/ML (docling, marker, mineru) score 0.83-0.88 overall but take 2-180 minutes on the same corpus — pdf-inspector reaches the low end of that range without any OCR, in 4 seconds.
 
-**Where we do well:** Speed (fastest of all engines), reading order, table detection vs other direct-text tools.
+**Where we do well:** Speed (fastest of all engines), the best table detection of any engine shown, and heading detection now on par with opendataloader. Overall lands within 0.01 of opendataloader at roughly 2.5× the speed.
 
-**Where we lag:** Heading detection trails opendataloader — many PDFs use bold text at body font size for headings, or headings that are only slightly larger than body text. Table detection trails OCR-based engines that can see visual table structure.
+**Where we lag:** Reading order still trails opendataloader slightly, and table structure trails OCR-based engines that can see visual layout.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Re-ran the benchmark on current `main` and refreshed the README table. Only the pdf-inspector row moved (competitor numbers are unchanged from the previous table):

| Metric | Was | Now |
|---|---|---|
| Overall | 0.78 | **0.83** |
| Reading order (NID) | 0.87 | 0.88 |
| Tables (TEDS) | 0.59 | **0.66** |
| Headings (MHS) | 0.57 | **0.74** |

The cumulative effect of the recent classification/table fixes: overall now within 0.01 of opendataloader (0.83 vs 0.84) at ~2.5× the speed, best table score of the group, and heading detection now on par (0.74 vs 0.74) where it previously trailed. Prose updated to match — the old "heading detection trails opendataloader" caveat no longer holds.

The landing page benchmark (PR #135) is updated with the same numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README benchmarks with current `opendataloader-bench` results; only the `pdf-inspector` row changed. `pdf-inspector` is now 0.83 overall (was 0.78), 0.66 on tables (was 0.59, best shown), 0.74 on headings (was 0.57), still 4s; prose now notes parity with `opendataloader` on headings and a near tie overall at ~2.5× the speed.

<sup>Written for commit e1501efbaad8121527511e2d2a9e7a57b9adc8d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

