### PR TITLE
fix(pypi): slim sdist and keep type stub in it (0.2.4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ include = [
     "external/bcmaps/**",
     "docs/rust-api.md",
     "LICENSE",
+    # maturin derives the sdist file list from this allowlist; the stub must
+    # ship so wheels built from the sdist keep their type hints.
+    "pdf_inspector.pyi",
 ]
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "pdf-inspector"
 # Bump this to publish to PyPI — CI publishes automatically when the version
 # changes on main (same flow as napi/package.json for npm).
-version = "0.2.3"
+version = "0.2.4"
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
 readme = "docs/python.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Follow-up to #152: maturin derives the sdist file list from Cargo's `include` allowlist, so the sdist drops from **10.09 MiB → 1.35 MiB** for free. But the allowlist omitted `pdf_inspector.pyi`, so wheels built **from the sdist** (source-build platforms) would silently lose type hints — CI wheels were unaffected. Add the stub to the allowlist and bump to **0.2.4** to ship the slim sdist; merging auto-publishes.

## Verification

- Rebuilt sdist: 1.35 MiB, contains `src/`, `external/bcmaps/`, `pdf_inspector.pyi`, `docs/python.md` (readme), `Cargo.{toml,lock}`.
- `pip install <sdist>` in a clean venv compiles successfully; extraction works and the installed wheel contains the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slim the Python sdist to 1.35 MiB by deriving files from Cargo’s include allowlist used by `maturin`. Bump to 0.2.4 for release.

- **Bug Fixes**
  - Include `pdf_inspector.pyi` in the Cargo `include` list so wheels built from the sdist keep type hints.
  - Verified `pip install` from the sdist compiles and the installed wheel includes the stub.

<sup>Written for commit 80074e4683ae747f56dafd2f9231bcc95e53092d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

