### PR TITLE
chore(napi): bump @firecrawl/pdf-inspector to 1.10.3

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Updates only `napi/package.json`, bumping `@firecrawl/pdf-inspector` from `1.10.2` to `1.10.3` so the latest changes on `main` can be published to npm.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@firecrawl/pdf-inspector` in `napi/package.json` from 1.10.2 to 1.10.3 to publish the latest changes on `main` to npm. No code or API changes.

<sup>Written for commit 69e47e01e7e30e68605b520fbb9fda3a7eb1a363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

