### PR TITLE
docs(pypi): reformat Types section as stub-style code block (0.2.3)

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -81,16 +81,51 @@ result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 
 ## Types
 
-**`PdfResult` fields:** `pdf_type`, `markdown`, `page_count`, `processing_time_ms`, `pages_needing_ocr`, `title`, `confidence`, `is_complex_layout`, `pages_with_tables`, `pages_with_columns`, `has_encoding_issues`
+Type stubs (`pdf_inspector.pyi`) ship with the package. Result types at a glance:
 
-**`PdfClassification` fields:** `pdf_type`, `page_count`, `pages_needing_ocr` (0-indexed), `confidence`
+```python
+class PdfResult:                     # process_pdf / detect_pdf
+    pdf_type: str                    # "text_based" | "scanned" | "image_based" | "mixed"
+    markdown: str | None             # extracted Markdown (None for detect_pdf)
+    page_count: int
+    processing_time_ms: int
+    pages_needing_ocr: list[int]
+    title: str | None
+    confidence: float                # 0.0 - 1.0
+    is_complex_layout: bool
+    pages_with_tables: list[int]
+    pages_with_columns: list[int]
+    has_encoding_issues: bool        # broken font encodings — consider OCR fallback
 
-**`TextItem` fields:** `text`, `x`, `y`, `width`, `height`, `font`, `font_size`, `page`, `is_bold`, `is_italic`, `item_type`
+class PdfClassification:             # classify_pdf
+    pdf_type: str
+    page_count: int
+    pages_needing_ocr: list[int]     # 0-indexed
+    confidence: float
 
-**`RegionText` fields:** `text`, `needs_ocr`
+class TextItem:                      # extract_text_with_positions
+    text: str
+    x: float
+    y: float
+    width: float
+    height: float
+    font: str
+    font_size: float
+    page: int
+    is_bold: bool
+    is_italic: bool
+    is_underline: bool
+    is_strikeout: bool
+    item_type: str
 
-**`PageRegionTexts` fields:** `page` (0-indexed), `regions` (list of RegionText)
+class PageRegionTexts:               # extract_text_in_regions
+    page: int                        # 0-indexed
+    regions: list[RegionText]        # RegionText: text: str, needs_ocr: bool
 
-**`PageMarkdown` fields:** `page` (0-indexed), `markdown`, `needs_ocr`
-
-**`PagesExtractionResult` fields:** `pages` (list of PageMarkdown), `pages_with_tables` (1-indexed), `pages_with_columns` (1-indexed), `pages_needing_ocr` (1-indexed), `is_complex`
+class PagesExtractionResult:         # extract_pages_markdown
+    pages: list[PageMarkdown]        # PageMarkdown: page (0-indexed), markdown, needs_ocr
+    pages_with_tables: list[int]     # 1-indexed
+    pages_with_columns: list[int]    # 1-indexed
+    pages_needing_ocr: list[int]     # 1-indexed
+    is_complex: bool                 # any page has tables or multi-column layout
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "pdf-inspector"
 # Bump this to publish to PyPI — CI publishes automatically when the version
 # changes on main (same flow as napi/package.json for npm).
-version = "0.2.2"
+version = "0.2.3"
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
 readme = "docs/python.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

The **Types** section on the [PyPI page](https://pypi.org/project/pdf-inspector/#description) renders poorly — each type is a bold label followed by a long comma-separated run of backticked field names, which turns into cramped walls of inline code.

- Replace it with a single ```python code block mirroring `pdf_inspector.pyi`: field names, types, and short comments (index base, value ranges, which function returns what).
- Adds the `is_underline` / `is_strikeout` `TextItem` fields that the docs page was missing.
- Bumps to **0.2.3** so the new description publishes (PyPI descriptions are frozen per release); merging auto-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted the PyPI “Types” section into a single stub-style Python code block mirroring `pdf_inspector.pyi` for clearer docs, and added the missing `is_underline` and `is_strikeout` fields to `TextItem`. Bumps `pdf-inspector` to 0.2.3 so the updated description publishes on PyPI.

<sup>Written for commit b51298439079de95b25279473b325d0121c80ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

