### PR TITLE
feat(npm): split platform binaries into optionalDependencies (1.11.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     paths: ['napi/package.json']
+  # Manual fallback: retry a publish that failed partway (per-package
+  # already-published checks make re-runs idempotent).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,6 +15,10 @@ permissions:
 jobs:
   check-version:
     name: Check version change
+    # Guard manual dispatches: npm trusted publishing matches
+    # repo+workflow+environment but NOT branch, so without this a
+    # workflow_dispatch from any branch could publish unmerged code.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
@@ -25,11 +32,21 @@ jobs:
         id: check
         run: |
           NEW_VERSION=$(node -p "require('./napi/package.json').version")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual dispatch rebuilds and publishes the current version; the
+            # per-package already-published checks in the publish job skip
+            # anything that made it out in a previous partial run.
+            echo "manual dispatch: publishing v$NEW_VERSION"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           OLD_VERSION=$(git show HEAD~1:napi/package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
           echo "old=$OLD_VERSION new=$NEW_VERSION"
           if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
@@ -115,14 +132,81 @@ jobs:
         with:
           path: napi/artifacts
 
-      - name: Collect binaries and publish
+      - name: Publish platform packages
         working-directory: napi
         run: |
-          cp artifacts/bindings-*/*.node .
+          VERSION="${{ needs.check-version.outputs.version }}"
+
+          for node_file in artifacts/bindings-*/pdf-inspector.*.node; do
+            base=$(basename "$node_file")
+            suffix=${base#pdf-inspector.}
+            suffix=${suffix%.node}
+            pkg="@firecrawl/pdf-inspector-$suffix"
+
+            if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
+              echo "$pkg@$VERSION already published — skipping"
+              continue
+            fi
+
+            dir="npm-dist/$suffix"
+            mkdir -p "$dir"
+            cp "$node_file" "$dir/"
+            node -e '
+              const [suffix, version] = process.argv.slice(1)
+              const meta = {
+                "linux-x64-gnu":  { os: ["linux"],  cpu: ["x64"], libc: ["glibc"] },
+                "darwin-arm64":   { os: ["darwin"], cpu: ["arm64"] },
+                "win32-x64-msvc": { os: ["win32"],  cpu: ["x64"] },
+              }[suffix]
+              if (!meta) {
+                console.error(`unknown platform suffix: ${suffix} — add it to the meta map`)
+                process.exit(1)
+              }
+              const pkg = {
+                name: `@firecrawl/pdf-inspector-${suffix}`,
+                version,
+                description: `Prebuilt ${suffix} binary for @firecrawl/pdf-inspector`,
+                main: `pdf-inspector.${suffix}.node`,
+                files: [`pdf-inspector.${suffix}.node`],
+                license: "MIT",
+                engines: { node: ">= 10" },
+                repository: { type: "git", url: "https://github.com/firecrawl/pdf-inspector" },
+                publishConfig: { access: "public" },
+                ...meta,
+              }
+              require("fs").writeFileSync(`npm-dist/${suffix}/package.json`, JSON.stringify(pkg, null, 2) + "\n")
+            ' "$suffix" "$VERSION"
+
+            echo "=== $pkg@$VERSION ==="
+            ls -la "$dir"
+            (cd "$dir" && npm publish --provenance --access public)
+          done
+
+      - name: Publish main package
+        working-directory: napi
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+
+          if npm view "@firecrawl/pdf-inspector@$VERSION" version >/dev/null 2>&1; then
+            echo "@firecrawl/pdf-inspector@$VERSION already published — skipping"
+            exit 0
+          fi
+
           cp artifacts/js-bindings/index.js .
           cp artifacts/js-bindings/index.d.ts .
 
-          echo "=== Package contents ==="
-          ls -la *.node index.js index.d.ts
+          # Stamp optionalDependencies to this exact version so the platform
+          # pins can never drift from the main package version.
+          node -e '
+            const fs = require("fs")
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"))
+            for (const dep of Object.keys(pkg.optionalDependencies ?? {})) {
+              pkg.optionalDependencies[dep] = pkg.version
+            }
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n")
+          '
+
+          echo "=== Main package contents ==="
+          npm pack --dry-run
 
           npm publish --provenance --access public

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "env_logger",
  "log",

--- a/napi/README.md
+++ b/napi/README.md
@@ -12,7 +12,7 @@ npm install @firecrawl/pdf-inspector
 bun add @firecrawl/pdf-inspector
 ```
 
-Prebuilt binaries included for **linux-x64** and **macOS ARM64**. No Rust toolchain needed.
+Prebuilt binaries for **Linux x64**, **macOS ARM64**, and **Windows x64** — npm installs only the one matching your platform. No Rust toolchain needed.
 
 ## API
 
@@ -90,10 +90,13 @@ interface RegionText {
 
 ## Platforms
 
-| Platform | Architecture | Supported |
-|----------|-------------|-----------|
-| Linux    | x64         | Yes       |
-| macOS    | ARM64       | Yes       |
+Prebuilt binaries ship as platform-specific packages installed automatically via `optionalDependencies`:
+
+| Platform | Architecture | Package |
+|----------|-------------|---------|
+| Linux    | x64 (glibc) | `@firecrawl/pdf-inspector-linux-x64-gnu` |
+| macOS    | ARM64       | `@firecrawl/pdf-inspector-darwin-arm64` |
+| Windows  | x64         | `@firecrawl/pdf-inspector-win32-x64-msvc` |
 
 ## License
 

--- a/napi/bun.lock
+++ b/napi/bun.lock
@@ -7,6 +7,11 @@
       "devDependencies": {
         "@napi-rs/cli": "^3.4.1",
       },
+      "optionalDependencies": {
+        "@firecrawl/pdf-inspector-darwin-arm64": "1.11.0",
+        "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.0",
+        "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.0",
+      },
     },
   },
   "packages": {

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -22,7 +22,6 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "*.node",
     "bin/",
     "README.md"
   ],
@@ -51,5 +50,10 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.4.1"
+  },
+  "optionalDependencies": {
+    "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.0",
+    "@firecrawl/pdf-inspector-darwin-arm64": "1.11.0",
+    "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.0"
   }
 }

--- a/napi/package.json
+++ b/napi/package.json
@@ -39,10 +39,7 @@
       "x86_64-unknown-linux-gnu",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc"
-    ],
-    "package": {
-      "name": "@firecrawl/pdf-inspector-js"
-    }
+    ]
   },
   "scripts": {
     "build": "napi build --platform --release",


### PR DESCRIPTION
## Summary

`@firecrawl/pdf-inspector` ships all three platform binaries in one package — **17.6 MB unpacked**, so every install downloads every platform's binary. This splits it the standard napi-rs way:

- **3 platform packages** (`@firecrawl/pdf-inspector-linux-x64-gnu` / `-darwin-arm64` / `-win32-x64-msvc`), each containing only its `.node` binary with `os`/`cpu`(/`libc`) fields so npm installs exactly one. Generated and published by the workflow — names match the napi-generated loader's existing `require` fallbacks.
- **Main package** drops `*.node` from `files` → **8.5 kB tarball / 44.8 kB unpacked**, and pins the platform packages as `optionalDependencies`. The publish job re-stamps the pins to the exact version so they can never drift on future bumps.
- **Workflow hardening**: `workflow_dispatch` fallback (main-only guard, same as crates/PyPI) and per-package `npm view` already-published checks, so a partial release is retryable idempotently.

## Verification (local, darwin-arm64)

- Built the addon; generated loader falls back to `@firecrawl/pdf-inspector-darwin-arm64`. `npm pack --dry-run`: main tarball = index.js, index.d.ts, bin/, README (no binaries).
- Simulated the workflow's platform-package generation, packed both tarballs, installed them in a clean project: `processPdf` returns identical output to the bundled 1.10.4 (11,118 md chars on the fixture), binary resolves from the platform package, and the `pdf-inspector` CLI bin works.
- `bun install` with a cold cache succeeds while the platform packages are still unpublished (optional deps tolerated), so the build job has no chicken-and-egg problem.

## ⚠️ One-time setup before this can publish

npm **trusted publishing can't create brand-new packages** — the 3 platform packages must exist and have this workflow configured as trusted publisher on npmjs.com before the publish job can succeed. See PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `@firecrawl/pdf-inspector` into platform-specific binary packages listed as `optionalDependencies`, so installs fetch only the needed binary and the main tarball is ~8.5 kB. Hardened the publish workflow with per-package checks, exact version pinning, and a manual retry path.

- **Refactors**
  - Added `@firecrawl/pdf-inspector-{linux-x64-gnu,darwin-arm64,win32-x64-msvc}` packages, each shipping a single `.node` with proper `os`/`cpu`/`libc`.
  - Main package drops `*.node` from `files` and pins the platform packages in `optionalDependencies` to the exact version at publish.
  - Publish flow: guards `workflow_dispatch` to `main`, skips already-published packages, publishes platforms first, then the main package.
  - Docs: README now lists Windows support and the platform package mapping; removed stale `napi.package.name` to align with loader/package names.

- **Migration**
  - Pre-create the three platform packages on npm and enable trusted publishing for this workflow before the first release.

<sup>Written for commit 20d6540fb55f352cb403277e05effeb111834258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

