### PR TITLE
feat(pypi): add package readme and project URLs (0.2.2)

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -1,8 +1,16 @@
-# Python API
+# pdf-inspector
 
-Python bindings via [PyO3](https://pyo3.rs). Requires Rust toolchain for building from source.
+Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Python bindings via [PyO3](https://pyo3.rs) for the [pdf-inspector](https://github.com/firecrawl/pdf-inspector) Rust library.
+
+Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
 
 ## Install
+
+```bash
+pip install pdf-inspector
+```
+
+Prebuilt wheels cover CPython ≥3.8 on Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x64). Other platforms build from source, which requires a Rust toolchain. For local development in a repo checkout:
 
 ```bash
 pip install maturin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ build-backend = "maturin"
 name = "pdf-inspector"
 # Bump this to publish to PyPI — CI publishes automatically when the version
 # changes on main (same flow as napi/package.json for npm).
-version = "0.2.1"
+version = "0.2.2"
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
+readme = "docs/python.md"
 license = { text = "MIT" }
 requires-python = ">=3.8"
 classifiers = [
@@ -18,6 +19,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Text Processing",
 ]
+
+[project.urls]
+Homepage = "https://github.com/firecrawl/pdf-inspector"
+Repository = "https://github.com/firecrawl/pdf-inspector"
+Documentation = "https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md"
 
 [tool.maturin]
 features = ["python"]


### PR DESCRIPTION
## Summary

PyPI shows an empty project description for `pdf-inspector` because `pyproject.toml` declares no `readme`. This PR:

- Points `readme` at `docs/python.md` so PyPI renders a real project page (verified locally: sdist `PKG-INFO` embeds it as GFM with `Description-Content-Type: text/markdown`).
- Refreshes `docs/python.md`: intro paragraph, `pip install pdf-inspector` with wheel coverage (the old instructions were maturin-from-source only), keeps the dev setup.
- Adds `[project.urls]` (Homepage/Repository/Documentation) for the PyPI sidebar.
- Bumps version to **0.2.2** — PyPI files are immutable, so the description only shows up with a new release. Merging auto-publishes via the pyproject.toml paths trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a package `readme` and project URLs so PyPI shows a complete page for `pdf-inspector`.
Point `readme` to `docs/python.md` (updated with pip install and wheel coverage) and bump version to 0.2.2 to publish.

<sup>Written for commit d0911fe1b3dbf49ed08afc92bf32e4bb09d748c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

