### PR TITLE
docs(tables): document the stacked-box 6-rect precision gate

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -3820,7 +3820,7 @@ mod tests {
         // corpus gains — too few boxes for the anti-prose guards to work.
         // If this ever becomes worth revisiting, the guards need stronger
         // signals first; flipping this assertion is the entry point.
-        let rects: Vec<PdfRect> = (0..3)
+        let mut rects: Vec<PdfRect> = (0..3)
             .map(|i| PdfRect {
                 x: 100.0,
                 y: 600.0 - i as f32 * 22.0,
@@ -3829,6 +3829,18 @@ mod tests {
                 page: 1,
             })
             .collect();
+        // Unrelated scattered rects push the page past the 6-rect page gate
+        // so the run reaches clustering, while the 3-box stack itself stays
+        // below the 6-rect cluster minimum.
+        for i in 0..4 {
+            rects.push(PdfRect {
+                x: 100.0 + i as f32 * 120.0,
+                y: 100.0,
+                width: 40.0,
+                height: 15.0,
+                page: 1,
+            });
+        }
         let items: Vec<TextItem> = ["Step One: Plan", "Step Two: Build", "Step Three: Ship"]
             .iter()
             .enumerate()

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -493,6 +493,14 @@ pub fn detect_tables_from_rects(
         }
     }
 
+    // NOTE: 3-5 box stacks never reach detect_stacked_box_table — the main
+    // loop requires >=6-rect clusters (and a >=6-rect page). This is a
+    // deliberate precision gate: routing smaller clusters through the
+    // detector was tried and regressed four pdf-evals documents (striped
+    // bullet lists, wrapped regulation text, stats-table columns) while
+    // improving nothing — with so few boxes the anti-prose guards have too
+    // little signal to discriminate. See stacked_box_three_rows_below_
+    // cluster_minimum for the pinned behavior.
     if tables.is_empty() {
         // When no tables detected but clusters exist, generate XY hint regions
         // from cluster bounding boxes to scope heuristic table detection.
@@ -754,7 +762,9 @@ fn detect_stacked_box_table(
         // Count horizontally separated text runs inside the box. A single
         // list row flows as one run; two-plus runs across most boxes means
         // multi-column content (striped prose or a real grid) that must not
-        // collapse into a one-column table.
+        // collapse into a one-column table. Same-baseline only: boxed
+        // display/diagram rows legitimately scatter segments at mixed
+        // baselines, and those must stay one row.
         let mut runs = 1usize;
         for pair in in_box.windows(2) {
             let (prev, item) = (pair[0].1, pair[1].1);
@@ -3798,6 +3808,37 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert!((merged[0].x_left - 20.0).abs() < 0.01);
         assert!((merged[0].x_right - 340.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn stacked_box_three_rows_below_cluster_minimum() {
+        // Pins a deliberate precision gate: a 3-box stack stays below the
+        // main loop's 6-rect cluster minimum and is NOT detected end-to-end.
+        // Routing smaller clusters through detect_stacked_box_table was
+        // tried and regressed four pdf-evals documents (striped bullet
+        // lists, wrapped regulation text, stats-table columns) with no
+        // corpus gains — too few boxes for the anti-prose guards to work.
+        // If this ever becomes worth revisiting, the guards need stronger
+        // signals first; flipping this assertion is the entry point.
+        let rects: Vec<PdfRect> = (0..3)
+            .map(|i| PdfRect {
+                x: 100.0,
+                y: 600.0 - i as f32 * 22.0,
+                width: 300.0,
+                height: 22.0,
+                page: 1,
+            })
+            .collect();
+        let items: Vec<TextItem> = ["Step One: Plan", "Step Two: Build", "Step Three: Ship"]
+            .iter()
+            .enumerate()
+            .map(|(i, t)| make_item(t, 120.0, 605.0 - i as f32 * 22.0, 10.0))
+            .collect();
+        let (tables, _) = detect_tables_from_rects(&items, &rects, 1);
+        assert!(
+            tables.is_empty(),
+            "3-box stacks are intentionally below the detection floor"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to cubic's review finding on #157 (`detect_stacked_box_table` is unreachable for 3-5-rect clusters — the main loop requires ≥6-rect clusters on a ≥6-rect page).

**The finding is factually correct, and this PR resolves it by documenting the gate as deliberate rather than removing it.** Routing smaller clusters through the detector was fully implemented and measured first:

- opendataloader-bench: **0.0000 movement** on every metric — no corpus doc needs the small-cluster path (the #157 target doc's cluster has 75 rects).
- pdf-evals: **four real-document regressions** across three guard-tuning iterations — striped bullet lists became tables (Russian grading norms), wrapped regulation text became tables (td9264), a stats-table column got ripped out (dergi), a label column got separated from a hospital equipment table (HTM 02-01). Each guard fix for one doc broke another: with only 3-5 boxes the anti-prose/anti-grid guards have too little signal to discriminate.

So this PR ships the honest version: a NOTE at the call site explaining the precision gate and the measurements behind it, plus `stacked_box_three_rows_below_cluster_minimum` — an end-to-end test through `detect_tables_from_rects` that pins the 3-box stack as intentionally below the detection floor and marks the entry point if it's ever revisited.

Verified: full test suite passes, opendataloader-bench byte-identical to post-#157 main, pdf-evals snapshots byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the stacked-box detector’s 6-rect precision gate so 3–5 box stacks stay below the detection floor, and clarified same-baseline handling in the run-counting comment. Updated the end-to-end test (`stacked_box_three_rows_below_cluster_minimum`) to push the page past the 6-rect page gate and explicitly pin the cluster-minimum behavior.

<sup>Written for commit 270ff509d56ba7e8d8fbbbe246c634e7ff6fb20d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

