### PR TITLE
fix(crate): allowlist package contents to fit crates.io size cap

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     paths: ['Cargo.toml']
+  # Manual fallback: retry a publish that failed after the version was
+  # already merged (a plain re-push won't register as a version change).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,6 +17,10 @@ env:
 jobs:
   check-version:
     name: Check version change
+    # Guard manual dispatches: crates.io trusted publishing matches
+    # repo+workflow+environment but NOT branch, so without this a
+    # workflow_dispatch from any branch could publish unmerged code.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
@@ -28,17 +35,26 @@ jobs:
         id: check
         run: |
           NEW_VERSION=$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["package"]["version"])')
-          OLD_VERSION=$(git show HEAD~1:Cargo.toml | python3 -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["package"]["version"])')
-          echo "old=$OLD_VERSION new=$NEW_VERSION"
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-          if [ "$NEW_VERSION" = "$OLD_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual dispatch publishes the current version regardless of the
+            # previous commit; the crates.io check below still prevents
+            # double-publishing an already-released version.
+            echo "manual dispatch: publishing v$NEW_VERSION"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            OLD_VERSION=$(git show HEAD~1:Cargo.toml | python3 -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["package"]["version"])')
+            echo "old=$OLD_VERSION new=$NEW_VERSION"
 
-          echo "changed=true" >> "$GITHUB_OUTPUT"
+            if [ "$NEW_VERSION" = "$OLD_VERSION" ]; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              echo "published=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
           HTTP_STATUS=$(curl --silent --show-error --output /tmp/crate-version.json --write-out "%{http_code}" \
             -H "User-Agent: firecrawl/pdf-inspector publish workflow (https://github.com/firecrawl/pdf-inspector)" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,15 @@ description = "Fast PDF inspection, classification, and text extraction with sma
 license = "MIT"
 repository = "https://github.com/firecrawl/pdf-inspector"
 readme = "docs/rust-api.md"
+# Explicit allowlist: crates.io caps uploads at 10 MiB and tests/fixtures
+# alone exceeds that. external/bcmaps ships in the crate — tounicode.rs
+# loads it at runtime relative to CARGO_MANIFEST_DIR.
+include = [
+    "src/**",
+    "external/bcmaps/**",
+    "docs/rust-api.md",
+    "LICENSE",
+]
 
 [lib]
 name = "pdf_inspector"


### PR DESCRIPTION
## Summary

The 0.1.5 crate publish from #151 failed with **413 Payload Too Large**: with no `include`/`exclude`, cargo packaged the whole repo (260 files, 10.1 MiB compressed vs the 10 MiB cap) — `tests/fixtures` alone is 10.2 MB, and recent fixture additions pushed it over.

- **Explicit `include` allowlist** in `Cargo.toml`: `src/**`, `external/bcmaps/**` (loaded at runtime by `tounicode.rs` relative to `CARGO_MANIFEST_DIR`, so it must ship), `docs/rust-api.md`, `LICENSE`. Result: 211→174 files… 3.3 MiB / **1.3 MiB compressed**. Future fixture PDFs can never break publishing again.
- **`workflow_dispatch` fallback** in `publish-crate.yml` (same pattern as publish-pypi.yml, incl. main-only branch guard): 0.1.5 is already merged, so a re-push won't register as a version change — after this merges, publish is triggered manually. The crates.io already-published check still guards against double-publishing.

## Verification

- `cargo package` builds and verifies the packaged crate; archive contains src (incl. bins), bcmaps, readme, license.
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crates.io publish failure by allowlisting crate contents to stay under the 10 MiB upload cap. Also adds a safe manual publish path in CI to retry failed publishes without bumping the version.

- **Bug Fixes**
  - Add explicit `include` in `Cargo.toml`: `src/**`, `external/bcmaps/**`, `docs/rust-api.md`, `LICENSE`.
  - Exclude large `tests/fixtures/**`; package is ~3.3 MiB (1.3 MiB compressed).
  - Keep `external/bcmaps/**` for runtime use by `tounicode.rs`.

- **New Features**
  - Add `workflow_dispatch` to `.github/workflows/publish-crate.yml` to manually publish the current version.
  - Restrict manual runs to `main`; crates.io check still blocks double-publish.

<sup>Written for commit 5841efea35540c4b073389490892d51d136a5bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

