### PR TITLE
fix(headings): bold-size fallback tiers when nothing clears the ratio gate

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -391,6 +391,25 @@ pub(crate) fn compute_heading_tiers(lines: &[TextLine], base_size: f32) -> Vec<f
         }
     }
 
+    // Books often set section headings barely above body size (e.g. 11pt
+    // bold over 10pt text). When nothing clears the 1.2x ratio gate, fall
+    // back to bold lines modestly larger than body so those documents still
+    // get an H1 instead of every bold heading defaulting to H2.
+    if tiers.is_empty() {
+        let mut bold_sizes: Vec<f32> = lines
+            .iter()
+            .filter_map(|line| line.items.first())
+            .filter(|it| it.is_bold && it.font_size / base_size >= 1.05)
+            .map(|it| it.font_size)
+            .collect();
+        bold_sizes.sort_by(|a, b| b.total_cmp(a));
+        for size in bold_sizes {
+            if !tiers.iter().any(|&t| (t - size).abs() < 0.5) {
+                tiers.push(size);
+            }
+        }
+    }
+
     // Cap at 4 tiers
     tiers.truncate(4);
     tiers
@@ -406,17 +425,21 @@ pub(crate) fn detect_header_level(
 ) -> Option<usize> {
     let ratio = font_size / base_size;
 
-    if ratio < 1.2 {
-        return None; // Regular text
-    }
-
-    if !heading_tiers.is_empty() {
-        // Match font_size to a tier (within 0.5pt tolerance)
+    // Tier matches are trusted below the 1.2x gate (down to 1.05x): tiers
+    // from the bold fallback are legitimately close to body size.
+    if ratio >= 1.05 && !heading_tiers.is_empty() {
         for (i, &tier_size) in heading_tiers.iter().enumerate() {
             if (font_size - tier_size).abs() < 0.5 {
                 return Some(i + 1); // tier 0 → H1, tier 1 → H2, etc.
             }
         }
+    }
+
+    if ratio < 1.2 {
+        return None; // Regular text
+    }
+
+    if !heading_tiers.is_empty() {
         // No tier match but large ratio — assign level after last tier
         if ratio >= 1.5 {
             let level = (heading_tiers.len() + 1).min(4);
@@ -441,6 +464,60 @@ pub(crate) fn detect_header_level(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn line_of(text: &str, font_size: f32, bold: bool, y: f32) -> crate::types::TextLine {
+        let item = crate::types::TextItem {
+            text: text.into(),
+            x: 72.0,
+            y,
+            width: text.len() as f32 * font_size * 0.5,
+            height: font_size,
+            font: "Test".into(),
+            font_size,
+            page: 1,
+            is_bold: bold,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: crate::types::ItemType::Text,
+            mcid: None,
+        };
+        crate::types::TextLine {
+            items: vec![item],
+            y,
+            page: 1,
+            adaptive_threshold: 0.10,
+        }
+    }
+
+    #[test]
+    fn bold_fallback_tiers_when_nothing_clears_ratio_gate() {
+        // 10pt body, 11pt bold section headings (book-style): no size clears
+        // 1.2x, so bold sizes modestly above body form the tiers.
+        let lines = vec![
+            line_of("4. Entropy", 11.0, true, 700.0),
+            line_of("body text about entropy", 10.0, false, 680.0),
+            line_of("5. The dynamics", 11.0, true, 500.0),
+        ];
+        let tiers = compute_heading_tiers(&lines, 10.0);
+        assert_eq!(tiers, vec![11.0]);
+        assert_eq!(detect_header_level(11.0, 10.0, &tiers), Some(1));
+        // Non-tier body text stays regular.
+        assert_eq!(detect_header_level(10.0, 10.0, &tiers), None);
+    }
+
+    #[test]
+    fn bold_fallback_skipped_when_real_tiers_exist() {
+        let lines = vec![
+            line_of("Chapter One", 18.0, false, 700.0),
+            line_of("bold label", 11.0, true, 600.0),
+            line_of("body", 10.0, false, 580.0),
+        ];
+        let tiers = compute_heading_tiers(&lines, 10.0);
+        assert_eq!(tiers, vec![18.0]);
+        // The 11pt bold label does not match any tier and stays non-heading.
+        assert_eq!(detect_header_level(11.0, 10.0, &tiers), None);
+    }
 
     #[test]
     fn toc_entry_with_single_dot_group() {

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -415,6 +415,16 @@ pub(crate) fn compute_heading_tiers(lines: &[TextLine], base_size: f32) -> Vec<f
     tiers
 }
 
+/// Boldness of a line judged by character mass, so a heading with an
+/// unbold section-number prefix ("4. " + bold title) still counts as bold.
+pub(crate) fn line_is_mostly_bold(line: &TextLine) -> bool {
+    let (bold, total) = line.items.iter().fold((0usize, 0usize), |(b, t), it| {
+        let n = it.text.trim().chars().count();
+        (b + if it.is_bold { n } else { 0 }, t + n)
+    });
+    total > 0 && bold * 2 >= total
+}
+
 /// Detect header level from font size using document-specific heading tiers.
 /// When tiers are available, maps tier 0→H1, tier 1→H2, etc.
 /// Falls back to ratio-based thresholds when no tiers exist.

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -422,12 +422,14 @@ pub(crate) fn detect_header_level(
     font_size: f32,
     base_size: f32,
     heading_tiers: &[f32],
+    is_bold: bool,
 ) -> Option<usize> {
     let ratio = font_size / base_size;
 
-    // Tier matches are trusted below the 1.2x gate (down to 1.05x): tiers
-    // from the bold fallback are legitimately close to body size.
-    if ratio >= 1.05 && !heading_tiers.is_empty() {
+    // Tier matches are trusted below the 1.2x gate (down to 1.05x) only for
+    // bold lines: sub-gate tiers come from the bold fallback, and honoring
+    // them for non-bold text at the same size would promote captions.
+    if (1.05..1.2).contains(&ratio) && is_bold && !heading_tiers.is_empty() {
         for (i, &tier_size) in heading_tiers.iter().enumerate() {
             if (font_size - tier_size).abs() < 0.5 {
                 return Some(i + 1); // tier 0 → H1, tier 1 → H2, etc.
@@ -440,6 +442,12 @@ pub(crate) fn detect_header_level(
     }
 
     if !heading_tiers.is_empty() {
+        // Match font_size to a tier (within 0.5pt tolerance)
+        for (i, &tier_size) in heading_tiers.iter().enumerate() {
+            if (font_size - tier_size).abs() < 0.5 {
+                return Some(i + 1); // tier 0 → H1, tier 1 → H2, etc.
+            }
+        }
         // No tier match but large ratio — assign level after last tier
         if ratio >= 1.5 {
             let level = (heading_tiers.len() + 1).min(4);
@@ -501,9 +509,11 @@ mod tests {
         ];
         let tiers = compute_heading_tiers(&lines, 10.0);
         assert_eq!(tiers, vec![11.0]);
-        assert_eq!(detect_header_level(11.0, 10.0, &tiers), Some(1));
+        assert_eq!(detect_header_level(11.0, 10.0, &tiers, true), Some(1));
+        // Non-bold text at the fallback size must not become a heading.
+        assert_eq!(detect_header_level(11.0, 10.0, &tiers, false), None);
         // Non-tier body text stays regular.
-        assert_eq!(detect_header_level(10.0, 10.0, &tiers), None);
+        assert_eq!(detect_header_level(10.0, 10.0, &tiers, true), None);
     }
 
     #[test]
@@ -516,7 +526,7 @@ mod tests {
         let tiers = compute_heading_tiers(&lines, 10.0);
         assert_eq!(tiers, vec![18.0]);
         // The 11pt bold label does not match any tier and stays non-heading.
-        assert_eq!(detect_header_level(11.0, 10.0, &tiers), None);
+        assert_eq!(detect_header_level(11.0, 10.0, &tiers, true), None);
     }
 
     #[test]

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -725,7 +725,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
                 line_font_size,
                 base_size,
                 &heading_tiers,
-                line.items.first().is_some_and(|i| i.is_bold),
+                crate::markdown::analysis::line_is_mostly_bold(line),
             )
             .or_else(|| {
                 // Rarity-based heading detection (inspired by opendataloader).
@@ -1077,7 +1077,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
                 line_font_size,
                 base_size,
                 &heading_tiers,
-                line.items.first().is_some_and(|i| i.is_bold),
+                crate::markdown::analysis::line_is_mostly_bold(line),
             )
             .or_else(|| {
                 if line_font_size < base_size * 0.95 {

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -721,7 +721,13 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             && toc_suppress_page != Some(line.page)
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
-            detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
+            detect_header_level(
+                line_font_size,
+                base_size,
+                &heading_tiers,
+                line.items.first().is_some_and(|i| i.is_bold),
+            )
+            .or_else(|| {
                 // Rarity-based heading detection (inspired by opendataloader).
                 // Heading probability scoring with lookahead context.
                 // Score = rarity * 0.5 + bold * 0.3 + standalone * 0.2
@@ -1067,34 +1073,38 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             && !(options.detect_code && line.items.iter().any(|i| is_monospace_font(&i.font)))
         {
             let line_font_size = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
-            if let Some(header_level) =
-                detect_header_level(line_font_size, base_size, &heading_tiers).or_else(|| {
-                    if line_font_size < base_size * 0.95 {
-                        return None;
-                    }
-                    let word_count = plain_trimmed.split_whitespace().count();
-                    if !(1..=15).contains(&word_count) {
-                        return None;
-                    }
-                    if wrapped_bold_paragraph_lines.contains(&line_idx) {
-                        return None;
-                    }
-                    let rarity = font_size_rarity(line_font_size, &font_stats);
-                    let all_bold = !line.items.is_empty() && line.items.iter().all(|i| i.is_bold);
-                    let standalone = !in_paragraph;
-                    let isolated = isolated_lines.contains(&line_idx);
-                    let score = rarity * 0.5
-                        + if all_bold { 0.3 } else { 0.0 }
-                        + if standalone { 0.2 } else { 0.0 }
-                        + if isolated { 0.3 } else { 0.0 };
-                    let enough_words =
-                        word_count >= 2 || (all_bold && isolated && plain_trimmed.len() >= 4);
-                    if score >= 0.5 && standalone && enough_words {
-                        return Some(bold_heading_level(&heading_tiers));
-                    }
-                    None
-                })
-            {
+            if let Some(header_level) = detect_header_level(
+                line_font_size,
+                base_size,
+                &heading_tiers,
+                line.items.first().is_some_and(|i| i.is_bold),
+            )
+            .or_else(|| {
+                if line_font_size < base_size * 0.95 {
+                    return None;
+                }
+                let word_count = plain_trimmed.split_whitespace().count();
+                if !(1..=15).contains(&word_count) {
+                    return None;
+                }
+                if wrapped_bold_paragraph_lines.contains(&line_idx) {
+                    return None;
+                }
+                let rarity = font_size_rarity(line_font_size, &font_stats);
+                let all_bold = !line.items.is_empty() && line.items.iter().all(|i| i.is_bold);
+                let standalone = !in_paragraph;
+                let isolated = isolated_lines.contains(&line_idx);
+                let score = rarity * 0.5
+                    + if all_bold { 0.3 } else { 0.0 }
+                    + if standalone { 0.2 } else { 0.0 }
+                    + if isolated { 0.3 } else { 0.0 };
+                let enough_words =
+                    word_count >= 2 || (all_bold && isolated && plain_trimmed.len() >= 4);
+                if score >= 0.5 && standalone && enough_words {
+                    return Some(bold_heading_level(&heading_tiers));
+                }
+                None
+            }) {
                 if in_paragraph {
                     output.push_str("\n\n");
                     in_paragraph = false;

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1360,29 +1360,29 @@ mod tests {
     fn test_detect_header_level() {
         // With three tiers: 24→H1, 18→H2, 15→H3, 12→None
         let tiers = vec![24.0, 18.0, 15.0];
-        assert_eq!(detect_header_level(24.0, 12.0, &tiers), Some(1));
-        assert_eq!(detect_header_level(18.0, 12.0, &tiers), Some(2));
-        assert_eq!(detect_header_level(15.0, 12.0, &tiers), Some(3));
-        assert_eq!(detect_header_level(12.0, 12.0, &tiers), None);
+        assert_eq!(detect_header_level(24.0, 12.0, &tiers, false), Some(1));
+        assert_eq!(detect_header_level(18.0, 12.0, &tiers, false), Some(2));
+        assert_eq!(detect_header_level(15.0, 12.0, &tiers, false), Some(3));
+        assert_eq!(detect_header_level(12.0, 12.0, &tiers, false), None);
 
         // Single tier: 15→H1 (ratio 1.25 ≥ 1.2), 14→None (ratio 1.17 < 1.2)
         let tiers = vec![15.0];
-        assert_eq!(detect_header_level(15.0, 12.0, &tiers), Some(1));
-        assert_eq!(detect_header_level(14.0, 12.0, &tiers), None);
-        assert_eq!(detect_header_level(12.0, 12.0, &tiers), None);
+        assert_eq!(detect_header_level(15.0, 12.0, &tiers, false), Some(1));
+        assert_eq!(detect_header_level(14.0, 12.0, &tiers, false), None);
+        assert_eq!(detect_header_level(12.0, 12.0, &tiers, false), None);
 
         // No tiers (empty): falls back to ratio thresholds
         let tiers: Vec<f32> = vec![];
-        assert_eq!(detect_header_level(24.0, 12.0, &tiers), Some(1));
-        assert_eq!(detect_header_level(18.0, 12.0, &tiers), Some(2));
-        assert_eq!(detect_header_level(15.0, 12.0, &tiers), Some(3));
-        assert_eq!(detect_header_level(14.5, 12.0, &tiers), Some(4));
-        assert_eq!(detect_header_level(14.0, 12.0, &tiers), None);
-        assert_eq!(detect_header_level(12.0, 12.0, &tiers), None);
+        assert_eq!(detect_header_level(24.0, 12.0, &tiers, false), Some(1));
+        assert_eq!(detect_header_level(18.0, 12.0, &tiers, false), Some(2));
+        assert_eq!(detect_header_level(15.0, 12.0, &tiers, false), Some(3));
+        assert_eq!(detect_header_level(14.5, 12.0, &tiers, false), Some(4));
+        assert_eq!(detect_header_level(14.0, 12.0, &tiers, false), None);
+        assert_eq!(detect_header_level(12.0, 12.0, &tiers, false), None);
 
         // Body text excluded when tiers exist: 13pt (ratio 1.08) → None
         let tiers = vec![20.0];
-        assert_eq!(detect_header_level(13.0, 12.0, &tiers), None);
+        assert_eq!(detect_header_level(13.0, 12.0, &tiers, false), None);
     }
 
     #[test]

--- a/src/markdown/preprocess.rs
+++ b/src/markdown/preprocess.rs
@@ -42,7 +42,12 @@ fn effective_heading_level(
 
     // Fall back to font-size heuristic
     let font = line.items.first().map(|i| i.font_size).unwrap_or(base_size);
-    detect_header_level(font, base_size, heading_tiers)
+    detect_header_level(
+        font,
+        base_size,
+        heading_tiers,
+        line.items.first().is_some_and(|i| i.is_bold),
+    )
 }
 
 /// Merge consecutive heading lines at the same level into a single line.

--- a/src/markdown/preprocess.rs
+++ b/src/markdown/preprocess.rs
@@ -46,7 +46,7 @@ fn effective_heading_level(
         font,
         base_size,
         heading_tiers,
-        line.items.first().is_some_and(|i| i.is_bold),
+        crate::markdown::analysis::line_is_mostly_bold(line),
     )
 }
 


### PR DESCRIPTION
## Summary

Bench doc `01030000000028` (IntechOpen book page): section headings are 11pt bold over 10pt body. The 1.2× heading-tier ratio gate excludes them, so `compute_heading_tiers` returns nothing and every bold heading falls back to a hardcoded H2 — **H1 is unreachable for the entire document class**.

**Fix**: when no size clears the 1.2× gate, build tiers from bold line sizes ≥1.05× body (same clustering, same 4-tier cap), and let `detect_header_level` honor tier matches down to 1.05×. Documents with real tiers are untouched (the fallback only runs on an empty tier list), and non-tier bold lines keep the existing `bold_heading_level` behavior.

## Results

- opendataloader-bench: **byte-identical scores** — its MHS metric scores relative hierarchy, not absolute levels, so this is invisible to it by construction. The motivation is semantic correctness of the output (`# 4. Entropy` instead of `## 4. Entropy`).
- pdf-evals: 11 snapshots change; semantic composite on the changed set **0.6686 → 0.6727** with p10/median/p90 all up.

## Testing

2 new unit tests (fallback tiers form and map to H1; fallback skipped when real tiers exist). `cargo fmt` / `clippy -D warnings` / full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heading detection so book-style headings just above body size (e.g., 11pt bold over 10pt) map to correct H1/H2 by adding a bold-size fallback and tightening sub-gate logic. Boldness is now judged by character mass so mixed lines like "4. " + bold title are recognized.

- **Bug Fixes**
  - When `compute_heading_tiers` finds no tiers, build tiers from bold lines ≥1.05× body, dedup within 0.5pt, cap at 4.
  - `detect_header_level` now takes `is_bold`: trust tier matches down to 1.05× only for bold lines; restore ≥1.2× matching for all; keep others as regular text.
  - Boldness detection uses character mass across the line and is applied at all call sites; add tests ensuring non-bold lines at fallback size are not promoted and that fallback is skipped when real tiers exist.

<sup>Written for commit 9353d7c88315ffdd6f94a0754c8386e8d1c78c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

