### PR TITLE
fix(ci): move x86_64 macOS wheel build to macos-15-intel

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -89,7 +89,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - os: macos-13
+          # macos-13 was retired by GitHub; macos-15-intel is the remaining
+          # Intel runner label (available through 2027).
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary

The first publish run from #123 got stuck: the `x86_64-apple-darwin` wheel build is pinned to `macos-13`, which GitHub has retired, so the job queued indefinitely and the PyPI publish never ran. Switch it to `macos-15-intel`, the remaining Intel runner label.

After merging, publish v0.2.1 via the workflow's `workflow_dispatch` fallback (the paths filter means this workflow-only change won't retrigger it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the x86_64 macOS wheel build from the retired `macos-13` runner to `macos-15-intel`. This fixes the stuck CI job and unblocks the PyPI publish.

- **Migration**
  - After merge, trigger the “Publish PyPI” workflow via `workflow_dispatch` to publish v0.2.1.
  - Note: this workflow-only change won’t auto-trigger due to the paths filter.

<sup>Written for commit 99430bf970b3f34d183b07b94cde38f443cb8886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

