### PR TITLE
fix(extractor): use center-y for off-box link filtering

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -303,7 +303,11 @@ fn extract_positioned_text_impl(
         if let Some((bx0, by0, bx1, by1)) = clipped_box {
             links.retain(|it| {
                 let cx = it.x + it.width / 2.0;
-                cx >= bx0 - 6.0 && cx <= bx1 + 6.0 && it.y >= by0 - 6.0 && it.y <= by1 + 6.0
+                // Center-y, not it.y: link items carry an annotation rect,
+                // so y is a box edge — unlike text items, where y is a
+                // baseline and testing it directly is the natural semantics.
+                let cy = it.y + it.height / 2.0;
+                cx >= bx0 - 6.0 && cx <= bx1 + 6.0 && cy >= by0 - 6.0 && cy <= by1 + 6.0
             });
         }
         all_items.extend(links);


### PR DESCRIPTION
## Summary

Follow-up to cubic's last review comment on #160, which I initially waved off and shouldn't have: the off-box link filter tested `it.y` directly to mirror the text-item filter, but the mirroring argument doesn't hold — text items' `y` is a *baseline* (testing it directly is the natural semantics), while link items' `y` is their annotation *rect's bottom edge*. A tall link annotation straddling the bottom page edge could be dropped while still visibly anchored on-page.

One-line fix: test the link's center-y, matching the center-x check.

Tiny blast radius (requires an imposed-spread page that triggered clipping *and* an edge-straddling link annotation) — no movement expected or observed on either benchmark. `cargo fmt` / `clippy -D warnings` / full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix off-box link filtering by using the link annotation’s center-y instead of its bottom edge, so links that straddle page edges aren’t incorrectly dropped.

- **Bug Fixes**
  - Link filter now checks rect center `(cx, cy)` with the existing ±6.0 tolerance, matching the center-x logic.
  - Prevents clipping of partially visible links on imposed-spread pages near edges.

<sup>Written for commit 60a46d072665e256f2ba10188763d55d2d61969b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

