### PR TITLE
docs(registries): add Features and benchmark to crates.io/PyPI/npm pages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf-inspector"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 autobins = false
 authors = ["Firecrawl Team"]

--- a/docs/python.md
+++ b/docs/python.md
@@ -4,6 +4,26 @@ Fast PDF classification and text extraction. Detects whether a PDF is text-based
 
 Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
 
+## Features
+
+- **Smart classification** — `text_based` / `scanned` / `image_based` / `mixed` in ~10–50ms, with a confidence score and per-page OCR routing.
+- **Markdown conversion** — headings, lists, code blocks, bold/italic, URL linking, and dual-mode table detection (PDF drawing ops + text-alignment heuristics).
+- **Layout-aware extraction** — multi-column reading order, position and font info per text item, RTL support.
+- **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
+- **Lightweight** — native Rust core, no ML models, no external services; ships type stubs.
+
+## Benchmark
+
+[opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs), direct-extraction engines only — no OCR, no ML. Scores 0–1, higher is better:
+
+| Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
+|---|---|---|---|---|---|
+| **pdf-inspector** | 0.83 | 0.88 | **0.66** | 0.74 | **4s** |
+| opendataloader | 0.84 | 0.91 | 0.49 | 0.74 | 11s |
+| pymupdf4llm | 0.73 | 0.89 | 0.40 | 0.41 | 18s |
+
+OCR/ML engines (docling, marker, mineru) score 0.83–0.88 overall but take 2–180 minutes on the same corpus. Full numbers in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+
 ## Install
 
 ```bash

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -4,6 +4,26 @@ Fast PDF classification and text extraction. Detects whether a PDF is text-based
 
 Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
 
+## Features
+
+- **Smart classification** — TextBased / Scanned / ImageBased / Mixed in ~10–50ms, with a confidence score and per-page OCR routing.
+- **Markdown conversion** — headings, lists, code blocks, bold/italic, URL linking, and dual-mode table detection (PDF drawing ops + text-alignment heuristics).
+- **Layout-aware extraction** — multi-column reading order, position and font info per text item, RTL support.
+- **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
+- **Lightweight** — pure Rust, no ML models, no external services; single PDF dependency ([lopdf](https://crates.io/crates/lopdf)).
+
+## Benchmark
+
+[opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs), direct-extraction engines only — no OCR, no ML. Scores 0–1, higher is better:
+
+| Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
+|---|---|---|---|---|---|
+| **pdf-inspector** | 0.83 | 0.88 | **0.66** | 0.74 | **4s** |
+| opendataloader | 0.84 | 0.91 | 0.49 | 0.74 | 11s |
+| pymupdf4llm | 0.73 | 0.89 | 0.40 | 0.41 | 18s |
+
+OCR/ML engines (docling, marker, mineru) score 0.83–0.88 overall but take 2–180 minutes on the same corpus. Full numbers in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+
 ## Install
 
 ```bash

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger",
  "log",

--- a/napi/README.md
+++ b/napi/README.md
@@ -4,6 +4,26 @@ Fast PDF classification and region-based text extraction for Node.js/Bun. Native
 
 Built by [Firecrawl](https://firecrawl.dev) for hybrid OCR pipelines — extract text from PDF structure where possible, fall back to OCR only when needed.
 
+## Features
+
+- **Smart classification** — text-based / scanned / image-based / mixed in ~10–50ms, with a confidence score and per-page OCR routing.
+- **Region-based extraction** — pull text from bounding boxes with per-region quality checks (`needsOcr`).
+- **Layout-aware** — multi-column reading order, position and font info per text item, RTL support.
+- **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
+- **Lightweight** — native Rust core via napi-rs, no ML models, no external services; ~5–6 MB platform binary, TypeScript definitions included.
+
+## Benchmark
+
+[opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs), direct-extraction engines only — no OCR, no ML. Scores 0–1, higher is better:
+
+| Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
+|---|---|---|---|---|---|
+| **pdf-inspector** | 0.83 | 0.88 | **0.66** | 0.74 | **4s** |
+| opendataloader | 0.84 | 0.91 | 0.49 | 0.74 | 11s |
+| pymupdf4llm | 0.73 | 0.89 | 0.40 | 0.41 | 18s |
+
+OCR/ML engines (docling, marker, mineru) score 0.83–0.88 overall but take 2–180 minutes on the same corpus. Full numbers in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+
 ## Install
 
 ```bash

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -49,8 +49,8 @@
     "@napi-rs/cli": "^3.4.1"
   },
   "optionalDependencies": {
-    "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.0",
-    "@firecrawl/pdf-inspector-darwin-arm64": "1.11.0",
-    "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.0"
+    "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.1",
+    "@firecrawl/pdf-inspector-darwin-arm64": "1.11.1",
+    "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.1"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "pdf-inspector"
 # Bump this to publish to PyPI — CI publishes automatically when the version
 # changes on main (same flow as napi/package.json for npm).
-version = "0.2.4"
+version = "0.2.5"
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
 readme = "docs/python.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

The registry home pages jump straight from intro to install with nothing on what the library does or how it performs. Adds a concise **Features** list (5 bullets, adapted per ecosystem — e.g. region extraction + `needsOcr` on npm, type stubs on PyPI) and a compact **Benchmark** table (top 3 direct-extraction engines from opendataloader-bench, with the OCR/ML context line and a link to the full repo table) to:

- `docs/rust-api.md` (crates.io)
- `docs/python.md` (PyPI)
- `napi/README.md` (npm)

Bumps all three versions — crate **0.1.6**, python **0.2.5**, npm **1.11.1** (optionalDependencies pins updated in lockstep) — since registry pages are frozen per release. Merging triggers all three publish workflows in one push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear Features and Benchmark sections to the crates.io, PyPI, and npm readme pages so users can see capabilities and performance before install. Also bumps versions to republish all three registry pages in one push.

- Features list is tailored per ecosystem (e.g., region extraction + `needsOcr` on npm, type stubs on PyPI, pure Rust with `lopdf` on crates.io), plus a compact benchmark table comparing top direct-extraction engines with a link to full results.

**Dependencies**
- Rust crate `pdf-inspector` → 0.1.6
- Python `pdf-inspector` → 0.2.5
- npm `@firecrawl/pdf-inspector` → 1.11.1; platform packages pinned to `1.11.1` (`@firecrawl/pdf-inspector-linux-x64-gnu`, `@firecrawl/pdf-inspector-darwin-arm64`, `@firecrawl/pdf-inspector-win32-x64-msvc`)

<sup>Written for commit fee66fb277baba67eaaf68c77a069f62dc4f5f22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

