### PR TITLE
fix(markdown): lowercase-initial short fragments are not headings

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -174,6 +174,21 @@ pub(crate) fn is_toc_marker_heading(text: &str) -> bool {
 pub(crate) fn is_heading_fragment(text: &str) -> bool {
     let t = text.trim_end();
 
+    // A lowercase-initial one-or-two-word "heading" is a mid-sentence
+    // fragment beside display math ("or inversely", "and therefore") —
+    // real headings that short start uppercase. Measured as spurious
+    // headings on academic docs (fire-pdf ENG-5029 / opendataloader MHS).
+    {
+        let words: Vec<&str> = t.split_whitespace().collect();
+        if words.len() <= 2 {
+            if let Some(first_alpha) = t.chars().find(|c| c.is_alphabetic()) {
+                if first_alpha.is_lowercase() {
+                    return true;
+                }
+            }
+        }
+    }
+
     fn is_equation_number(s: &str) -> bool {
         s.strip_prefix('(')
             .and_then(|r| r.strip_suffix(')'))
@@ -460,6 +475,10 @@ mod tests {
     #[test]
     fn heading_fragments() {
         // Equation lead-ins: colon ending + inline equation reference
+        assert!(is_heading_fragment("or inversely"));
+        assert!(is_heading_fragment("and therefore"));
+        assert!(!is_heading_fragment("Introduction"));
+        assert!(!is_heading_fragment("iPhone Sales Strategy Overview")); // 4 words, exempt
         assert!(is_heading_fragment("Rearranging Equation (8) gives:"));
         // Display-equation neighbours ending in an equation number
         assert!(is_heading_fragment("S = kB ln W, (2)"));


### PR DESCRIPTION
A lowercase-initial one-or-two-word "heading" is a mid-sentence fragment beside display math (`or inversely`, `and therefore`) — real headings that short start uppercase. These were measured as spurious headings on academic docs via fire-pdf's coverage_fallback path (opendataloader MHS work, fire-pdf ENG-5029; fire-pdf's own label/font paths got the equivalent gate in fire-pdf #438/#439).

Implemented in `is_heading_fragment` so both bold-heading call sites inherit the gate.

**Verification:**
- Repro doc: `## or inversely` no longer emitted; the real `## 5. The dynamics` / `## 6. Modeling the dynamics` neighbors kept.
- Corpus sweep (708 opendataloader + ParseBench PDFs) vs main: 33 docs change, all lowercase-fragment demotions (`## caldera` → `**caldera**`, `## of quorum."` → bold, `## 100 mm` → bold) — no real heading in either corpus is lowercase-initial and ≤2 words.
- 4 new unit tests; full suite 607 + 141 pass; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3U6BKYCS73DVA83odAfYB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating one- or two-word lowercase fragments as headings. Fixes spurious headings near display math in `coverage_fallback` and keeps real headings intact (ENG-5029).

- **Bug Fixes**
  - Add rule in `is_heading_fragment`: ≤2 words with a lowercase initial are not headings; both bold-heading call sites inherit this.
  - Add 4 unit tests; corpus sweep shows only demotions of false headings (e.g., `## or inversely` → bold), real headings unchanged.

<sup>Written for commit 59b3fcd9e6cfa6055599dc6d87e7380c9da239bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

