### PR TITLE
chore(napi): bump @firecrawl/pdf-inspector to 1.10.4

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Ships #145 (exclusive item→region assignment). Pairs with firecrawl/fire-pdf#461 (assembly-side sweep dedup/salvage), which lands after this publishes + the fire-pdf dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3U6BKYCS73DVA83odAfYB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@firecrawl/pdf-inspector` to 1.10.4 to ship exclusive item-to-region assignment in extract_text_in_regions. Addresses Linear #145 by preventing double extraction in overlapping regions, reducing duplicate lines and avoiding occasional content loss.

<sup>Written for commit 9397cbfad62c55d4e76deb9f5dd33d1ee1494749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

