### PR TITLE
fix(headings): digit-only lines do not define heading tiers

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -407,6 +407,11 @@ pub(crate) fn compute_heading_tiers(lines: &[TextLine], base_size: f32) -> Vec<f
     if tiers.is_empty() {
         let mut bold_sizes: Vec<f32> = lines
             .iter()
+            .filter(|line| {
+                let text = line.text();
+                let t = text.trim();
+                !t.is_empty() && t.chars().any(|c| c.is_alphabetic())
+            })
             .filter_map(|line| line.items.first())
             .filter(|it| it.is_bold && it.font_size / base_size >= 1.05)
             .map(|it| it.font_size)

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -374,6 +374,15 @@ pub(crate) fn compute_heading_tiers(lines: &[TextLine], base_size: f32) -> Vec<f
     for line in lines {
         if let Some(first) = line.items.first() {
             if first.font_size / base_size >= 1.2 {
+                // Digit-only lines (page numbers, issue numbers) must not
+                // define heading tiers: a large bold folio claims tier 0 and
+                // blocks the bold-size fallback for the document's real
+                // same-size headings.
+                let text = line.text();
+                let t = text.trim();
+                if !t.is_empty() && t.chars().all(|c| !c.is_alphabetic()) {
+                    continue;
+                }
                 heading_sizes.push(first.font_size);
             }
         }
@@ -506,6 +515,19 @@ mod tests {
             page: 1,
             adaptive_threshold: 0.10,
         }
+    }
+
+    #[test]
+    fn digit_only_lines_do_not_define_tiers() {
+        // A 14pt bold page number must not claim tier 0 — that both demotes
+        // every real heading a level and blocks the bold-size fallback.
+        let lines = vec![
+            line_of("76", 14.0, true, 760.0),
+            line_of("Replace", 11.0, true, 700.0),
+            line_of("body text at eleven points", 11.0, false, 680.0),
+        ];
+        let tiers = compute_heading_tiers(&lines, 11.0);
+        assert!(tiers.is_empty(), "page number claimed a tier: {tiers:?}");
     }
 
     #[test]

--- a/tests/snapshots/thermo-freon12.md
+++ b/tests/snapshots/thermo-freon12.md
@@ -6,9 +6,7 @@
 
 #### Thermodynamic Properties
 
-**of**
-
-®
+**of** ®
 
 # Freon 12
 


### PR DESCRIPTION
## Summary

Found while diagnosing bench doc 069: its heading tier list was `[14.0]` — claimed by a **14pt bold page number** ("76") over 11pt body. Two consequences: every real heading in such documents sits one level too deep (`####` instead of `###`), and the bold-size fallback from #162 (gated on an empty tier list) is blocked for documents whose true headings match body size.

**Fix**: lines with no alphabetic characters (page numbers, folios, issue numbers) are excluded from `compute_heading_tiers`.

## Results

- opendataloader-bench: neutral by construction (MHS scores relative hierarchy, unchanged at 0.8567/0.7733).
- pdf-evals: 18 docs shift their heading levels up to where they belong (e.g. IRS publication: `#### Part One.` → `### Part One.`); semantic composite 0.5467 → **0.5473**, no percentile down.
- New unit test; full suite passes, fmt/clippy clean.

Note: this is hygiene groundwork for doc 069's real gap (single-word bold headings at body size — "Replace"/"Trash" as H1), which needs a separate, more careful heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude digit-only lines from heading tier detection in both the main pass and the bold-size fallback to keep page numbers from claiming tier 0 and demoting real headings. This restores correct levels and keeps the bold fallback active when tiers would otherwise be empty.

- **Bug Fixes**
  - Skip lines with no alphabetic characters in the main tier pass and the bold fallback pass.
  - Added unit test for the bold page-number case; regenerated `thermo-freon12` snapshot (cosmetic).
  - Results: bench-neutral; 18 eval docs shift up one level (#### → ###); semantic composite +0.0006.

<sup>Written for commit 83e868edac80812bdd3db597c17bc1d22ee3a9aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

