### PR TITLE
chore(napi): bump @firecrawl/pdf-inspector to 1.10.2

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Releases since 1.10.1:
- **#140** — lowercase-fragment heading gate (`or inversely` class; opendataloader MHS work, pairs with fire-pdf #438/#439)
- **#139** — per-page OCR routing reasons
- **#138** — `--password` support for encrypted PDFs
- **#137** — docs benchmark refresh

Patch bump: no API surface changes (routing reasons and password are additive).

Merging triggers the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3U6BKYCS73DVA83odAfYB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@firecrawl/pdf-inspector` to 1.10.2 to ship heading gating for lowercase fragments, per-page OCR routing reasons, and password support for encrypted PDFs. Patch release with no API changes; merge will publish to npm.

<sup>Written for commit 3c7135d4ae9c63470d2317a5baae6d2eeb340c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

