### PR TITLE
docs(crate): Rust-specific readme for crates.io (0.1.5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pdf-inspector"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 autobins = false
 authors = ["Firecrawl Team"]
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
 license = "MIT"
 repository = "https://github.com/firecrawl/pdf-inspector"
+readme = "docs/rust-api.md"
 
 [lib]
 name = "pdf_inspector"

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -1,10 +1,26 @@
-# Rust API
+# pdf-inspector
 
-Add to your `Cargo.toml`:
+Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Pure Rust, no ML models, no external services; the only PDF dependency is [lopdf](https://crates.io/crates/lopdf). Also available for [Python](https://pypi.org/project/pdf-inspector/) and [Node.js](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
+
+Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
+
+## Install
+
+```bash
+cargo add pdf-inspector
+```
+
+For the latest unreleased changes, use the git dependency instead:
 
 ```toml
 [dependencies]
 pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector" }
+```
+
+The crate also ships CLI binaries — `pdf2md` (PDF → Markdown, with `--json`, `--pages`, `--select-pages`) and `detect-pdf` (classification, with `--analyze --json`):
+
+```bash
+cargo install pdf-inspector
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Same treatment the PyPI page got: [crates.io/crates/pdf-inspector](https://crates.io/crates/pdf-inspector) currently renders the repo README, which leads with Python/Node quick starts and has repo-relative links that break off-GitHub. This PR gives the crate a Rust-specific page:

- `readme = "docs/rust-api.md"` in `Cargo.toml` — the existing Rust API doc, refreshed: intro paragraph, `cargo add pdf-inspector` install (was git-dependency only), CLI binaries install, links to the PyPI/npm siblings.
- Bump crate version to **0.1.5** — crates.io readmes are frozen per release; merging auto-publishes via `publish-crate.yml`.

## Verification

- `cargo package` builds and verifies the 0.1.5 crate; `docs/rust-api.md` is included in the archive and the packaged `Cargo.toml` carries the readme field.
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the crate readme to a Rust-focused `docs/rust-api.md` so crates.io shows correct content, including `cargo add` and CLI (`pdf2md`, `detect-pdf`) instructions. Bump `pdf-inspector` to 0.1.5 to republish the updated readme.

<sup>Written for commit fc4bd3771f9e139b5d6e0fd858e73e013cd4d7af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

