### PR TITLE
fix(headings): rescue wrapped bold headings on interleaved column pages

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1561,7 +1561,9 @@ fn group_single_column(items: Vec<TextItem>, adaptive_threshold: f32) -> Vec<Tex
                         .chars()
                         .next()
                         .is_some_and(|c| c.is_lowercase());
-                    let style_mismatch = last_item.is_bold != item.is_bold;
+                    // The whole line must be bold (a heading), not merely
+                    // its last run — mixed bold-label/value rows stay joined.
+                    let style_mismatch = last_line.items.iter().all(|i| i.is_bold) && !item.is_bold;
                     if line_wordy && incoming_wordy && (starts_lower || style_mismatch) {
                         return false;
                     }

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1519,12 +1519,12 @@ fn group_single_column(items: Vec<TextItem>, adaptive_threshold: f32) -> Vec<Tex
                     }
                 }
             }
-            // Same baseline, but separated by a wide void, where the incoming
-            // run starts mid-sentence (lowercase): the neighboring column's
-            // body text sharing a y with this line, in gutters too narrow
-            // for column detection. Both sides must be multi-word prose —
-            // TOC page numbers, table cells (which start with numbers or
-            // capitalized labels), and dot leaders stay joined.
+            // Same baseline, but separated by a wide void, with the incoming
+            // run starting alphabetic: the neighboring column's body text
+            // sharing a y with this line, in gutters too narrow for column
+            // detection. Both sides must be multi-word prose — TOC page
+            // numbers, dot leaders, and outline-numbered table cells (which
+            // start with digits) stay joined.
             if let Some(last_item) = last_line.items.last() {
                 let gap = item.x - (last_item.x + last_item.width);
                 if gap > (item.font_size.max(last_item.font_size) * 3.0).max(30.0)
@@ -1533,9 +1533,12 @@ fn group_single_column(items: Vec<TextItem>, adaptive_threshold: f32) -> Vec<Tex
                         .trim()
                         .chars()
                         .next()
-                        .is_some_and(|c| c.is_lowercase() && c.is_alphabetic())
+                        .is_some_and(|c| c.is_alphabetic())
                 {
-                    let wordy = |t: &str| {
+                    // The incoming run must be substantial prose; the line
+                    // side may be short (a wrapped heading's last words).
+                    let incoming_wordy = {
+                        let t = item.text.trim();
                         t.split_whitespace().count() >= 3
                             && t.chars().filter(|c| c.is_alphabetic()).count() >= 10
                     };
@@ -1545,7 +1548,21 @@ fn group_single_column(items: Vec<TextItem>, adaptive_threshold: f32) -> Vec<Tex
                         .map(|i| i.text.trim())
                         .collect::<Vec<_>>()
                         .join(" ");
-                    if wordy(&line_text) && wordy(item.text.trim()) {
+                    let line_wordy = line_text.split_whitespace().count() >= 2
+                        && line_text.chars().filter(|c| c.is_alphabetic()).count() >= 8;
+                    // Lowercase starts are mid-sentence continuations and
+                    // split on prose signals alone. Uppercase starts also
+                    // need a bold-style mismatch between the runs — a bold
+                    // heading beside regular body text — otherwise same-style
+                    // label rows (feature tiles, legends) would shatter.
+                    let starts_lower = item
+                        .text
+                        .trim()
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_lowercase());
+                    let style_mismatch = last_item.is_bold != item.is_bold;
+                    if line_wordy && incoming_wordy && (starts_lower || style_mismatch) {
                         return false;
                     }
                 }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -160,6 +160,110 @@ fn find_isolated_lines(lines: &[TextLine], base_size: f32, para_threshold: f32) 
 /// wrapped visual line as "standalone" once the first line is misclassified,
 /// producing a stack of `##` headings.  Multi-line body-size bold runs with a
 /// paragraph-sized word count should stay paragraph text.
+/// Merge 2-3 consecutive all-bold body-size lines into one line when the
+/// group is isolated (paragraph break before and after) and short enough to
+/// be a heading. Longer/wordier bold runs are wrapped bold paragraphs and
+/// are left for `find_wrapped_bold_paragraph_lines` to suppress.
+/// "9.5. ", "12.3.1. " — section-numbered heading prefix followed by a word.
+fn starts_with_section_number(t: &str) -> bool {
+    let t = t.trim_start();
+    let mut rest = t;
+    let mut groups = 0;
+    loop {
+        let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+        if digits == 0 || digits > 3 {
+            break;
+        }
+        groups += 1;
+        rest = &rest[digits..];
+        if let Some(r) = rest.strip_prefix('.') {
+            rest = r;
+        } else {
+            break;
+        }
+    }
+    groups >= 1
+        && rest.starts_with(char::is_whitespace)
+        && rest.trim_start().starts_with(|c: char| c.is_alphabetic())
+}
+
+fn merge_wrapped_bold_heading_groups(
+    lines: Vec<TextLine>,
+    base_size: f32,
+    para_threshold: f32,
+) -> Vec<TextLine> {
+    let mut out: Vec<TextLine> = Vec::with_capacity(lines.len());
+    let mut i = 0usize;
+    while i < lines.len() {
+        if !is_body_size_all_bold_line(&lines[i], base_size) {
+            out.push(lines[i].clone());
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut end = i;
+        let mut word_count = lines[i].text().split_whitespace().count();
+        while end + 1 < lines.len()
+            && is_body_size_all_bold_line(&lines[end + 1], base_size)
+            && is_wrapped_same_style_line(&lines[end], &lines[end + 1], para_threshold)
+        {
+            end += 1;
+            word_count += lines[end].text().split_whitespace().count();
+        }
+        let line_count = end - start + 1;
+        // Column-local isolation: on interleaved multi-column pages the
+        // vector neighbors may be the other column's lines, so judge the
+        // break by x-overlapping lines only.
+        let gx0 = lines[start..=end]
+            .iter()
+            .flat_map(|l| l.items.iter().map(|i| i.x))
+            .fold(f32::INFINITY, f32::min);
+        let gx1 = lines[start..=end]
+            .iter()
+            .flat_map(|l| l.items.iter().map(|i| i.x + i.width))
+            .fold(f32::NEG_INFINITY, f32::max);
+        let overlaps_x = |l: &TextLine| {
+            let lx0 = l.items.iter().map(|i| i.x).fold(f32::INFINITY, f32::min);
+            let lx1 = l
+                .items
+                .iter()
+                .map(|i| i.x + i.width)
+                .fold(f32::NEG_INFINITY, f32::max);
+            lx0 < gx1 && lx1 > gx0
+        };
+        let page = lines[start].page;
+        let break_before = !lines.iter().any(|l| {
+            l.page == page
+                && l.y > lines[start].y
+                && l.y - lines[start].y <= para_threshold
+                && overlaps_x(l)
+        });
+        let break_after = !lines.iter().any(|l| {
+            l.page == page
+                && l.y < lines[end].y
+                && lines[end].y - l.y <= para_threshold
+                && overlaps_x(l)
+        });
+        let numbered = starts_with_section_number(&lines[start].text());
+        if (2..=3).contains(&line_count)
+            && word_count <= 15
+            && ((break_before && break_after) || numbered)
+        {
+            let mut merged = lines[start].clone();
+            for l in &lines[start + 1..=end] {
+                merged.items.extend(l.items.iter().cloned());
+            }
+            out.push(merged);
+        } else {
+            for l in &lines[start..=end] {
+                out.push(l.clone());
+            }
+        }
+        i = end + 1;
+    }
+    out
+}
+
 fn find_wrapped_bold_paragraph_lines(
     lines: &[TextLine],
     base_size: f32,
@@ -468,6 +572,17 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
     // threshold and cause every line to be treated as a paragraph break.
     let para_threshold = compute_paragraph_threshold(&lines, base_size);
 
+    // Merge wrapped bold headings: a 2-3 line group of consecutive all-bold
+    // body-size lines that is isolated as a group (paragraph break before
+    // and after) is one heading that wrapped. Left split, the internal line
+    // gap breaks each line's isolation and neither classifies as a heading —
+    // the whole group then merges into the following body paragraph.
+    let lines = if std::env::var("PI_NO_MERGE").is_ok() {
+        lines
+    } else {
+        merge_wrapped_bold_heading_groups(lines, base_size, para_threshold)
+    };
+
     // Pre-scan: identify isolated lines (paragraph break before AND after).
     // These are heading candidates even without bold/large font — common in
     // academic papers where section titles like "Acknowledgements" sit alone
@@ -764,7 +879,10 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
                 // accept them only with the strongest signal combination.
                 let enough_words =
                     word_count >= 2 || (all_bold && isolated && plain_trimmed.len() >= 4);
-                if score >= 0.5 && standalone && enough_words && has_strong_signal {
+                let numbered_bold = all_bold && starts_with_section_number(plain_trimmed);
+                if numbered_bold
+                    || (score >= 0.5 && standalone && enough_words && has_strong_signal)
+                {
                     Some(bold_heading_level(&heading_tiers))
                 } else {
                     None
@@ -1214,6 +1332,19 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn section_number_prefix_detection() {
+        assert!(starts_with_section_number(
+            "9.5. Adapting to the New Normal"
+        ));
+        assert!(starts_with_section_number("12.3.1. Deep subsection"));
+        assert!(starts_with_section_number("2.1 Systems thinking"));
+        assert!(!starts_with_section_number("24% in October 2020."));
+        assert!(!starts_with_section_number("2020 was a hard year"));
+        assert!(!starts_with_section_number("Introduction"));
+    }
+
     use super::*;
     use crate::structure_tree::StructRole;
     use crate::types::TextItem;

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -182,7 +182,9 @@ fn starts_with_section_number(t: &str) -> bool {
             break;
         }
     }
-    groups >= 1
+    // Two components minimum ("9.5. "): a single "1. " is an ordered list
+    // item, and this prefix bypasses the isolation checks entirely.
+    groups >= 2
         && rest.starts_with(char::is_whitespace)
         && rest.trim_start().starts_with(|c: char| c.is_alphabetic())
 }
@@ -1340,6 +1342,7 @@ mod tests {
         ));
         assert!(starts_with_section_number("12.3.1. Deep subsection"));
         assert!(starts_with_section_number("2.1 Systems thinking"));
+        assert!(!starts_with_section_number("1. First item in a list"));
         assert!(!starts_with_section_number("24% in October 2020."));
         assert!(!starts_with_section_number("2020 was a hard year"));
         assert!(!starts_with_section_number("Introduction"));

--- a/tests/snapshots/thermo-freon12.md
+++ b/tests/snapshots/thermo-freon12.md
@@ -12,14 +12,16 @@
 
 # Freon 12
 
-**(R-12)** **Technical Information** **Technical Information**
+**(R-12)** **Technical Information Technical Information**
 
 **®** **Thermodynamic Properties of Freon 12 Refrigerant** **(R-12)** **SI Units**
 
 Tables of the thermodynamic **Units** properties of R-12 have been developed and are presented here. P = Pressure in kPa. Absolute This information is based on values calculated using the NIST REFPROP T = Temperature in Celcius Database (McLinden, M.O., Klein,
 
 S.A., Lemmon, E.W., and Peskin, Vf = Fluid (liquid) specific volume
-A.P., NIST Standard Reference in cubic meters per kilogram Database 23, NIST thermodynamic and transport properties of Vg = Vapour (gas) specific volume refrigerants and refrigerant in cubic meters per kilogram mixtures – REFPROP version 6.01, Standard Reference Data Program, df and dg = Fluid and Vapour National Institute of Standards and (respectively) densities in Technology, 1998). kilograms per cubic meter
+A.P., NIST Standard Reference in cubic meters per kilogram Database 23, NIST thermodynamic and transport properties of Vg = Vapour (gas) specific volume refrigerants and refrigerant in cubic meters per kilogram mixtures – REFPROP version 6.01, Standard Reference Data Program, df and dg = Fluid and Vapour National Institute of Standards and (respectively) densities in Technology, 1998).
+kilograms per cubic meter
+
 ##### H = Enthalpy (kJ/kg)
 
 ##### S = Entropy (kJ/kg.K)


### PR DESCRIPTION
## Summary

Follow-up to #163 targeting the remaining MHS gap. On report pages whose columns can't be detected (~6pt gutters), both columns' lines interleave in reading order — which quietly breaks every whitespace signal the bold-heading heuristic uses: `para_threshold` inflates to ~3× line height (cross-column gaps), and a wrapped heading's own internal line gap defeats the isolation check. Result: `9.5. Adapting to the New Normal: Changing Business Models` (bold, 2 wrapped lines) merged into the following body paragraph on bench doc 039, with siblings across the survey-report family.

Four changes:
1. **`merge_wrapped_bold_heading_groups`** — 2–3 consecutive all-bold body-size lines merge into one line when the group is isolated *column-locally* (breaks judged against x-overlapping lines only, immune to interleaving) or starts with a section number.
2. **Section-numbered bold headings** (`9.5. …`) classify without the standalone/isolation score gate — numbering is a stronger signal than whitespace.
3. **Uppercase-start unfusing** — #163's line-split extends to uppercase continuations, gated on a **bold-style mismatch** between runs; that gate came from a real counterexample (same-style feature-tile rows shattered and lost their heading, doc 182 −0.139 before the gate).
4. Line-side wordiness drops to 2 words so a wrapped heading's short last line ("Business Models") still splits from the neighboring column.

## Results

- **opendataloader-bench**: overall **0.8554 → 0.8576**, MHS **0.769 → 0.777**; docs 037 +0.161, 111 +0.157, 039 +0.091, 198 +0.028 — **zero regressions**.
- **pdf-evals** (63 snapshots, scored vs clean main build): composite 0.5952 → **0.5964**, only >0.02 per-doc mover is positive (+0.021).
- thermo-freon12 fixture snapshot regenerated: cosmetic churn on an already-scrambled 3-column legend page (verified equal-garbage both ways).

## Testing

New unit test for the section-number prefix parser; full suite (639 unit + 141 integration) passes; `cargo fmt` / `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrapped bold headings being merged into body text on interleaved two‑column pages with narrow gutters. Restores correct heading extraction (including numbered headings) and improves accuracy without regressions.

- **Bug Fixes**
  - Merge 2–3 consecutive all‑bold body‑size lines into one when the group is column‑locally isolated or starts with a multi‑component section number.
  - Allow section‑numbered bold headings to classify without the isolation gate; single‑component prefixes like "1. " no longer bypass it.
  - Unfuse uppercase starts across wide voids only when bold/regular styles mismatch and the whole line is bold; same‑style label/value rows stay joined.
  - Lower line‑side wordiness to 2 words so short wrapped tails split from the neighboring column.

<sup>Written for commit 2da46f613900014b883c290e612676a438e6d683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

