### PR TITLE
fix(tables): flatten page-number tables of contents instead of gridding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Evaluated on the [opendataloader-bench](https://github.com/opendataloader-projec
 
 | Engine | Overall | Reading Order (NID) | Tables (TEDS) | Headings (MHS) | Speed (200 docs) |
 |---|---|---|---|---|---|
-| pdf-inspector | 0.83 | 0.88 | 0.66 | 0.74 | 4s |
+| pdf-inspector | 0.83 | 0.89 | 0.66 | 0.74 | 4s |
 | opendataloader | 0.84 | 0.91 | 0.49 | 0.74 | 11s |
 | pymupdf4llm | 0.73 | 0.89 | 0.40 | 0.41 | 18s |
 | markitdown | 0.58 | 0.88 | 0.00 | 0.00 | 8s |

--- a/site/index.html
+++ b/site/index.html
@@ -310,7 +310,7 @@
           <tr><th>Engine</th><th>Overall</th><th>Reading order</th><th>Tables</th><th>Headings</th><th>200 docs</th></tr>
         </thead>
         <tbody>
-          <tr class="us"><td>pdf-inspector</td><td>0.83</td><td>0.88</td><td>0.66</td><td>0.74</td><td>4s</td></tr>
+          <tr class="us"><td>pdf-inspector</td><td>0.83</td><td>0.89</td><td>0.66</td><td>0.74</td><td>4s</td></tr>
           <tr><td>opendataloader</td><td>0.84</td><td>0.91</td><td>0.49</td><td>0.74</td><td>11s</td></tr>
           <tr><td>pymupdf4llm</td><td>0.73</td><td>0.89</td><td>0.40</td><td>0.41</td><td>18s</td></tr>
           <tr><td>markitdown</td><td>0.58</td><td>0.88</td><td>0.00</td><td>0.00</td><td>8s</td></tr>

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -917,31 +917,10 @@ pub fn is_table_of_contents(cells: &[Vec<String>]) -> bool {
     is_dot_leader_toc(cells) || is_tabular_toc(cells) || is_page_number_toc(cells)
 }
 
-/// Canonical lowercase roman numeral for `n` (covers the i/v/x/l/c range).
-fn to_roman_lower(mut n: u32) -> String {
-    const TABLE: [(u32, &str); 9] = [
-        (100, "c"),
-        (90, "xc"),
-        (50, "l"),
-        (40, "xl"),
-        (10, "x"),
-        (9, "ix"),
-        (5, "v"),
-        (4, "iv"),
-        (1, "i"),
-    ];
-    let mut out = String::new();
-    for (val, sym) in TABLE {
-        while n >= val {
-            out.push_str(sym);
-            n -= val;
-        }
-    }
-    out
-}
-
 /// Parse a page-number-like token: a short arabic integer (≤4 digits) or a
-/// lowercase/uppercase roman numeral (front-matter pages: i, ii, …, xii).
+/// canonical roman numeral (front-matter pages: i, ii, …, xxxviii). Roman
+/// parsing is shared with the formatter via `super::canonical_roman_value` so
+/// the two stay in sync.
 fn page_number_value(token: &str) -> Option<u32> {
     let t = token.trim();
     if t.is_empty() {
@@ -950,33 +929,7 @@ fn page_number_value(token: &str) -> Option<u32> {
     if t.chars().all(|c| c.is_ascii_digit()) && t.len() <= 4 {
         return t.parse().ok();
     }
-    // Roman numeral: accept only *canonical* forms so ordinary words made of
-    // {i,v,x,l,c} — "civil", "ill", "mix" — aren't mistaken for page numbers.
-    // Parse subtractively, then require the value to re-encode to the input.
-    let lower = t.to_ascii_lowercase();
-    if !lower.is_empty() && lower.len() <= 6 && lower.chars().all(|c| "ivxlc".contains(c)) {
-        let mut total = 0i32;
-        let mut prev = 0i32;
-        for c in lower.chars().rev() {
-            let v = match c {
-                'i' => 1,
-                'v' => 5,
-                'x' => 10,
-                'l' => 50,
-                'c' => 100,
-                _ => return None,
-            };
-            if v < prev {
-                total -= v;
-            } else {
-                total += v;
-                prev = v;
-            }
-        }
-        let value = u32::try_from(total).ok().filter(|&n| n > 0)?;
-        return (to_roman_lower(value) == lower).then_some(value);
-    }
-    None
+    super::canonical_roman_value(t)
 }
 
 /// Page-number-column TOC: title-based contents with no dot leaders and no
@@ -1039,7 +992,18 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
         return false;
     }
     let non_decreasing = page_vals.windows(2).filter(|w| w[1] >= w[0]).count();
-    (non_decreasing as f32) >= 0.7 * (page_vals.len() - 1) as f32
+    if (non_decreasing as f32) < 0.7 * (page_vals.len() - 1) as f32 {
+        return false;
+    }
+
+    // Stronger TOC signal: real page numbers SPAN the document — they skip
+    // (3, 6, 13, 24, …) so their range far exceeds the entry count. A dense
+    // ordinal / rank / ID column (1, 2, 3, …) has a range close to its length.
+    // Require the span to exceed the number of entries, which rejects those
+    // consecutive-sequence data tables that monotonicity alone would pass.
+    let min = *page_vals.iter().min().unwrap();
+    let max = *page_vals.iter().max().unwrap();
+    max.saturating_sub(min) > page_vals.len() as u32
 }
 
 /// Dot-leader TOC: any "Chapter 1 ........ 42" style with explicit leader
@@ -2024,6 +1988,22 @@ mod tests {
         assert_eq!(page_number_value("ix"), Some(9));
         assert_eq!(page_number_value("xii"), Some(12));
         assert_eq!(page_number_value("42"), Some(42));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_dense_ordinal_column() {
+        // Headerless title | rank table: values are a consecutive 1..n
+        // sequence (monotonic, no header, text first column) but their range
+        // ~= the row count, so it is data, not a table of contents.
+        let cells: Vec<Vec<String>> = vec![
+            vec!["Alice".into(), "1".into()],
+            vec!["Bob".into(), "2".into()],
+            vec!["Carol".into(), "3".into()],
+            vec!["Dave".into(), "4".into()],
+            vec!["Erin".into(), "5".into()],
+            vec!["Frank".into(), "6".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -996,14 +996,44 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
         return false;
     }
 
-    // Stronger TOC signal: real page numbers SPAN the document — they skip
-    // (3, 6, 13, 24, …) so their range far exceeds the entry count. A dense
-    // ordinal / rank / ID column (1, 2, 3, …) has a range close to its length.
-    // Require the span to exceed the number of entries, which rejects those
-    // consecutive-sequence data tables that monotonicity alone would pass.
+    // Stronger TOC signal. Real page numbers SPAN the document — entries skip
+    // (3, 6, 13, 24, …) so their range exceeds the entry count. A rank / ID /
+    // ordinal column is instead a *perfectly dense* consecutive run (1,2,3,… or
+    // 100,101,102,…). Accept anything with page gaps; for a dense run — which a
+    // one-page-per-entry TOC can also produce — fall back to a title signal:
+    // real contents entries are multi-word headings, rank labels are short.
     let min = *page_vals.iter().min().unwrap();
     let max = *page_vals.iter().max().unwrap();
-    max.saturating_sub(min) > page_vals.len() as u32
+    let span = max.saturating_sub(min);
+    if span > page_vals.len() as u32 {
+        return true;
+    }
+    let dense_consecutive = (span as usize) + 1 == page_vals.len() && {
+        let mut sorted = page_vals.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        sorted.len() == page_vals.len()
+    };
+    if !dense_consecutive {
+        // Narrow range but with a gap or repeat — still contents-like.
+        return true;
+    }
+    // Dense counter: only a TOC if the titles read like headings, not the
+    // short single-word labels typical of rank/leaderboard/ID tables.
+    let (total_words, titled_rows) = cells
+        .iter()
+        .filter_map(|row| row.first())
+        .filter(|c| c.chars().any(|ch| ch.is_alphabetic()))
+        .fold((0usize, 0usize), |(w, n), c| {
+            (
+                w + c
+                    .split_whitespace()
+                    .filter(|t| t.chars().any(|ch| ch.is_alphabetic()))
+                    .count(),
+                n + 1,
+            )
+        });
+    titled_rows > 0 && (total_words as f32) / titled_rows as f32 >= 1.8
 }
 
 /// Dot-leader TOC: any "Chapter 1 ........ 42" style with explicit leader
@@ -1988,6 +2018,21 @@ mod tests {
         assert_eq!(page_number_value("ix"), Some(9));
         assert_eq!(page_number_value("xii"), Some(12));
         assert_eq!(page_number_value("42"), Some(42));
+    }
+
+    #[test]
+    fn page_number_toc_matches_consecutive_pages_with_titles() {
+        // A short chapter-per-page contents: pages are a dense 1..n run, but
+        // the multi-word titles mark it as a real TOC (recovered by the title
+        // signal rather than rejected for lacking page gaps).
+        let cells: Vec<Vec<String>> = vec![
+            vec!["Introduction to the Study".into(), "1".into()],
+            vec!["Materials and Methods".into(), "2".into()],
+            vec!["Results and Discussion".into(), "3".into()],
+            vec!["Summary of Findings".into(), "4".into()],
+            vec!["References and Notes".into(), "5".into()],
+        ];
+        assert!(is_page_number_toc(&cells));
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -914,7 +914,109 @@ fn looks_like_number(s: &str) -> bool {
 ///
 /// Used by format.rs to render TOCs as flat lists instead of markdown tables.
 pub fn is_table_of_contents(cells: &[Vec<String>]) -> bool {
-    is_dot_leader_toc(cells) || is_tabular_toc(cells)
+    is_dot_leader_toc(cells) || is_tabular_toc(cells) || is_page_number_toc(cells)
+}
+
+/// Parse a page-number-like token: a short arabic integer (≤4 digits) or a
+/// lowercase/uppercase roman numeral (front-matter pages: i, ii, …, xii).
+fn page_number_value(token: &str) -> Option<u32> {
+    let t = token.trim();
+    if t.is_empty() {
+        return None;
+    }
+    if t.chars().all(|c| c.is_ascii_digit()) && t.len() <= 4 {
+        return t.parse().ok();
+    }
+    let lower = t.to_ascii_lowercase();
+    if !lower.is_empty() && lower.len() <= 6 && lower.chars().all(|c| "ivxlc".contains(c)) {
+        let mut total = 0i32;
+        let mut prev = 0i32;
+        for c in lower.chars().rev() {
+            let v = match c {
+                'i' => 1,
+                'v' => 5,
+                'x' => 10,
+                'l' => 50,
+                'c' => 100,
+                _ => return None,
+            };
+            if v < prev {
+                total -= v;
+            } else {
+                total += v;
+                prev = v;
+            }
+        }
+        return u32::try_from(total).ok().filter(|&n| n > 0);
+    }
+    None
+}
+
+/// Page-number-column TOC: title-based contents with no dot leaders and no
+/// section numbers (e.g. "About the Publisher  vii", "Experiment #1 …  3").
+/// The signature is a text-title first column and a last column that is almost
+/// entirely page numbers whose values are *mostly non-decreasing* — the
+/// monotonic run is what separates a real TOC from an incidental 2-column
+/// numeric data table.
+pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
+    let num_cols = cells.first().map(|r| r.len()).unwrap_or(0);
+    // A page-number TOC is a narrow list (title + page, optionally a leader
+    // column). Wider grids are data tables, not contents.
+    if !(2..=3).contains(&num_cols) || cells.len() < 5 {
+        return false;
+    }
+    let last = num_cols - 1;
+
+    // No header row: a TOC's first row is already an entry, so its last cell is
+    // a page number. A data table's first row is a column header (non-numeric) —
+    // the tell that separates "Mineral | CEC" tables from real contents.
+    let first_last = cells
+        .iter()
+        .find_map(|row| {
+            let c = row.get(last).map(|s| s.trim()).unwrap_or("");
+            (!c.is_empty()).then_some(c)
+        })
+        .unwrap_or("");
+    if page_number_value(first_last).is_none() {
+        return false;
+    }
+
+    // Last column: page numbers on ≥70% of filled rows; collect their values.
+    let mut filled = 0u32;
+    let mut page_vals: Vec<u32> = Vec::new();
+    for row in cells {
+        let cell = row.get(last).map(|s| s.trim()).unwrap_or("");
+        if cell.is_empty() {
+            continue;
+        }
+        filled += 1;
+        if let Some(v) = page_number_value(cell) {
+            page_vals.push(v);
+        }
+    }
+    if filled < 4 || (page_vals.len() as f32) < 0.7 * filled as f32 {
+        return false;
+    }
+
+    // First column: mostly text titles (has alphabetic content). This rejects
+    // numeric-vs-numeric grids.
+    let text_first = cells
+        .iter()
+        .filter(|row| {
+            row.first()
+                .is_some_and(|c| c.chars().any(|ch| ch.is_alphabetic()))
+        })
+        .count();
+    if (text_first as f32) < 0.6 * cells.len() as f32 {
+        return false;
+    }
+
+    // Page numbers mostly ascend (allow front-matter→body resets and noise).
+    if page_vals.len() < 2 {
+        return false;
+    }
+    let non_decreasing = page_vals.windows(2).filter(|w| w[1] >= w[0]).count();
+    (non_decreasing as f32) >= 0.7 * (page_vals.len() - 1) as f32
 }
 
 /// Dot-leader TOC: any "Chapter 1 ........ 42" style with explicit leader
@@ -1885,5 +1987,103 @@ mod tests {
         assert!(!starts_with_section_number("10.0%"));
         assert!(!starts_with_section_number(""));
         assert!(!starts_with_section_number("Hello world"));
+    }
+
+    #[test]
+    fn page_number_toc_matches_title_based_contents() {
+        // Title-left, page-number-right, no dot leaders, no section numbers.
+        let cells = vec![
+            vec!["About the Publisher".into(), "vii".into()],
+            vec!["About This Project".into(), "ix".into()],
+            vec!["Acknowledgments".into(), "xi".into()],
+            vec!["Experiment #1: Hydrostatic Pressure".into(), "3".into()],
+            vec!["Experiment #2: Bernoulli's Theorem".into(), "13".into()],
+            vec![
+                "Experiment #3: Energy Loss in Pipe Fittings".into(),
+                "24".into(),
+            ],
+        ];
+        assert!(is_page_number_toc(&cells));
+        assert!(is_table_of_contents(&cells));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_numeric_data_table() {
+        // Real 2-col data table: numeric first column, non-monotonic values.
+        let cells = vec![
+            vec!["101".into(), "45".into()],
+            vec!["102".into(), "12".into()],
+            vec!["103".into(), "88".into()],
+            vec!["104".into(), "7".into()],
+            vec!["105".into(), "63".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_non_monotonic_pages() {
+        // Text labels but the "page" column jumps around — a small data table,
+        // not a contents listing.
+        let cells = vec![
+            vec!["Apples".into(), "42".into()],
+            vec!["Oranges".into(), "7".into()],
+            vec!["Pears".into(), "91".into()],
+            vec!["Plums".into(), "3".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_header_row_data_table() {
+        // Real 2-col data table with a header row ("Mineral | CEC") and
+        // ascending values that mimic page numbers — the header tells us it
+        // is data, not contents.
+        let cells = vec![
+            vec![
+                "Mineral or colloid type".into(),
+                "CEC of pure colloid".into(),
+            ],
+            vec!["kaolinite".into(), "10".into()],
+            vec!["illite".into(), "30".into()],
+            vec!["montmorillonite".into(), "100".into()],
+            vec!["vermiculite".into(), "150".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_wide_data_grid() {
+        // A 4-column regional data table must not be read as a TOC even with a
+        // text first column and integer last column.
+        let cells = vec![
+            vec![
+                "REGIONS".into(),
+                "2007".into(),
+                "2010".into(),
+                "2016".into(),
+            ],
+            vec![
+                "National Capital Region".into(),
+                "9".into(),
+                "8".into(),
+                "5".into(),
+            ],
+            vec!["Cordillera".into(), "1".into(), "2".into(), "1".into()],
+            vec!["Ilocos Region".into(), "1".into(), "5".into(), "4".into()],
+            vec!["Cagayan Valley".into(), "1".into(), "3".into(), "5".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
+    }
+
+    #[test]
+    fn page_number_toc_needs_page_number_last_column() {
+        // Last column is prose, not page numbers.
+        let cells = vec![
+            vec!["Section A".into(), "see appendix".into()],
+            vec!["Section B".into(), "see notes".into()],
+            vec!["Section C".into(), "later".into()],
+            vec!["Section D".into(), "TBD".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
     }
 }

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -917,6 +917,29 @@ pub fn is_table_of_contents(cells: &[Vec<String>]) -> bool {
     is_dot_leader_toc(cells) || is_tabular_toc(cells) || is_page_number_toc(cells)
 }
 
+/// Canonical lowercase roman numeral for `n` (covers the i/v/x/l/c range).
+fn to_roman_lower(mut n: u32) -> String {
+    const TABLE: [(u32, &str); 9] = [
+        (100, "c"),
+        (90, "xc"),
+        (50, "l"),
+        (40, "xl"),
+        (10, "x"),
+        (9, "ix"),
+        (5, "v"),
+        (4, "iv"),
+        (1, "i"),
+    ];
+    let mut out = String::new();
+    for (val, sym) in TABLE {
+        while n >= val {
+            out.push_str(sym);
+            n -= val;
+        }
+    }
+    out
+}
+
 /// Parse a page-number-like token: a short arabic integer (≤4 digits) or a
 /// lowercase/uppercase roman numeral (front-matter pages: i, ii, …, xii).
 fn page_number_value(token: &str) -> Option<u32> {
@@ -927,6 +950,9 @@ fn page_number_value(token: &str) -> Option<u32> {
     if t.chars().all(|c| c.is_ascii_digit()) && t.len() <= 4 {
         return t.parse().ok();
     }
+    // Roman numeral: accept only *canonical* forms so ordinary words made of
+    // {i,v,x,l,c} — "civil", "ill", "mix" — aren't mistaken for page numbers.
+    // Parse subtractively, then require the value to re-encode to the input.
     let lower = t.to_ascii_lowercase();
     if !lower.is_empty() && lower.len() <= 6 && lower.chars().all(|c| "ivxlc".contains(c)) {
         let mut total = 0i32;
@@ -947,7 +973,8 @@ fn page_number_value(token: &str) -> Option<u32> {
                 prev = v;
             }
         }
-        return u32::try_from(total).ok().filter(|&n| n > 0);
+        let value = u32::try_from(total).ok().filter(|&n| n > 0)?;
+        return (to_roman_lower(value) == lower).then_some(value);
     }
     None
 }
@@ -968,15 +995,11 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     let last = num_cols - 1;
 
     // No header row: a TOC's first row is already an entry, so its last cell is
-    // a page number. A data table's first row is a column header (non-numeric) —
-    // the tell that separates "Mineral | CEC" tables from real contents.
-    let first_last = cells
-        .iter()
-        .find_map(|row| {
-            let c = row.get(last).map(|s| s.trim()).unwrap_or("");
-            (!c.is_empty()).then_some(c)
-        })
-        .unwrap_or("");
+    // a page number. A data table's first row is a column header (non-numeric,
+    // or an empty units cell like "Category | ") — the tell that separates
+    // "Mineral | CEC" tables from real contents. Check the actual first row,
+    // not the first non-empty one, so a blank header cell still rejects.
+    let first_last = cells[0].get(last).map(|s| s.trim()).unwrap_or("");
     if page_number_value(first_last).is_none() {
         return false;
     }
@@ -1990,6 +2013,34 @@ mod tests {
     }
 
     #[test]
+    fn page_number_value_rejects_roman_lookalike_words() {
+        // Ordinary words made only of {i,v,x,l,c} are not page numbers.
+        assert!(page_number_value("civil").is_none());
+        assert!(page_number_value("mix").is_none());
+        assert!(page_number_value("ill").is_none());
+        assert!(page_number_value("lil").is_none());
+        // Canonical roman numerals still parse.
+        assert_eq!(page_number_value("vii"), Some(7));
+        assert_eq!(page_number_value("ix"), Some(9));
+        assert_eq!(page_number_value("xii"), Some(12));
+        assert_eq!(page_number_value("42"), Some(42));
+    }
+
+    #[test]
+    fn page_number_toc_rejects_blank_header_cell() {
+        // First row is a header whose last cell is blank ("Category | ");
+        // must not be flattened even though later rows look TOC-like.
+        let cells = vec![
+            vec!["Category".into(), "".into()],
+            vec!["Alpha".into(), "3".into()],
+            vec!["Beta".into(), "9".into()],
+            vec!["Gamma".into(), "14".into()],
+            vec!["Delta".into(), "20".into()],
+        ];
+        assert!(!is_page_number_toc(&cells));
+    }
+
+    #[test]
     fn page_number_toc_matches_title_based_contents() {
         // Title-left, page-number-right, no dot leaders, no section numbers.
         let cells = vec![
@@ -2023,13 +2074,18 @@ mod tests {
     #[test]
     fn page_number_toc_rejects_non_monotonic_pages() {
         // Text labels but the "page" column jumps around — a small data table,
-        // not a contents listing.
-        let cells = vec![
+        // not a contents listing. 5 rows so the row-count guard passes and the
+        // monotonicity check is what does the rejecting.
+        let cells: Vec<Vec<String>> = vec![
             vec!["Apples".into(), "42".into()],
             vec!["Oranges".into(), "7".into()],
             vec!["Pears".into(), "91".into()],
             vec!["Plums".into(), "3".into()],
+            vec!["Grapes".into(), "60".into()],
         ];
+        // Sanity: this input clears the row-count and header guards, so a
+        // failure here is genuinely the monotonicity check.
+        assert!(cells.len() >= 5 && page_number_value(cells[0][1].trim()).is_some());
         assert!(!is_page_number_toc(&cells));
     }
 

--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -123,6 +123,7 @@ fn format_toc_as_list(cells: &[Vec<String>], footnotes: &[String]) -> String {
 
 /// True when the cell looks like a page number.  Accepts:
 ///   - plain digit tokens: "42", "86 86"
+///   - canonical roman numerals (front-matter pages): "vii", "ix", "xii"
 ///   - dashed section-page IDs: "5-21", "A-1", "B--3", "TC-2" (common in
 ///     technical manuals)
 fn is_page_number_cell(cell: &str) -> bool {
@@ -138,11 +139,45 @@ fn is_page_number_cell(cell: &str) -> bool {
         if all_digits {
             return t.len() <= 4;
         }
+        if is_canonical_roman(t) {
+            return true;
+        }
         // Section-page form: uppercase letters, digits, dashes; at least
         // one digit present.
         t.chars()
             .all(|c| c.is_ascii_digit() || c.is_ascii_uppercase() || c == '-')
             && t.chars().any(|c| c.is_ascii_digit())
+    })
+}
+
+/// True when `token` is a canonical lowercase/uppercase roman numeral in the
+/// i/v/x/l/c range (rejects ordinary words like "civil" or "mix").
+fn is_canonical_roman(token: &str) -> bool {
+    let lower = token.to_ascii_lowercase();
+    if lower.is_empty() || !lower.chars().all(|c| "ivxlc".contains(c)) {
+        return false;
+    }
+    const TABLE: [(u32, &str); 9] = [
+        (100, "c"),
+        (90, "xc"),
+        (50, "l"),
+        (40, "xl"),
+        (10, "x"),
+        (9, "ix"),
+        (5, "v"),
+        (4, "iv"),
+        (1, "i"),
+    ];
+    // Re-encode 1..=399 and check for an exact match.
+    (1..400u32).any(|mut n| {
+        let mut out = String::new();
+        for (val, sym) in TABLE {
+            while n >= val {
+                out.push_str(sym);
+                n -= val;
+            }
+        }
+        out == lower
     })
 }
 

--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -139,7 +139,7 @@ fn is_page_number_cell(cell: &str) -> bool {
         if all_digits {
             return t.len() <= 4;
         }
-        if is_canonical_roman(t) {
+        if super::canonical_roman_value(t).is_some() {
             return true;
         }
         // Section-page form: uppercase letters, digits, dashes; at least
@@ -147,37 +147,6 @@ fn is_page_number_cell(cell: &str) -> bool {
         t.chars()
             .all(|c| c.is_ascii_digit() || c.is_ascii_uppercase() || c == '-')
             && t.chars().any(|c| c.is_ascii_digit())
-    })
-}
-
-/// True when `token` is a canonical lowercase/uppercase roman numeral in the
-/// i/v/x/l/c range (rejects ordinary words like "civil" or "mix").
-fn is_canonical_roman(token: &str) -> bool {
-    let lower = token.to_ascii_lowercase();
-    if lower.is_empty() || !lower.chars().all(|c| "ivxlc".contains(c)) {
-        return false;
-    }
-    const TABLE: [(u32, &str); 9] = [
-        (100, "c"),
-        (90, "xc"),
-        (50, "l"),
-        (40, "xl"),
-        (10, "x"),
-        (9, "ix"),
-        (5, "v"),
-        (4, "iv"),
-        (1, "i"),
-    ];
-    // Re-encode 1..=399 and check for an exact match.
-    (1..400u32).any(|mut n| {
-        let mut out = String::new();
-        for (val, sym) in TABLE {
-            while n >= val {
-                out.push_str(sym);
-                n -= val;
-            }
-        }
-        out == lower
     })
 }
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -177,6 +177,60 @@ pub(crate) fn try_build_rect_guided_table(
     ))
 }
 
+/// Canonical lowercase roman numeral for `n` (the i/v/x/l/c range).
+pub(super) fn to_roman_lower(mut n: u32) -> String {
+    const TABLE: [(u32, &str); 9] = [
+        (100, "c"),
+        (90, "xc"),
+        (50, "l"),
+        (40, "xl"),
+        (10, "x"),
+        (9, "ix"),
+        (5, "v"),
+        (4, "iv"),
+        (1, "i"),
+    ];
+    let mut out = String::new();
+    for (val, sym) in TABLE {
+        while n >= val {
+            out.push_str(sym);
+            n -= val;
+        }
+    }
+    out
+}
+
+/// Parse a *canonical* roman numeral (i/v/x/l/c range, ≤8 chars) to its value.
+/// Returns `None` for non-canonical strings, so ordinary words made of those
+/// letters — "civil", "mix", "ill" — are not mistaken for numbers. Shared by
+/// the TOC detector and the TOC formatter so the two stay in sync.
+pub(super) fn canonical_roman_value(token: &str) -> Option<u32> {
+    let lower = token.trim().to_ascii_lowercase();
+    if lower.is_empty() || lower.len() > 8 || !lower.chars().all(|c| "ivxlc".contains(c)) {
+        return None;
+    }
+    let mut total = 0i32;
+    let mut prev = 0i32;
+    for c in lower.chars().rev() {
+        let v = match c {
+            'i' => 1,
+            'v' => 5,
+            'x' => 10,
+            'l' => 50,
+            'c' => 100,
+            _ => return None,
+        };
+        if v < prev {
+            total -= v;
+        } else {
+            total += v;
+            prev = v;
+        }
+    }
+    let value = u32::try_from(total).ok().filter(|&n| n > 0)?;
+    (to_roman_lower(value) == lower).then_some(value)
+}
+
 /// Split a TextItem whose text contains multiple whitespace-separated tokens
 /// (like "10 11 12 ... 31") into individual TextItems, each assigned to the
 /// nearest column boundary.


### PR DESCRIPTION
## Summary

A title-based table-of-contents page — `About the Publisher  vii`, `Experiment #1: Hydrostatic Pressure  3` — with no dot leaders and no section numbers was being detected as a 2-column data table and rendered as a markdown grid. That scrambles the page's linear reading order (a leading cause of reading-order/NID loss on those docs) and scores zero on table structure.

The codebase already renders detected TOCs as a flat per-row list (`TableKind::Toc` → `format_toc_as_list`), but `is_table_of_contents` only recognized dot-leader and section-numbered TOCs. This adds the missing **page-number-column** case.

`is_page_number_toc` matches a narrow (2–3 column) list where:
- the last column is page numbers (short integers or roman numerals) on ≥70% of rows, and those values are **mostly non-decreasing** (the monotonic run is what separates a contents list from an incidental numeric column),
- the first column is text titles,
- there is **no header row** — a TOC's first row is already an entry with a page number, whereas a data table opens with a column header.

The narrow-width, no-header, and monotonic guards keep real tables intact — verified on a 4-column regional data table and a 2-column `Mineral | CEC` table (header row + ascending values) that both correctly stay gridded.

## Impact (opendataloader-bench, 200 docs)

| Metric | Before | After |
|---|---|---|
| Overall | 0.830 | **0.834** |
| Reading order (NID) | 0.883 | **0.888** |
| Tables (TEDS) | 0.656 | 0.656 |
| Headings (MHS) | 0.736 | **0.742** |

NID (reading order) and MHS improve with **no TEDS regression** — the change removes phantom-table scrambling without touching real tables.

## Testing

- Unit tests: title-based TOC matches; a numeric data table, a non-monotonic label/number table, a prose last column, a **header-row** `Mineral | CEC` table, and a **4-column** regional grid all correctly rejected.
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass.
- Corpus FP sweep: table flattening only hits genuine contents/index pages (e.g. a financial-statements TOC in an annual report); real data tables are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misdetected page-number-only tables of contents by flattening them into lists instead of grids, restoring reading order. Benchmarks/docs updated: NID 0.89 (rounded); TEDS unchanged.

- **Bug Fixes**
  - Added `is_page_number_toc` and wired it into `is_table_of_contents`.
  - Detection: 2–3 cols; ≥5 rows; last col is page numbers (short ints or canonical roman ≤8 chars) on ≥70% of filled rows; values mostly non-decreasing; first col has text; no header row (checks the first row’s last cell). Accept any page sequence with a gap; for perfectly dense runs, flatten only when first-col titles read like multi‑word headings, otherwise keep as a table.
  - Shared `canonical_roman_value`/`to_roman_lower` in `tables::mod` and use them in both detector and `format::is_page_number_cell`; formatter now recognizes canonical roman numerals for clean title/page splits.
  - Guards keep real tables intact (e.g., 4‑col regional grid; 2‑col `Mineral | CEC` with header).

<sup>Written for commit 5a2bad71a1d2057bae524a0a9aee4ccd3845cb13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

