### PR TITLE
fix(extractor): clip page content to the visible page box

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -190,6 +190,7 @@ fn extract_positioned_text_impl(
         // outside the CropBox. Extracting it interleaves invisible text into
         // the page and poisons font statistics. Rotated pages are left alone
         // — their item coordinates are already transformed out of box space.
+        let mut clipped_box: Option<(f32, f32, f32, f32)> = None;
         if !coords_rotated {
             if let Some((bx0, by0, bx1, by1)) = get_page_box(doc, page_id) {
                 const TOL: f32 = 6.0;
@@ -245,6 +246,7 @@ fn extract_positioned_text_impl(
                             x0 < bx1 + TOL && x1 > bx0 - TOL && y0 < by1 + TOL && y1 > by0 - TOL
                         };
                         rects.retain(|r| overlaps(r.x, r.y, r.width, r.height));
+                        clipped_box = Some((bx0, by0, bx1, by1));
                         lines.retain(|l| {
                             overlaps(
                                 l.x1.min(l.x2),
@@ -296,7 +298,14 @@ fn extract_positioned_text_impl(
         all_lines.extend(lines);
 
         // Extract hyperlinks from page annotations
-        let links = extract_page_links(doc, page_id, *page_num);
+        let mut links = extract_page_links(doc, page_id, *page_num);
+        // Annotations from the neighboring page are off-box too.
+        if let Some((bx0, by0, bx1, by1)) = clipped_box {
+            links.retain(|it| {
+                let cx = it.x + it.width / 2.0;
+                cx >= bx0 - 6.0 && cx <= bx1 + 6.0 && it.y >= by0 - 6.0 && it.y <= by1 + 6.0
+            });
+        }
         all_items.extend(links);
     }
 

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -176,14 +176,59 @@ fn extract_positioned_text_impl(
                 continue;
             }
         }
-        let ((mut items, rects, lines), has_gid_fonts, _coords_rotated) = extract_page_text_items(
-            doc,
-            page_id,
-            *page_num,
-            font_cmaps,
-            include_invisible,
-            &mut style_cache,
-        )?;
+        let ((mut items, mut rects, mut lines), has_gid_fonts, coords_rotated) =
+            extract_page_text_items(
+                doc,
+                page_id,
+                *page_num,
+                font_cmaps,
+                include_invisible,
+                &mut style_cache,
+            )?;
+        // Clip to the visible page box: single-page extracts and imposed
+        // spreads keep neighboring pages' content in the stream, positioned
+        // outside the CropBox. Extracting it interleaves invisible text into
+        // the page and poisons font statistics. Rotated pages are left alone
+        // — their item coordinates are already transformed out of box space.
+        if !coords_rotated {
+            if let Some((bx0, by0, bx1, by1)) = get_page_box(doc, page_id) {
+                const TOL: f32 = 6.0;
+                if bx1 - bx0 >= 72.0 && by1 - by0 >= 72.0 {
+                    let before = items.len();
+                    items.retain(|it| {
+                        let cx = it.x + it.width / 2.0;
+                        cx >= bx0 - TOL && cx <= bx1 + TOL && it.y >= by0 - TOL && it.y <= by1 + TOL
+                    });
+                    if items.len() < before {
+                        debug!(
+                            "page {}: clipped {} items outside page box ({:.0},{:.0})-({:.0},{:.0})",
+                            page_num,
+                            before - items.len(),
+                            bx0,
+                            by0,
+                            bx1,
+                            by1
+                        );
+                        // Only prune off-page geometry when off-page text
+                        // existed — same neighboring-page content.
+                        let overlaps = |x: f32, y: f32, w: f32, h: f32| {
+                            let (x0, x1) = if w < 0.0 { (x + w, x) } else { (x, x + w) };
+                            let (y0, y1) = if h < 0.0 { (y + h, y) } else { (y, y + h) };
+                            x0 < bx1 + TOL && x1 > bx0 - TOL && y0 < by1 + TOL && y1 > by0 - TOL
+                        };
+                        rects.retain(|r| overlaps(r.x, r.y, r.width, r.height));
+                        lines.retain(|l| {
+                            overlaps(
+                                l.x1.min(l.x2),
+                                l.y1.min(l.y2),
+                                (l.x2 - l.x1).abs(),
+                                (l.y2 - l.y1).abs(),
+                            )
+                        });
+                    }
+                }
+            }
+        }
         if has_gid_fonts {
             gid_encoded_pages.insert(*page_num);
         }
@@ -965,6 +1010,46 @@ pub(crate) fn get_number(obj: &Object) -> Option<f32> {
         Object::Real(r) => Some(*r),
         _ => None,
     }
+}
+
+/// Visible page box: CropBox if present, else MediaBox, walking page-tree
+/// inheritance (both attributes are inheritable). Returns normalized
+/// (x0, y0, x1, y1) in PDF space.
+fn get_page_box(doc: &Document, page_id: ObjectId) -> Option<(f32, f32, f32, f32)> {
+    fn find_box(doc: &Document, page_id: ObjectId, key: &[u8]) -> Option<Vec<f32>> {
+        let mut id = page_id;
+        for _ in 0..32 {
+            let dict = doc.get_dictionary(id).ok()?;
+            if let Ok(obj) = dict.get(key) {
+                let arr = match obj {
+                    Object::Array(a) => Some(a.clone()),
+                    Object::Reference(r) => match doc.get_object(*r) {
+                        Ok(Object::Array(a)) => Some(a.clone()),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(arr) = arr {
+                    let vals: Vec<f32> = arr.iter().filter_map(get_number).collect();
+                    if vals.len() >= 4 {
+                        return Some(vals);
+                    }
+                }
+            }
+            match dict.get(b"Parent") {
+                Ok(Object::Reference(p)) => id = *p,
+                _ => return None,
+            }
+        }
+        None
+    }
+    let v = find_box(doc, page_id, b"CropBox").or_else(|| find_box(doc, page_id, b"MediaBox"))?;
+    Some((
+        v[0].min(v[2]),
+        v[1].min(v[3]),
+        v[0].max(v[2]),
+        v[1].max(v[3]),
+    ))
 }
 
 #[cfg(test)]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -193,12 +193,40 @@ fn extract_positioned_text_impl(
         if !coords_rotated {
             if let Some((bx0, by0, bx1, by1)) = get_page_box(doc, page_id) {
                 const TOL: f32 = 6.0;
-                if bx1 - bx0 >= 72.0 && by1 - by0 >= 72.0 {
+                let outside = |it: &TextItem| {
+                    let cx = it.x + it.width / 2.0;
+                    !(cx >= bx0 - TOL && cx <= bx1 + TOL && it.y >= by0 - TOL && it.y <= by1 + TOL)
+                };
+                // Only clip when the off-page material reads as coherent text
+                // (neighboring-page paragraphs). Curved/rotated display text
+                // leaves short glyph fragments with artifact coordinates
+                // outside the box, and those must stay.
+                let off: Vec<&TextItem> = items.iter().filter(|it| outside(it)).collect();
+                // Judge by character mass: paragraphs are dominated by long
+                // word runs even when interleaved with short math fragments,
+                // while glyph-confetti is short items through and through.
+                let total_chars: usize = off.iter().map(|it| it.text.trim().chars().count()).sum();
+                let wordy_chars: usize = off
+                    .iter()
+                    .map(|it| it.text.trim().chars().count())
+                    .filter(|&n| n >= 4)
+                    .sum();
+                // Genuine neighboring-page content is cleanly separated from
+                // on-page text. When an off-page item continues an on-page
+                // line (same baseline, near-adjacent x), the coordinates are
+                // artifacts of transforms we mis-model — don't clip those.
+                let straddles = off.iter().any(|o| {
+                    items.iter().any(|i| {
+                        !outside(i)
+                            && (i.y - o.y).abs() <= 2.0
+                            && (o.x - (i.x + i.width)).abs() <= 10.0
+                    })
+                });
+                let coherent =
+                    off.len() >= 10 && wordy_chars * 2 >= total_chars.max(1) && !straddles;
+                if bx1 - bx0 >= 72.0 && by1 - by0 >= 72.0 && coherent {
                     let before = items.len();
-                    items.retain(|it| {
-                        let cx = it.x + it.width / 2.0;
-                        cx >= bx0 - TOL && cx <= bx1 + TOL && it.y >= by0 - TOL && it.y <= by1 + TOL
-                    });
+                    items.retain(|it| !outside(it));
                     if items.len() < before {
                         debug!(
                             "page {}: clipped {} items outside page box ({:.0},{:.0})-({:.0},{:.0})",


### PR DESCRIPTION
## Summary

The single biggest non-OCR gap to liteparse: single-page extracts and imposed spreads keep neighboring pages' content in the stream, positioned outside the CropBox. We extracted it — appending whole invisible sections to pages (doc 028: 6.5KB output for a 3KB page), scrambling NID, and poisoning font statistics (off-page text claimed heading tiers, dragging MHS).

**Fix**: clip items to CropBox-else-MediaBox (page-tree inheritance, normalized, 6pt tolerance, degenerate boxes ignored; rotated pages skipped — their coordinates are already transformed out of box space). Off-page rects/lines are pruned only when off-page text was found.

**Guards, each defeated by a real document during verification:**
- **Coherence by character mass**: curved/arced display text leaves 1–3-char glyph fragments with artifact coordinates outside the box (Karibib town profile) — only clip when off-page material is dominated by ≥4-char word runs (math fragments in real paragraphs are outweighed by their prose).
- **Straddle check**: one PDF computes inflated coordinates for *visible* body text; the tell is an off-page item continuing an on-page baseline at near-adjacent x — coordinates there are artifacts of transforms we mis-model, so clipping is skipped.

## Results

- **opendataloader-bench**: overall **0.8445 → 0.8532** (+0.009, biggest single fix of the day), NID 0.894 → **0.902**, MHS 0.750 → **0.761**; five docs up (+0.43, +0.38, +0.36, +0.30, +0.26), **zero regressions**.
- **pdf-evals** (isolated vs clean main build): 9 snapshots change, semantic composite wash (0.4723 → 0.4703, noise); the two guard counterexample docs verified byte-identical to main.

## Testing

`cargo fmt` / `clippy -D warnings` / full suite (634 unit + 141 integration) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clips extracted page content and link annotations to the visible page box (CropBox, else MediaBox) to drop off-page text from neighboring pages. This prevents invisible content from polluting pages and improves NID/MHS accuracy.

- **Bug Fixes**
  - Clip text items by center to the page box with 6pt tolerance; skip rotated pages; ignore boxes smaller than 1 inch.
  - Resolve page box via page-tree inheritance and normalize coordinates.
  - Add guards: coherence check (favor ≥4-char word runs) and straddle check to avoid clipping real on-page text.
  - When clipping happened, prune rects/lines by overlap and clip off-box link annotations; form fields unchanged.
  - Bench results: overall 0.8445 → 0.8537, NID +0.008, MHS +0.013; six docs up, no regressions.

<sup>Written for commit 1caa419a653e2056e22ebab960751a0cffa9971b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

