### PR TITLE
docs(site): redesign open-source project page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -213,7 +213,7 @@
   .button code { font: inherit; }
   .arrow { font-family: var(--mono); color: currentColor; }
 
-  .terminal {
+  .playground {
     border: 1px solid rgba(255,255,255,.08);
     border-radius: 12px;
     background: var(--code);
@@ -222,36 +222,99 @@
     overflow: hidden;
     position: relative;
   }
-  .terminal-head {
-    height: 42px;
-    padding: 0 14px;
+  .playground-switcher {
+    min-height: 53px;
+    padding: 9px 10px;
     border-bottom: 1px solid rgba(255,255,255,.08);
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    background: #181818;
+  }
+  .playground-switch {
+    padding: 3px;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    border: 1px solid rgba(255,255,255,.08);
+    border-radius: 8px;
+    background: rgba(255,255,255,.035);
+  }
+  .playground-switch button {
+    height: 27px;
+    padding: 0 9px;
+    border: 0;
+    border-radius: 5px;
+    color: rgba(255,255,255,.48);
+    background: transparent;
+    cursor: pointer;
+    font: 500 10px/1 var(--mono);
+    transition: color .15s ease, background .15s ease, box-shadow .15s ease;
+  }
+  .playground-switch button:hover { color: #fff; }
+  .language-switch button[aria-pressed="true"] {
+    color: var(--ink);
+    background: #fff;
+    box-shadow: 0 1px 5px rgba(0,0,0,.25);
+  }
+  .mode-switch button[aria-pressed="true"] { color: #ff9c70; background: var(--heat-16); }
+  .terminal-head {
+    height: 40px;
+    padding: 0 14px;
+    border-bottom: 1px solid rgba(255,255,255,.08);
+    display: flex;
+    align-items: center;
+    gap: 9px;
     color: rgba(255,255,255,.42);
     font: 11px/1 var(--mono);
   }
   .term-dots { display: flex; gap: 5px; }
   .term-dots i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.17); }
-  .terminal pre { margin: 0; padding: 24px 18px 28px; overflow-x: hidden; white-space: pre; font: 12px/1.75 var(--mono); }
+  .example-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .copy-button {
+    margin-left: auto;
+    padding: 4px 6px;
+    border: 0;
+    border-radius: 4px;
+    color: rgba(255,255,255,.42);
+    background: transparent;
+    cursor: pointer;
+    font: 10px/1 var(--mono);
+  }
+  .copy-button:hover, .copy-button:focus-visible { color: #fff; background: rgba(255,255,255,.06); }
+  .playground-body { min-height: 245px; }
+  .playground-panel {
+    min-height: 245px;
+    margin: 0;
+    padding: 22px 18px 24px;
+    overflow-x: hidden;
+    white-space: pre;
+    font: 11px/1.75 var(--mono);
+  }
+  .playground-panel[hidden] { display: none; }
+  .playground .cm { color: rgba(255,255,255,.34); }
+  .playground .kw { color: #ff9c70; }
+  .playground .str { color: #d5bea9; }
+  .playground .fn { color: #fff; font-weight: 600; }
   .prompt { color: var(--heat); }
   .term-muted { color: rgba(255,255,255,.38); }
   .term-key { color: #ffb28f; }
-  .terminal-result {
-    margin: 0 18px 18px;
-    padding: 12px 13px;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 7px 16px;
-    border: 1px solid rgba(255,255,255,.08);
-    border-radius: 7px;
-    background: rgba(255,255,255,.035);
+  .playground-meta {
+    min-height: 42px;
+    padding: 0 14px;
+    border-top: 1px solid rgba(255,255,255,.08);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
     color: rgba(255,255,255,.52);
-    font: 11px/1.3 var(--mono);
+    font: 10px/1.3 var(--mono);
   }
-  .terminal-result strong { color: #fff; font-weight: 500; }
-  .terminal-result strong.hot { color: #ff8b59; }
+  .playground-meta span { display: inline-flex; align-items: center; gap: 6px; }
+  .playground-meta span::before { content: ""; width: 4px; height: 4px; background: rgba(255,255,255,.24); }
+  .playground-meta span:first-child { color: #ff9c70; }
+  .playground-meta span:first-child::before { background: var(--heat); }
 
   .package-row { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--border); background: var(--surface); }
   .package {
@@ -403,11 +466,11 @@
   .footer-links { display: flex; gap: 20px; flex-wrap: wrap; color: var(--ink-48); font: 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .05em; }
   .footer-links a:hover { color: var(--heat); }
 
-  a:focus-visible, label:focus-visible { outline: 2px solid var(--heat); outline-offset: 3px; }
+  a:focus-visible, button:focus-visible, label:focus-visible { outline: 2px solid var(--heat); outline-offset: 3px; }
 
   @media (max-width: 900px) {
     .hero-main { grid-template-columns: 1fr; gap: 44px; }
-    .terminal { max-width: 580px; }
+    .playground { max-width: 580px; }
     .section-intro { grid-template-columns: 1fr; gap: 20px; }
     .capability-grid { grid-template-columns: repeat(2, 1fr); }
     .capability:nth-child(3n) { border-right: 1px solid var(--border); }
@@ -425,7 +488,12 @@
     .project-brand small { display: none; }
     .hero-main { min-height: auto; padding-top: 70px; }
     h1 { font-size: clamp(47px, 14vw, 66px); }
-    .terminal pre { padding: 20px 16px 24px; font-size: 11px; }
+    .playground-switcher { align-items: stretch; flex-direction: column; }
+    .playground-switch { display: grid; }
+    .language-switch { grid-template-columns: repeat(3, 1fr); }
+    .mode-switch { grid-template-columns: repeat(2, 1fr); }
+    .playground-switch button { width: 100%; }
+    .playground-panel { padding: 20px 16px 22px; font-size: 10.5px; }
     .package-row { grid-template-columns: 1fr; }
     .package { border-right: 0; border-bottom: 1px solid var(--border); }
     .package:last-child { border-bottom: 0; }
@@ -481,31 +549,85 @@
           <div class="rust-label"><i aria-hidden="true">RS</i>Rust core</div>
         </div>
         <h1>PDF structure,<br><em>built for speed.</em></h1>
-        <p class="hero-copy">A Rust-powered, open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Use it from Node.js or the bundled CLI, with packages also available from PyPI and crates.io.</p>
+        <p class="hero-copy">A Rust-powered, open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Use the native core from Node.js, Python, or Rust, or drop into the bundled CLI.</p>
         <div class="hero-actions">
           <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View on GitHub <span class="arrow" aria-hidden="true">↗</span></a>
           <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
 
-      <div class="terminal" aria-label="pdf-inspector command line example">
+      <div class="playground" data-playground aria-label="Interactive pdf-inspector examples">
+        <div class="playground-switcher">
+          <div class="playground-switch language-switch" role="group" aria-label="Language">
+            <button type="button" data-language="node" aria-pressed="true">Node.js</button>
+            <button type="button" data-language="python" aria-pressed="false">Python</button>
+            <button type="button" data-language="rust" aria-pressed="false">Rust</button>
+          </div>
+          <div class="playground-switch mode-switch" role="group" aria-label="Example type">
+            <button type="button" data-mode="code" aria-pressed="true">Code</button>
+            <button type="button" data-mode="cli" aria-pressed="false">CLI</button>
+          </div>
+        </div>
         <div class="terminal-head">
           <div class="term-dots" aria-hidden="true"><i></i><i></i><i></i></div>
-          <span>npm CLI · local</span>
+          <span class="example-title">npm · Node.js code</span>
+          <button class="copy-button" type="button" aria-label="Copy example">Copy</button>
         </div>
-        <pre><span class="prompt">$</span> npm i -g @firecrawl/pdf-inspector
-<span class="term-muted">   installed the native package + CLI</span>
+        <div class="playground-body" aria-live="polite">
+          <pre class="playground-panel" data-example="node-code" data-title="npm · Node.js code"><span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="str">'node:fs'</span>;
+<span class="kw">import</span> {
+  processPdf
+} <span class="kw">from</span> <span class="str">'@firecrawl/pdf-inspector'</span>;
+
+<span class="kw">const</span> pdf = <span class="fn">readFileSync</span>(<span class="str">'annual-report.pdf'</span>);
+<span class="kw">const</span> result = <span class="fn">processPdf</span>(pdf);
+
+console.<span class="fn">log</span>(result.markdown);</pre>
+          <pre class="playground-panel" data-example="node-cli" data-title="npm · bundled CLI" hidden><span class="prompt">$</span> npm i -g @firecrawl/pdf-inspector
+<span class="term-muted">   installed native package + CLI</span>
 
 <span class="prompt">$</span> pdf-inspector annual-report.pdf
 <span class="term-key"># Annual report 2025</span>
 
 ## Financial highlights
-| Metric | 2025 | 2024 |
-|---|---:|---:|</pre>
-        <div class="terminal-result">
-          <span>document type</span><strong class="hot">TextBased</strong>
-          <span>output</span><strong>structured Markdown</strong>
-          <span>engine</span><strong>Rust</strong>
+| Metric | 2025 | 2024 |</pre>
+          <pre class="playground-panel" data-example="python-code" data-title="PyPI · Python code" hidden><span class="kw">import</span> pdf_inspector
+
+result = pdf_inspector.<span class="fn">process_pdf</span>(
+    <span class="str">"annual-report.pdf"</span>
+)
+
+<span class="fn">print</span>(result.pdf_type)
+<span class="fn">print</span>(result.markdown)</pre>
+          <pre class="playground-panel" data-example="python-cli" data-title="PyPI · Python shell" hidden><span class="prompt">$</span> pip install pdf-inspector
+<span class="prompt">$</span> python
+
+<span class="term-key">&gt;&gt;&gt;</span> import pdf_inspector as pdf
+<span class="term-key">&gt;&gt;&gt;</span> result = pdf.process_pdf(<span class="str">"report.pdf"</span>)
+<span class="term-key">&gt;&gt;&gt;</span> print(result.markdown)
+<span class="term-key"># Annual report 2025</span></pre>
+          <pre class="playground-panel" data-example="rust-code" data-title="crates.io · Rust code" hidden><span class="kw">use</span> pdf_inspector::process_pdf;
+
+<span class="kw">let</span> result = <span class="fn">process_pdf</span>(
+    <span class="str">"annual-report.pdf"</span>
+)?;
+
+<span class="kw">if let Some</span>(markdown) = result.markdown {
+    <span class="fn">println!</span>(<span class="str">"{markdown}"</span>);
+}</pre>
+          <pre class="playground-panel" data-example="rust-cli" data-title="crates.io · Rust CLI" hidden><span class="prompt">$</span> cargo install pdf-inspector
+<span class="term-muted">   installed pdf2md + detect-pdf</span>
+
+<span class="prompt">$</span> pdf2md annual-report.pdf
+<span class="term-key"># Annual report 2025</span>
+
+## Financial highlights
+| Metric | 2025 | 2024 |</pre>
+        </div>
+        <div class="playground-meta" aria-label="Runtime details">
+          <span>Rust core</span>
+          <span>Runs locally</span>
+          <span>Structured Markdown</span>
         </div>
       </div>
     </div>
@@ -742,6 +864,82 @@ result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="str">"do
     </div>
   </div>
 </footer>
+
+<script>
+  (() => {
+    const playground = document.querySelector('[data-playground]');
+    if (!playground) return;
+
+    const languageButtons = [...playground.querySelectorAll('[data-language]')];
+    const modeButtons = [...playground.querySelectorAll('[data-mode]')];
+    const panels = [...playground.querySelectorAll('[data-example]')];
+    const title = playground.querySelector('.example-title');
+    const copyButton = playground.querySelector('.copy-button');
+    let language = 'node';
+    let mode = 'code';
+
+    const update = () => {
+      const key = `${language}-${mode}`;
+      const activePanel = panels.find((panel) => panel.dataset.example === key);
+
+      languageButtons.forEach((button) => {
+        button.setAttribute('aria-pressed', String(button.dataset.language === language));
+      });
+      modeButtons.forEach((button) => {
+        button.setAttribute('aria-pressed', String(button.dataset.mode === mode));
+      });
+      panels.forEach((panel) => { panel.hidden = panel !== activePanel; });
+
+      if (activePanel) title.textContent = activePanel.dataset.title;
+      copyButton.textContent = 'Copy';
+    };
+
+    const copyText = async (text) => {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.setAttribute('readonly', '');
+      textArea.style.position = 'fixed';
+      textArea.style.opacity = '0';
+      document.body.appendChild(textArea);
+      textArea.select();
+      const copied = document.execCommand('copy');
+      textArea.remove();
+      if (!copied) throw new Error('Copy failed');
+    };
+
+    languageButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        language = button.dataset.language;
+        update();
+      });
+    });
+
+    modeButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        mode = button.dataset.mode;
+        update();
+      });
+    });
+
+    copyButton.addEventListener('click', async () => {
+      const activePanel = panels.find((panel) => !panel.hidden);
+      if (!activePanel) return;
+
+      try {
+        await copyText(activePanel.textContent.trim());
+        copyButton.textContent = 'Copied';
+        window.setTimeout(() => { copyButton.textContent = 'Copy'; }, 1400);
+      } catch {
+        copyButton.textContent = 'Select to copy';
+      }
+    });
+  })();
+</script>
 
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -215,7 +215,7 @@
   }
   .term-dots { display: flex; gap: 5px; }
   .term-dots i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.17); }
-  .terminal pre { margin: 0; padding: 24px 22px 28px; overflow-x: hidden; white-space: pre-wrap; overflow-wrap: anywhere; font: 13px/1.75 var(--mono); }
+  .terminal pre { margin: 0; padding: 24px 18px 28px; overflow-x: hidden; white-space: pre; font: 12px/1.75 var(--mono); }
   .prompt { color: var(--heat); }
   .term-muted { color: rgba(255,255,255,.38); }
   .term-key { color: #ffb28f; }
@@ -406,6 +406,7 @@
     .project-brand small { display: none; }
     .hero-main { min-height: auto; padding-top: 70px; }
     h1 { font-size: clamp(47px, 14vw, 66px); }
+    .terminal pre { padding: 20px 16px 24px; font-size: 11px; }
     .package-row { grid-template-columns: 1fr; }
     .package { border-right: 0; border-bottom: 1px solid var(--border); }
     .package:last-child { border-bottom: 0; }
@@ -470,7 +471,7 @@
           <div class="term-dots" aria-hidden="true"><i></i><i></i><i></i></div>
           <span>npm CLI · local</span>
         </div>
-        <pre><span class="prompt">$</span> npm install -g @firecrawl/pdf-inspector
+        <pre><span class="prompt">$</span> npm i -g @firecrawl/pdf-inspector
 <span class="term-muted">   installed the native package + CLI</span>
 
 <span class="prompt">$</span> pdf-inspector annual-report.pdf

--- a/site/index.html
+++ b/site/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>pdf-inspector — fast, open-source PDF to Markdown</title>
-<meta name="description" content="An open-source Rust library for fast PDF classification and structured Markdown extraction, with bindings for Rust, Python, Node.js, and the command line.">
+<meta name="description" content="A fast, open-source Node.js package and CLI for PDF classification and structured Markdown extraction, powered by a native Rust core.">
 <meta name="theme-color" content="#f9f9f9">
 <meta property="og:title" content="pdf-inspector">
-<meta property="og:description" content="Fast, open-source PDF classification and structured Markdown extraction. Built in Rust by Firecrawl.">
+<meta property="og:description" content="A fast Node.js package and bundled CLI for PDF classification and structured Markdown extraction, powered by Rust.">
 <meta property="og:type" content="website">
 <link rel="icon" href="assets/firecrawl-mark.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -192,6 +192,8 @@
   .button-primary { color: #fff; background: var(--heat); border-color: var(--heat); }
   .button-primary:hover, .button-primary:focus-visible { background: var(--heat-dark); border-color: var(--heat-dark); }
   .button code { font: inherit; }
+  .source-link { padding: 0 5px; color: var(--ink-48); font-size: 14px; text-decoration: underline; text-decoration-color: var(--ink-16); text-underline-offset: 4px; }
+  .source-link:hover, .source-link:focus-visible { color: var(--heat-dark); text-decoration-color: var(--heat); }
   .arrow { font-family: var(--mono); color: currentColor; }
 
   .terminal {
@@ -258,6 +260,8 @@
   .package-top { display: flex; justify-content: space-between; color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
   .package code { display: block; margin-top: 12px; overflow: hidden; text-overflow: ellipsis; color: var(--ink-88); font: 13px/1.4 var(--mono); white-space: nowrap; }
   .package:hover .package-top, .package:focus-visible .package-top { color: var(--heat); }
+  .package-featured { background: var(--heat-4); box-shadow: inset 0 2px var(--heat); }
+  .package-featured .package-top { color: var(--heat-dark); }
 
   section { scroll-margin-top: 68px; }
   .section-label {
@@ -376,22 +380,6 @@
   #node:checked ~ .usage-grid #panel-node,
   #cli:checked ~ .usage-grid #panel-cli { display: block; }
 
-  .contribute-grid { display: grid; grid-template-columns: 1.1fr .9fr; border: 1px solid var(--border); background: var(--surface); }
-  .repo-map { padding: 30px; border-right: 1px solid var(--border); }
-  .repo-title { display: flex; justify-content: space-between; margin-bottom: 24px; color: var(--ink-32); font: 11px/1 var(--mono); }
-  .repo-files { border-top: 1px solid var(--border); }
-  .repo-file { min-height: 54px; padding: 0 4px; border-bottom: 1px solid var(--border); display: grid; grid-template-columns: 160px 1fr; align-items: center; gap: 20px; }
-  .repo-file code { color: var(--heat-dark); font: 12px var(--mono); }
-  .repo-file span { color: var(--ink-48); font-size: 13px; }
-  .contribute-links { display: grid; grid-template-columns: 1fr 1fr; }
-  .contribute-link { min-height: 158px; padding: 23px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); display: flex; flex-direction: column; justify-content: space-between; }
-  .contribute-link:nth-child(2n) { border-right: 0; }
-  .contribute-link:nth-last-child(-n+2) { border-bottom: 0; }
-  .contribute-link span { color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; }
-  .contribute-link strong { font-size: 16px; font-weight: 500; }
-  .contribute-link:hover { background: var(--heat-4); }
-  .contribute-link:hover strong { color: var(--heat-dark); }
-
   .footer-main { min-height: 168px; padding-top: 36px; padding-bottom: 36px; display: flex; justify-content: space-between; align-items: flex-end; gap: 28px; }
   .footer-brand { display: flex; align-items: center; gap: 10px; color: var(--ink-48); font-size: 13px; }
   .footer-brand img { width: 102px; height: auto; }
@@ -413,8 +401,6 @@
     .pipe-arrow { width: 1px; height: 24px; justify-self: center; }
     .pipe-arrow::after { right: auto; bottom: -7px; top: auto; transform: rotate(90deg); }
     .pipe-node { min-height: 130px; }
-    .contribute-grid { grid-template-columns: 1fr; }
-    .repo-map { border-right: 0; border-bottom: 1px solid var(--border); }
   }
 
   @media (max-width: 680px) {
@@ -442,10 +428,6 @@
     #node:checked ~ .usage-grid .tab-list label[for=node],
     #cli:checked ~ .usage-grid .tab-list label[for=cli] { box-shadow: inset 0 -2px var(--heat); }
     .code-panel { padding: 22px 20px; min-height: 330px; }
-    .repo-file { grid-template-columns: 1fr; gap: 4px; padding: 13px 4px; }
-    .contribute-links { grid-template-columns: 1fr; }
-    .contribute-link, .contribute-link:nth-child(2n), .contribute-link:nth-last-child(-n+2) { min-height: 112px; border-right: 0; border-bottom: 1px solid var(--border); }
-    .contribute-link:last-child { border-bottom: 0; }
     .footer-main { align-items: flex-start; flex-direction: column; }
   }
 
@@ -480,22 +462,24 @@
       <div>
         <div class="oss-label"><i aria-hidden="true"></i>Firecrawl open source · MIT</div>
         <h1>PDF structure,<br><em>built for speed.</em></h1>
-        <p class="hero-copy">A Rust library that classifies PDFs and turns native text into clean, position-aware Markdown. Run it locally from Rust, Python, Node.js, or the command line.</p>
+        <p class="hero-copy">A native Node.js package and bundled CLI that classify PDFs and turn native text into clean, position-aware Markdown. Install once from npm, then use it in code or from your shell.</p>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View source <span class="arrow" aria-hidden="true">↗</span></a>
-          <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="button button-primary" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">npm package <span class="arrow" aria-hidden="true">↗</span></a>
+          <a class="button" href="https://pypi.org/project/pdf-inspector/">PyPI <span class="arrow" aria-hidden="true">↗</span></a>
+          <a class="button" href="https://crates.io/crates/pdf-inspector">crates.io <span class="arrow" aria-hidden="true">↗</span></a>
+          <a class="source-link" href="https://github.com/firecrawl/pdf-inspector">View source</a>
         </div>
       </div>
 
       <div class="terminal" aria-label="pdf-inspector command line example">
         <div class="terminal-head">
           <div class="term-dots" aria-hidden="true"><i></i><i></i><i></i></div>
-          <span>pdf2md · local</span>
+          <span>npm CLI · local</span>
         </div>
-        <pre><span class="prompt">$</span> cargo install pdf-inspector
-<span class="term-muted">   Installed package `pdf-inspector`</span>
+        <pre><span class="prompt">$</span> npm install -g @firecrawl/pdf-inspector
+<span class="term-muted">   installed the native package + CLI</span>
 
-<span class="prompt">$</span> pdf2md annual-report.pdf
+<span class="prompt">$</span> pdf-inspector annual-report.pdf
 <span class="term-key"># Annual report 2025</span>
 
 ## Financial highlights
@@ -509,31 +493,31 @@
     </div>
 
     <div class="project-strip" aria-label="Project details">
-      <div class="project-stat"><span>Core</span><strong>Pure Rust</strong></div>
-      <div class="project-stat"><span>Interfaces</span><strong>Rust · Python · Node · CLI</strong></div>
-      <div class="project-stat"><span>Binaries</span><strong>pdf2md · detect-pdf</strong></div>
+      <div class="project-stat"><span>Primary API</span><strong>Node.js · TypeScript</strong></div>
+      <div class="project-stat"><span>Bundled CLI</span><strong>pdf-inspector</strong></div>
+      <div class="project-stat"><span>Native core</span><strong>Pure Rust</strong></div>
       <div class="project-stat"><span>License</span><strong>MIT</strong></div>
     </div>
 
     <div class="package-row" aria-label="Package installation">
-      <a class="package" href="https://crates.io/crates/pdf-inspector">
-        <span class="package-top"><span>crates.io</span><span>Rust ↗</span></span>
-        <code>cargo add pdf-inspector</code>
+      <a class="package package-featured" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
+        <span class="package-top"><span>npm · primary</span><span>Node.js + CLI ↗</span></span>
+        <code>npm i @firecrawl/pdf-inspector</code>
       </a>
       <a class="package" href="https://pypi.org/project/pdf-inspector/">
         <span class="package-top"><span>PyPI</span><span>Python ↗</span></span>
         <code>pip install pdf-inspector</code>
       </a>
-      <a class="package" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
-        <span class="package-top"><span>npm</span><span>Node.js ↗</span></span>
-        <code>npm i @firecrawl/pdf-inspector</code>
+      <a class="package" href="https://crates.io/crates/pdf-inspector">
+        <span class="package-top"><span>crates.io</span><span>Rust ↗</span></span>
+        <code>cargo add pdf-inspector</code>
       </a>
     </div>
   </div>
 
   <section id="capabilities" class="full-rule">
     <div class="shell">
-      <div class="section-label pad"><span>[ <b>01</b> / 05 ]</span><span>Core capabilities</span></div>
+      <div class="section-label pad"><span>[ <b>01</b> / 04 ]</span><span>Core capabilities</span></div>
       <div class="section-body pad">
         <div class="section-intro">
           <h2>A focused PDF<br>toolchain.</h2>
@@ -566,9 +550,9 @@
             <p>Emit headings, lists, tables, links, code, emphasis, captions, page markers, and token-efficient cleanup.</p>
           </article>
           <article class="capability">
-            <div class="cap-id"><span>06</span><span>lib.rs</span></div>
-            <h3>Local by default</h3>
-            <p>No model weights or external services. Use the Rust API directly or ship the maintained Python, Node.js, and CLI interfaces.</p>
+            <div class="cap-id"><span>06</span><span>napi/</span></div>
+            <h3>Node-first delivery</h3>
+            <p>Prebuilt native binaries, TypeScript definitions, and the bundled pdf-inspector CLI ship together through npm.</p>
           </article>
         </div>
       </div>
@@ -577,7 +561,7 @@
 
   <section id="architecture" class="full-rule">
     <div class="shell">
-      <div class="section-label pad"><span>[ <b>02</b> / 05 ]</span><span>Architecture</span></div>
+      <div class="section-label pad"><span>[ <b>02</b> / 04 ]</span><span>Architecture</span></div>
       <div class="section-body pad">
         <div class="section-intro">
           <h2>One parse.<br>Clear stages.</h2>
@@ -607,7 +591,7 @@
               <p>Clean Markdown plus classification and extraction metadata.</p>
             </div>
           </div>
-          <div class="arch-foot">Start in <code>src/lib.rs</code>, use <code>process_pdf</code>, and opt into JSON or positioned items when your pipeline needs more structure.</div>
+          <div class="arch-foot">Start with <code>@firecrawl/pdf-inspector</code> and <code>processPdf</code>, or run the bundled <code>pdf-inspector</code> CLI. Both use the same Rust pipeline.</div>
         </div>
       </div>
     </div>
@@ -615,7 +599,7 @@
 
   <section id="benchmark" class="full-rule">
     <div class="shell">
-      <div class="section-label pad"><span>[ <b>03</b> / 05 ]</span><span>Benchmark</span></div>
+      <div class="section-label pad"><span>[ <b>03</b> / 04 ]</span><span>Benchmark</span></div>
       <div class="section-body pad">
         <div class="section-intro">
           <h2>Measured on<br>real documents.</h2>
@@ -649,46 +633,25 @@
 
   <section id="usage" class="full-rule">
     <div class="shell">
-      <div class="section-label pad"><span>[ <b>04</b> / 05 ]</span><span>Usage</span></div>
+      <div class="section-label pad"><span>[ <b>04</b> / 04 ]</span><span>Usage</span></div>
       <div class="section-body pad">
         <div class="section-intro">
-          <h2>Use it from<br>your stack.</h2>
-          <p>The same processing pipeline is available across every interface. Choose a package for application code or install the binaries for scripts, shell pipelines, and quick inspection.</p>
+          <h2>Start with Node.<br>Use the CLI.</h2>
+          <p>The npm package is the main entry point: import the native Node.js API in application code or use the bundled pdf-inspector command for scripts and shell pipelines. Python and Rust packages expose the same core when you need them.</p>
         </div>
         <div class="tabs">
-          <input type="radio" name="language" id="rust" checked>
-          <input type="radio" name="language" id="python">
-          <input type="radio" name="language" id="node">
+          <input type="radio" name="language" id="node" checked>
           <input type="radio" name="language" id="cli">
+          <input type="radio" name="language" id="python">
+          <input type="radio" name="language" id="rust">
           <div class="usage-grid">
             <div class="tab-list" role="tablist" aria-label="Language examples">
-              <label for="rust" role="tab">Rust</label>
-              <label for="python" role="tab">Python</label>
               <label for="node" role="tab">Node.js</label>
               <label for="cli" role="tab">CLI</label>
+              <label for="python" role="tab">Python</label>
+              <label for="rust" role="tab">Rust</label>
             </div>
             <div class="panels">
-              <div class="code-panel" id="panel-rust" role="tabpanel"><pre><span class="cm">// cargo add pdf-inspector</span>
-<span class="kw">use</span> pdf_inspector::process_pdf;
-
-<span class="kw">let</span> result = <span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)?;
-<span class="fn">println!</span>(<span class="str">"Type: {:?}"</span>, result.pdf_type);
-
-<span class="kw">if let</span> <span class="kw">Some</span>(markdown) = &amp;result.markdown {
-    <span class="fn">println!</span>(<span class="str">"{}"</span>, markdown);
-}
-
-<span class="cm">// </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/rust-api.md">Full Rust API reference ↗</a></pre></div>
-              <div class="code-panel" id="panel-python" role="tabpanel"><pre><span class="cm"># pip install pdf-inspector</span>
-<span class="kw">import</span> pdf_inspector
-
-result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)
-
-<span class="fn">print</span>(result.pdf_type)
-<span class="fn">print</span>(result.markdown)
-<span class="fn">print</span>(result.pages_needing_ocr)
-
-<span class="cm"># </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md">Full Python API reference ↗</a></pre></div>
               <div class="code-panel" id="panel-node" role="tabpanel"><pre><span class="cm">// npm i @firecrawl/pdf-inspector</span>
 <span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="str">'node:fs'</span>;
 <span class="kw">import</span> { processPdf } <span class="kw">from</span> <span class="str">'@firecrawl/pdf-inspector'</span>;
@@ -701,48 +664,42 @@ console.<span class="fn">log</span>(result.pdfType);
 console.<span class="fn">log</span>(result.markdown);
 
 <span class="cm">// </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/napi/README.md">Full Node.js API reference ↗</a></pre></div>
-              <div class="code-panel" id="panel-cli" role="tabpanel"><pre><span class="cm"># install both binaries</span>
-cargo <span class="fn">install</span> pdf-inspector
+              <div class="code-panel" id="panel-cli" role="tabpanel"><pre><span class="cm"># run directly from npm</span>
+npx <span class="fn">@firecrawl/pdf-inspector</span> document.pdf
 
-<span class="cm"># PDF → Markdown</span>
-<span class="fn">pdf2md</span> document.pdf
+<span class="cm"># or install the bundled CLI globally</span>
+npm install -g <span class="fn">@firecrawl/pdf-inspector</span>
+<span class="fn">pdf-inspector</span> document.pdf
 
 <span class="cm"># structured pipeline output</span>
-<span class="fn">pdf2md</span> document.pdf --json
+<span class="fn">pdf-inspector</span> document.pdf --json
 
-<span class="cm"># classification and layout analysis</span>
-<span class="fn">detect-pdf</span> document.pdf --analyze --json</pre></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+<span class="cm"># classification only</span>
+<span class="fn">pdf-inspector</span> detect document.pdf --json
 
-  <section id="contribute" class="full-rule">
-    <div class="shell">
-      <div class="section-label pad"><span>[ <b>05</b> / 05 ]</span><span>Project</span></div>
-      <div class="section-body pad">
-        <div class="section-intro">
-          <h2>Read it. Run it.<br>Improve it.</h2>
-          <p>The codebase is organized around the extraction pipeline, with unit, integration, and regression coverage for the PDF edge cases that matter. Start with the module closest to the behavior you want to understand.</p>
-        </div>
-        <div class="contribute-grid">
-          <div class="repo-map">
-            <div class="repo-title"><span>REPOSITORY MAP</span><span>firecrawl/pdf-inspector</span></div>
-            <div class="repo-files">
-              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/extractor"><code>src/extractor/</code><span>Content streams, fonts, links, layout, reading order</span></a>
-              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/tables"><code>src/tables/</code><span>Grid, rectangle, line, and heuristic table detection</span></a>
-              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/markdown"><code>src/markdown/</code><span>Analysis, classification, conversion, and cleanup</span></a>
-              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/napi"><code>napi/</code><span>Node.js and Bun bindings via napi-rs</span></a>
-              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/tests"><code>tests/</code><span>Fixtures, integration coverage, and snapshots</span></a>
+<span class="cm"># </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/napi/README.md">Node.js and CLI reference ↗</a></pre></div>
+              <div class="code-panel" id="panel-python" role="tabpanel"><pre><span class="cm"># pip install pdf-inspector</span>
+<span class="kw">import</span> pdf_inspector
+
+result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)
+
+<span class="fn">print</span>(result.pdf_type)
+<span class="fn">print</span>(result.markdown)
+<span class="fn">print</span>(result.pages_needing_ocr)
+
+<span class="cm"># </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md">Full Python API reference ↗</a></pre></div>
+              <div class="code-panel" id="panel-rust" role="tabpanel"><pre><span class="cm">// cargo add pdf-inspector</span>
+<span class="kw">use</span> pdf_inspector::process_pdf;
+
+<span class="kw">let</span> result = <span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)?;
+<span class="fn">println!</span>(<span class="str">"Type: {:?}"</span>, result.pdf_type);
+
+<span class="kw">if let</span> <span class="kw">Some</span>(markdown) = &amp;result.markdown {
+    <span class="fn">println!</span>(<span class="str">"{}"</span>, markdown);
+}
+
+<span class="cm">// </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/rust-api.md">Full Rust API reference ↗</a></pre></div>
             </div>
-          </div>
-          <div class="contribute-links">
-            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector"><span>Source</span><strong>Browse the repository ↗</strong></a>
-            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/issues"><span>Issues</span><strong>Report or pick up a bug ↗</strong></a>
-            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/pulls"><span>Contribute</span><strong>Open a pull request ↗</strong></a>
-            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/releases"><span>Releases</span><strong>See what changed ↗</strong></a>
           </div>
         </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -140,9 +140,16 @@
     gap: 64px;
     position: relative;
   }
-  .oss-label {
-    width: max-content;
+  .hero-labels {
     margin-bottom: 25px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .oss-label,
+  .rust-label {
+    width: max-content;
     padding: 6px 9px 6px 7px;
     display: flex;
     align-items: center;
@@ -156,6 +163,18 @@
     text-transform: uppercase;
   }
   .oss-label i { width: 6px; height: 16px; background: var(--heat); display: block; }
+  .rust-label {
+    padding-left: 8px;
+    border-color: var(--ink);
+    background: var(--ink);
+    color: var(--surface);
+  }
+  .rust-label i {
+    color: var(--heat);
+    font-style: normal;
+    font-weight: 700;
+    letter-spacing: -.03em;
+  }
   h1 {
     max-width: 780px;
     margin: 0;
@@ -457,9 +476,12 @@
   <div class="shell hero">
     <div class="hero-main pad">
       <div>
-        <div class="oss-label"><i aria-hidden="true"></i>Firecrawl open source · MIT</div>
+        <div class="hero-labels">
+          <div class="oss-label"><i aria-hidden="true"></i>Firecrawl open source · MIT</div>
+          <div class="rust-label"><i aria-hidden="true">RS</i>Rust core</div>
+        </div>
         <h1>PDF structure,<br><em>built for speed.</em></h1>
-        <p class="hero-copy">An open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Install it from npm, PyPI, or crates.io, or use the bundled command line.</p>
+        <p class="hero-copy">A Rust-powered, open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Use it from Node.js or the bundled CLI, with packages also available from PyPI and crates.io.</p>
         <div class="hero-actions">
           <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View on GitHub <span class="arrow" aria-hidden="true">↗</span></a>
           <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
@@ -483,6 +505,7 @@
         <div class="terminal-result">
           <span>document type</span><strong class="hot">TextBased</strong>
           <span>output</span><strong>structured Markdown</strong>
+          <span>engine</span><strong>Rust</strong>
         </div>
       </div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -3,422 +3,762 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>pdf-inspector — PDF classification &amp; text extraction, no OCR</title>
-<meta name="description" content="Fast Rust library that classifies PDFs (text-based vs scanned) and extracts clean Markdown — no OCR, no ML models. Bindings for Rust, Python, and Node.js.">
+<title>pdf-inspector — fast, open-source PDF to Markdown</title>
+<meta name="description" content="An open-source Rust library for fast PDF classification and structured Markdown extraction, with bindings for Rust, Python, Node.js, and the command line.">
+<meta name="theme-color" content="#f9f9f9">
 <meta property="og:title" content="pdf-inspector">
-<meta property="og:description" content="Classify PDFs and extract clean Markdown in milliseconds. No OCR. No ML. Pure Rust.">
+<meta property="og:description" content="Fast, open-source PDF classification and structured Markdown extraction. Built in Rust by Firecrawl.">
 <meta property="og:type" content="website">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%93%84%3C/text%3E%3C/svg%3E">
+<link rel="icon" href="assets/firecrawl-mark.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,800&family=Hanken+Grotesk:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet">
 <style>
   :root {
-    --paper: #f4efe4;
-    --paper-2: #eee7d8;
-    --ink: #1b1712;
-    --ink-soft: #4a433a;
-    --muted: #8b8375;
-    --line: #d9cfbb;
-    --accent: #dd3f22;
-    --accent-deep: #b32d15;
-    --card: #faf6ec;
-    --display: "Bricolage Grotesque", serif;
-    --body: "Hanken Grotesk", sans-serif;
-    --mono: "JetBrains Mono", monospace;
+    --heat: #fa5d19;
+    --heat-dark: #db4808;
+    --heat-4: rgba(250, 93, 25, 0.04);
+    --heat-8: rgba(250, 93, 25, 0.08);
+    --heat-16: rgba(250, 93, 25, 0.16);
+    --ink: #262626;
+    --ink-88: rgba(38, 38, 38, 0.88);
+    --ink-64: rgba(38, 38, 38, 0.64);
+    --ink-48: rgba(38, 38, 38, 0.48);
+    --ink-32: rgba(38, 38, 38, 0.32);
+    --ink-16: rgba(38, 38, 38, 0.16);
+    --ink-6: rgba(38, 38, 38, 0.06);
+    --base: #f9f9f9;
+    --lighter: #fbfbfb;
+    --surface: #ffffff;
+    --border: #ededed;
+    --border-muted: #e8e8e8;
+    --code: #1c1c1c;
+    --sans: "Geist", "Helvetica Neue", Arial, sans-serif;
+    --mono: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+    --width: 1112px;
   }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  html { scroll-behavior: smooth; }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; scroll-padding-top: 82px; }
   body {
-    background: var(--paper);
+    margin: 0;
+    background: var(--base);
     color: var(--ink);
-    font-family: var(--body);
-    font-size: 17px;
-    line-height: 1.6;
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.5;
     -webkit-font-smoothing: antialiased;
-    overflow-x: hidden;
-    background-image:
-      radial-gradient(circle at 1px 1px, rgba(27,23,18,0.05) 1px, transparent 0);
-    background-size: 22px 22px;
+    text-rendering: optimizeLegibility;
   }
-  ::selection { background: var(--accent); color: var(--paper); }
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+    background-image: linear-gradient(to right, rgba(38,38,38,.018) 1px, transparent 1px);
+    background-size: 64px 100%;
+    -webkit-mask-image: linear-gradient(to right, transparent, black 15%, black 85%, transparent);
+    mask-image: linear-gradient(to right, transparent, black 15%, black 85%, transparent);
+  }
+  ::selection { background: var(--heat-16); color: var(--heat-dark); }
   a { color: inherit; text-decoration: none; }
+  img { display: block; }
+  button, input { font: inherit; }
 
-  .wrap { max-width: 1120px; margin: 0 auto; padding: 0 28px; }
-
-  /* ── nav ── */
-  nav {
-    position: sticky; top: 0; z-index: 50;
-    background: rgba(244,239,228,0.82);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--line);
+  .shell {
+    width: min(calc(100% - 32px), var(--width));
+    margin: 0 auto;
+    border-left: 1px solid var(--border);
+    border-right: 1px solid var(--border);
   }
-  .nav-in { display: flex; align-items: center; gap: 22px; height: 60px; }
-  .brand { font-family: var(--mono); font-weight: 700; font-size: 15px; letter-spacing: -0.02em; display: flex; align-items: center; gap: 9px; }
-  .brand .dot { width: 9px; height: 9px; background: var(--accent); border-radius: 50%; box-shadow: 0 0 0 3px rgba(221,63,34,0.18); }
-  .nav-links { margin-left: auto; display: flex; gap: 24px; align-items: center; font-size: 14.5px; font-weight: 500; }
-  .nav-links a { color: var(--ink-soft); transition: color .15s; }
-  .nav-links a:hover { color: var(--accent); }
-  .nav-gh { border: 1px solid var(--ink); border-radius: 999px; padding: 6px 15px; color: var(--ink) !important; transition: all .15s; }
-  .nav-gh:hover { background: var(--ink); color: var(--paper) !important; }
-  @media (max-width: 680px) { .nav-links .hide-sm { display: none; } }
+  .pad { padding-left: clamp(22px, 4vw, 48px); padding-right: clamp(22px, 4vw, 48px); }
+  .full-rule { border-top: 1px solid var(--border); }
 
-  /* ── hero ── */
-  header { padding: 74px 0 40px; position: relative; }
-  .eyebrow { font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 22px; }
-  h1 {
-    font-family: var(--display);
-    font-weight: 800;
-    font-size: clamp(2.9rem, 8vw, 6.1rem);
-    line-height: 0.96;
-    letter-spacing: -0.035em;
-    max-width: 15ch;
+  .site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    height: 68px;
+    border-bottom: 1px solid var(--border);
+    background: rgba(249, 249, 249, 0.9);
+    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(14px);
   }
-  h1 .em { color: var(--accent); font-style: normal; position: relative; }
-  h1 .strike { position: relative; white-space: nowrap; }
-  h1 .strike::after { content: ""; position: absolute; left: -2%; right: -2%; top: 54%; height: 0.09em; background: var(--accent); transform: rotate(-3deg); }
-  .lede { margin-top: 28px; font-size: clamp(1.05rem, 2.2vw, 1.32rem); color: var(--ink-soft); max-width: 46ch; line-height: 1.5; }
-  .lede b { color: var(--ink); font-weight: 600; }
+  .nav-inner {
+    width: min(calc(100% - 32px), var(--width));
+    height: 100%;
+    margin: 0 auto;
+    padding: 0 18px;
+    display: flex;
+    align-items: center;
+    border-left: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+  }
+  .project-brand { display: flex; align-items: center; gap: 11px; font-weight: 500; letter-spacing: -0.02em; }
+  .project-brand img { width: 15px; height: 22px; }
+  .project-brand span { font-family: var(--mono); font-size: 14px; }
+  .project-brand small { color: var(--ink-32); font: 400 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .08em; }
+  .nav-links { margin-left: auto; display: flex; align-items: center; gap: 23px; color: var(--ink-64); font-size: 14px; }
+  .nav-links a { transition: color .15s ease; }
+  .nav-links a:hover, .nav-links a:focus-visible { color: var(--heat); }
+  .github-link {
+    height: 36px;
+    padding: 0 15px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--ink);
+    border-radius: 8px;
+    color: var(--surface) !important;
+    background: var(--ink);
+    font-weight: 500;
+  }
+  .github-link:hover, .github-link:focus-visible { background: var(--heat); border-color: var(--heat); }
 
-  .hero-grid { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 48px; align-items: end; }
-  @media (max-width: 880px) { .hero-grid { grid-template-columns: 1fr; gap: 40px; } }
-
-  /* readout card */
-  .readout {
-    background: var(--ink); color: var(--paper);
-    border-radius: 14px; padding: 22px 22px 20px;
-    font-family: var(--mono); font-size: 13px;
-    box-shadow: 14px 14px 0 rgba(27,23,18,0.09);
+  .hero { position: relative; overflow: hidden; }
+  .hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(var(--border) 1px, transparent 1px),
+      linear-gradient(90deg, var(--border) 1px, transparent 1px);
+    background-size: 56px 56px;
+    opacity: .36;
+    -webkit-mask-image: radial-gradient(circle at 72% 38%, black, transparent 56%);
+    mask-image: radial-gradient(circle at 72% 38%, black, transparent 56%);
+  }
+  .hero-main {
+    min-height: 588px;
+    padding-top: clamp(76px, 10vw, 122px);
+    padding-bottom: 72px;
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(310px, .75fr);
+    align-items: center;
+    gap: 64px;
     position: relative;
   }
-  .readout .rlabel { color: #b8ad98; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 16px; display: flex; justify-content: space-between; }
-  .readout .rrow { display: flex; justify-content: space-between; align-items: center; padding: 9px 0; border-top: 1px solid rgba(255,255,255,0.09); }
-  .readout .rrow:first-of-type { border-top: none; }
-  .readout .k { color: #cfc6b3; }
-  .readout .v { font-weight: 700; }
-  .readout .v.hot { color: var(--accent); }
-  .bar { height: 6px; background: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; margin-top: 3px; width: 96px; }
-  .bar > i { display: block; height: 100%; background: var(--accent); border-radius: 3px; }
-
-  /* ── install row ── */
-  .installs { display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; margin-top: 54px; }
-  @media (max-width: 720px) { .installs { grid-template-columns: 1fr; } }
-  .inst {
-    background: var(--card); border: 1px solid var(--line); border-radius: 11px;
-    padding: 15px 17px; transition: transform .16s, border-color .16s, box-shadow .16s;
-    cursor: pointer;
+  .oss-label {
+    width: max-content;
+    margin-bottom: 25px;
+    padding: 6px 9px 6px 7px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: 7px;
+    background: rgba(255,255,255,.78);
+    color: var(--ink-64);
+    font: 500 11px/1 var(--mono);
+    letter-spacing: .05em;
+    text-transform: uppercase;
   }
-  .inst:hover { transform: translateY(-3px); border-color: var(--accent); box-shadow: 0 8px 22px rgba(27,23,18,0.07); }
-  .inst .reg { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 8px; display: flex; justify-content: space-between; }
-  .inst code { font-family: var(--mono); font-size: 14px; color: var(--ink); font-weight: 500; }
-  .inst .arrow { color: var(--accent); opacity: 0; transition: opacity .16s; }
-  .inst:hover .arrow { opacity: 1; }
-
-  /* ── section scaffold ── */
-  section { padding: 66px 0; border-top: 1px solid var(--line); }
-  .sec-head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 40px; flex-wrap: wrap; }
-  .sec-num { font-family: var(--mono); font-size: 13px; color: var(--accent); font-weight: 700; }
-  .sec-title { font-family: var(--display); font-weight: 600; font-size: clamp(1.7rem, 4vw, 2.6rem); letter-spacing: -0.025em; }
-  .sec-sub { color: var(--ink-soft); max-width: 52ch; font-size: 1.02rem; }
-
-  /* ── features ── */
-  .feat-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
-  @media (max-width: 900px) { .feat-grid { grid-template-columns: repeat(2,1fr); } }
-  @media (max-width: 560px) { .feat-grid { grid-template-columns: 1fr; } }
-  .feat { background: var(--card); padding: 24px 22px; transition: background .16s; }
-  .feat:hover { background: #fff; }
-  .feat .fn { font-family: var(--mono); font-size: 12px; color: var(--accent); font-weight: 700; }
-  .feat h3 { font-family: var(--display); font-weight: 600; font-size: 1.16rem; margin: 12px 0 8px; letter-spacing: -0.01em; }
-  .feat p { font-size: 14.5px; color: var(--ink-soft); line-height: 1.5; }
-
-  /* ── benchmark ── */
-  .bench {
-    border: 1px solid var(--line); border-radius: 14px; overflow: hidden;
-    background: var(--card);
+  .oss-label i { width: 6px; height: 16px; background: var(--heat); display: block; }
+  h1 {
+    max-width: 780px;
+    margin: 0;
+    font-size: clamp(48px, 7.3vw, 82px);
+    font-weight: 500;
+    line-height: .99;
+    letter-spacing: -.055em;
   }
-  table { width: 100%; border-collapse: collapse; font-size: 15px; }
-  thead th { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); text-align: right; padding: 15px 18px; background: var(--paper-2); border-bottom: 1px solid var(--line); font-weight: 500; }
-  thead th:first-child { text-align: left; }
-  tbody td { padding: 14px 18px; text-align: right; font-family: var(--mono); border-bottom: 1px solid var(--line); }
-  tbody td:first-child { text-align: left; font-family: var(--body); font-weight: 500; }
-  tbody tr:last-child td { border-bottom: none; }
-  tbody tr.us { background: rgba(221,63,34,0.06); }
-  tbody tr.us td:first-child { color: var(--accent-deep); font-weight: 700; }
-  tbody tr.us td:first-child::before { content: "▸ "; color: var(--accent); }
-  .bench-foot { padding: 15px 18px; font-size: 13.5px; color: var(--ink-soft); background: var(--paper-2); border-top: 1px solid var(--line); }
-  .bench-wrap { overflow-x: auto; }
-  .callouts { display: grid; grid-template-columns: 1fr; gap: 16px; margin-top: 22px; }
-  .callout { border-left: 3px solid var(--accent); padding: 4px 0 4px 16px; }
-  .callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 5px; }
-  .callout p { font-size: 14.5px; color: var(--ink-soft); }
+  h1 em { color: var(--heat); font-style: normal; }
+  .hero-copy {
+    max-width: 650px;
+    margin: 27px 0 0;
+    color: var(--ink-64);
+    font-size: clamp(18px, 2vw, 21px);
+    line-height: 1.48;
+    letter-spacing: -.015em;
+  }
+  .hero-actions { margin-top: 31px; display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+  .button {
+    height: 44px;
+    padding: 0 17px;
+    border: 1px solid var(--border-muted);
+    border-radius: 9px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    background: var(--surface);
+    font-size: 14px;
+    font-weight: 500;
+    transition: transform .15s ease, border-color .15s ease, background .15s ease, color .15s ease;
+  }
+  .button:hover, .button:focus-visible { transform: translateY(-1px); border-color: var(--ink-32); }
+  .button-primary { color: #fff; background: var(--heat); border-color: var(--heat); }
+  .button-primary:hover, .button-primary:focus-visible { background: var(--heat-dark); border-color: var(--heat-dark); }
+  .button code { font: inherit; }
+  .arrow { font-family: var(--mono); color: currentColor; }
 
-  /* ── quickstart tabs ── */
+  .terminal {
+    border: 1px solid rgba(255,255,255,.08);
+    border-radius: 12px;
+    background: var(--code);
+    color: #f7f7f7;
+    box-shadow: 0 26px 65px rgba(38,38,38,.14);
+    overflow: hidden;
+    position: relative;
+  }
+  .terminal-head {
+    height: 42px;
+    padding: 0 14px;
+    border-bottom: 1px solid rgba(255,255,255,.08);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: rgba(255,255,255,.42);
+    font: 11px/1 var(--mono);
+  }
+  .term-dots { display: flex; gap: 5px; }
+  .term-dots i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.17); }
+  .terminal pre { margin: 0; padding: 24px 22px 28px; overflow-x: auto; font: 13px/1.75 var(--mono); }
+  .prompt { color: var(--heat); }
+  .term-muted { color: rgba(255,255,255,.38); }
+  .term-key { color: #ffb28f; }
+  .terminal-result {
+    margin: 0 18px 18px;
+    padding: 12px 13px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 7px 16px;
+    border: 1px solid rgba(255,255,255,.08);
+    border-radius: 7px;
+    background: rgba(255,255,255,.035);
+    color: rgba(255,255,255,.52);
+    font: 11px/1.3 var(--mono);
+  }
+  .terminal-result strong { color: #fff; font-weight: 500; }
+  .terminal-result strong.hot { color: #ff8b59; }
+
+  .project-strip {
+    min-height: 86px;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    border-top: 1px solid var(--border);
+  }
+  .project-stat { padding: 20px 24px; border-right: 1px solid var(--border); }
+  .project-stat:last-child { border-right: 0; }
+  .project-stat span { display: block; color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+  .project-stat strong { display: block; margin-top: 9px; font-size: 15px; font-weight: 500; letter-spacing: -.01em; }
+
+  .package-row { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--border); }
+  .package {
+    min-width: 0;
+    padding: 22px 24px;
+    border-right: 1px solid var(--border);
+    background: var(--lighter);
+    transition: background .15s ease;
+  }
+  .package:last-child { border-right: 0; }
+  .package:hover, .package:focus-visible { background: var(--heat-4); }
+  .package-top { display: flex; justify-content: space-between; color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+  .package code { display: block; margin-top: 12px; overflow: hidden; text-overflow: ellipsis; color: var(--ink-88); font: 13px/1.4 var(--mono); white-space: nowrap; }
+  .package:hover .package-top, .package:focus-visible .package-top { color: var(--heat); }
+
+  section { scroll-margin-top: 68px; }
+  .section-label {
+    min-height: 88px;
+    padding-top: 28px;
+    padding-bottom: 28px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    color: var(--ink-32);
+    font: 11px/1 var(--mono);
+    letter-spacing: .07em;
+    text-transform: uppercase;
+  }
+  .section-label::before { content: ""; width: 2px; height: 18px; background: var(--heat); }
+  .section-label b { color: var(--heat); font-weight: 500; }
+  .section-body { padding-top: clamp(64px, 8vw, 96px); padding-bottom: clamp(64px, 8vw, 96px); }
+  .section-intro { display: grid; grid-template-columns: .85fr 1.15fr; gap: 64px; margin-bottom: 48px; align-items: start; }
+  .section-intro h2 { margin: 0; font-size: clamp(34px, 5vw, 52px); line-height: 1.05; letter-spacing: -.04em; font-weight: 500; }
+  .section-intro p { max-width: 610px; margin: 4px 0 0; color: var(--ink-64); font-size: 17px; line-height: 1.58; }
+  .text-link { color: var(--heat-dark); text-decoration: underline; text-decoration-color: var(--heat-16); text-underline-offset: 4px; }
+  .text-link:hover, .text-link:focus-visible { text-decoration-color: var(--heat); }
+
+  .capability-grid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--border); }
+  .capability {
+    min-height: 245px;
+    padding: 27px 25px;
+    border-right: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .capability:nth-child(3n) { border-right: 0; }
+  .capability:nth-last-child(-n+3) { border-bottom: 0; }
+  .cap-id { display: flex; justify-content: space-between; color: var(--ink-32); font: 11px/1 var(--mono); }
+  .cap-id span:first-child { color: var(--heat); }
+  .capability h3 { margin: 54px 0 9px; font-size: 19px; font-weight: 500; letter-spacing: -.025em; }
+  .capability p { margin: 0; color: var(--ink-64); font-size: 14px; line-height: 1.55; }
+
+  .architecture {
+    border: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .arch-head { padding: 18px 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; color: var(--ink-32); font: 11px/1 var(--mono); }
+  .pipeline { padding: 34px; display: grid; grid-template-columns: .74fr 34px 1fr 34px 1fr 34px 1fr; align-items: stretch; }
+  .pipe-node { min-height: 156px; padding: 20px; border: 1px solid var(--border-muted); border-radius: 9px; background: var(--lighter); }
+  .pipe-node.source { background: var(--ink); color: white; border-color: var(--ink); display: flex; flex-direction: column; justify-content: space-between; }
+  .pipe-node .path-label { color: var(--ink-32); font: 10px/1.3 var(--mono); }
+  .pipe-node.source .path-label { color: rgba(255,255,255,.38); }
+  .pipe-node h3 { margin: 34px 0 6px; font-size: 16px; font-weight: 500; letter-spacing: -.02em; }
+  .pipe-node.source h3 { margin: 0; color: #fff; font: 500 18px/1.2 var(--mono); }
+  .pipe-node p { margin: 0; color: var(--ink-48); font-size: 12px; line-height: 1.45; }
+  .pipe-node.source p { color: rgba(255,255,255,.5); }
+  .pipe-node.split { display: grid; grid-template-rows: 1fr 1fr; gap: 8px; padding: 8px; }
+  .mini-node { padding: 11px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
+  .mini-node strong { display: block; font: 500 12px/1.3 var(--mono); }
+  .mini-node span { display: block; margin-top: 5px; color: var(--ink-32); font-size: 11px; }
+  .pipe-arrow { align-self: center; height: 1px; background: var(--border-muted); position: relative; }
+  .pipe-arrow::after { content: "›"; position: absolute; right: -2px; top: 50%; transform: translateY(-52%); color: var(--heat); font: 18px/1 var(--mono); }
+  .arch-foot { padding: 16px 20px; border-top: 1px solid var(--border); color: var(--ink-48); font-size: 13px; }
+  .arch-foot code { color: var(--ink-88); font: 12px var(--mono); }
+
+  .benchmark-card { border: 1px solid var(--border); background: var(--surface); overflow: hidden; }
+  .benchmark-top { padding: 17px 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; gap: 20px; color: var(--ink-48); font: 11px/1.4 var(--mono); }
+  .benchmark-top strong { color: var(--heat); font-weight: 500; }
+  .table-scroll { overflow-x: auto; }
+  table { width: 100%; min-width: 760px; border-collapse: collapse; font-size: 14px; }
+  th, td { padding: 16px 18px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); text-align: right; }
+  th:last-child, td:last-child { border-right: 0; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { background: var(--lighter); color: var(--ink-32); font: 500 10px/1.3 var(--mono); letter-spacing: .06em; text-transform: uppercase; white-space: nowrap; }
+  tbody td { color: var(--ink-64); font: 13px/1.3 var(--mono); }
+  tbody td:first-child { color: var(--ink-88); font-family: var(--sans); font-weight: 500; }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody tr.highlight { background: var(--heat-4); }
+  tbody tr.highlight td { color: var(--heat-dark); font-weight: 500; }
+  tbody tr.highlight td:first-child::before { content: ""; display: inline-block; width: 6px; height: 6px; margin-right: 9px; background: var(--heat); }
+  .benchmark-note { padding: 17px 20px; border-top: 1px solid var(--border); color: var(--ink-48); font-size: 12px; }
+  .best-fit { margin-top: 22px; padding: 24px 25px; border-left: 2px solid var(--heat); background: var(--heat-4); }
+  .best-fit strong { display: block; margin-bottom: 7px; color: var(--heat-dark); font: 500 11px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; }
+  .best-fit p { margin: 0; max-width: 960px; color: var(--ink-64); font-size: 15px; line-height: 1.58; }
+
+  .usage-grid { display: grid; grid-template-columns: 230px 1fr; border: 1px solid var(--border); background: var(--surface); }
   .tabs input { position: absolute; opacity: 0; pointer-events: none; }
-  .tablist { display: flex; gap: 6px; margin-bottom: 0; }
-  .tablist label {
-    font-family: var(--mono); font-size: 13px; font-weight: 500;
-    padding: 10px 18px; cursor: pointer; color: var(--muted);
-    border: 1px solid var(--line); border-bottom: none;
-    border-radius: 9px 9px 0 0; background: var(--paper-2); transition: all .15s;
+  .tab-list { border-right: 1px solid var(--border); background: var(--lighter); }
+  .tab-list label {
+    height: 55px;
+    padding: 0 18px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--ink-48);
+    cursor: pointer;
+    font: 12px/1 var(--mono);
   }
-  .tablist label:hover { color: var(--ink); }
-  .panel { display: none; }
-  .code {
-    background: var(--ink); border-radius: 0 12px 12px 12px;
-    padding: 22px 24px; overflow-x: auto;
-    font-family: var(--mono); font-size: 13.5px; line-height: 1.7;
-    color: #e9e2d3;
-    box-shadow: 12px 12px 0 rgba(27,23,18,0.07);
-  }
-  .code .cm { color: #8a8069; }
-  .code .kw { color: #ff9f7a; }
-  .code .st { color: #cbb78a; }
-  .code .fn { color: #f4efe4; font-weight: 700; }
-  #t-rust:checked ~ .tablist label[for=t-rust],
-  #t-py:checked ~ .tablist label[for=t-py],
-  #t-node:checked ~ .tablist label[for=t-node],
-  #t-cli:checked ~ .tablist label[for=t-cli] {
-    background: var(--ink); color: var(--paper); border-color: var(--ink);
-  }
-  #t-rust:checked ~ .panels #p-rust,
-  #t-py:checked ~ .panels #p-py,
-  #t-node:checked ~ .panels #p-node,
-  #t-cli:checked ~ .panels #p-cli { display: block; }
-  .code a.ref { color: #ff9f7a; border-bottom: 1px dotted #ff9f7a; }
+  .tab-list label::after { content: "↗"; opacity: 0; color: var(--heat); }
+  .tab-list label:hover { color: var(--ink); }
+  .code-panel { display: none; min-height: 355px; padding: 25px 27px; background: var(--code); color: #f5f5f5; overflow-x: auto; }
+  .code-panel pre { margin: 0; font: 13px/1.75 var(--mono); }
+  .code-panel .cm { color: rgba(255,255,255,.34); }
+  .code-panel .kw { color: #ff9c70; }
+  .code-panel .str { color: #d5bea9; }
+  .code-panel .fn { color: #fff; font-weight: 600; }
+  .code-panel a { color: #ff9c70; text-decoration: underline; text-underline-offset: 3px; }
+  #rust:checked ~ .usage-grid .tab-list label[for=rust],
+  #python:checked ~ .usage-grid .tab-list label[for=python],
+  #node:checked ~ .usage-grid .tab-list label[for=node],
+  #cli:checked ~ .usage-grid .tab-list label[for=cli] { color: var(--ink); background: var(--surface); box-shadow: inset 2px 0 var(--heat); }
+  #rust:checked ~ .usage-grid .tab-list label[for=rust]::after,
+  #python:checked ~ .usage-grid .tab-list label[for=python]::after,
+  #node:checked ~ .usage-grid .tab-list label[for=node]::after,
+  #cli:checked ~ .usage-grid .tab-list label[for=cli]::after { opacity: 1; }
+  #rust:checked ~ .usage-grid #panel-rust,
+  #python:checked ~ .usage-grid #panel-python,
+  #node:checked ~ .usage-grid #panel-node,
+  #cli:checked ~ .usage-grid #panel-cli { display: block; }
 
-  /* ── closing split (OSS vs hosted) ── */
-  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
-  @media (max-width: 780px) { .split { grid-template-columns: 1fr; } }
-  .path { border: 1px solid var(--line); border-radius: 16px; padding: 32px 30px; background: var(--card); display: flex; flex-direction: column; }
-  .path .ptag { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 15px; }
-  .path h3 { font-family: var(--display); font-weight: 600; font-size: 1.5rem; letter-spacing: -0.02em; line-height: 1.05; margin-bottom: 12px; }
-  .path p { color: var(--ink-soft); font-size: 15px; line-height: 1.5; flex: 1; margin-bottom: 24px; }
-  .pbtns { display: flex; gap: 12px; flex-wrap: wrap; }
-  .path-pro { background: var(--ink); border-color: var(--ink); box-shadow: 14px 14px 0 rgba(27,23,18,0.09); }
-  .path-pro .ptag { color: #b8ad98; }
-  .path-pro .ptag b { color: var(--accent); font-weight: 700; }
-  .path-pro h3 { color: var(--paper); }
-  .path-pro p { color: #cfc6b3; }
-  .btn { font-family: var(--mono); font-size: 14px; font-weight: 500; padding: 13px 24px; border-radius: 999px; transition: all .15s; border: 1px solid var(--ink); }
-  .btn-p { background: var(--accent); border-color: var(--accent); color: var(--paper); }
-  .btn-p:hover { background: var(--accent-deep); border-color: var(--accent-deep); }
-  .btn-s:hover { background: var(--ink); color: var(--paper); }
-  .btn-pro { background: var(--accent); border-color: var(--accent); color: var(--paper); }
-  .btn-pro:hover { background: var(--accent-deep); border-color: var(--accent-deep); }
-  .btn-ghost { color: var(--paper); border-color: rgba(255,255,255,0.3); }
-  .btn-ghost:hover { border-color: var(--paper); background: rgba(255,255,255,0.08); }
-  .fc-mark { height: 34px; width: auto; display: block; margin-bottom: 20px; }
-  .fc-wordmark { height: 15px; width: auto; vertical-align: -2px; transition: opacity .15s; }
-  .fc-wordmark:hover { opacity: 0.65; }
-  footer { border-top: 1px solid var(--line); padding: 34px 0; font-size: 14px; color: var(--muted); }
-  .foot-in { display: flex; justify-content: space-between; align-items: center; gap: 18px; flex-wrap: wrap; }
-  .foot-in a { color: var(--ink-soft); }
-  .foot-in a:hover { color: var(--accent); }
-  .foot-links { display: flex; gap: 20px; font-family: var(--mono); font-size: 13px; }
+  .contribute-grid { display: grid; grid-template-columns: 1.1fr .9fr; border: 1px solid var(--border); background: var(--surface); }
+  .repo-map { padding: 30px; border-right: 1px solid var(--border); }
+  .repo-title { display: flex; justify-content: space-between; margin-bottom: 24px; color: var(--ink-32); font: 11px/1 var(--mono); }
+  .repo-files { border-top: 1px solid var(--border); }
+  .repo-file { min-height: 54px; padding: 0 4px; border-bottom: 1px solid var(--border); display: grid; grid-template-columns: 160px 1fr; align-items: center; gap: 20px; }
+  .repo-file code { color: var(--heat-dark); font: 12px var(--mono); }
+  .repo-file span { color: var(--ink-48); font-size: 13px; }
+  .contribute-links { display: grid; grid-template-columns: 1fr 1fr; }
+  .contribute-link { min-height: 158px; padding: 23px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); display: flex; flex-direction: column; justify-content: space-between; }
+  .contribute-link:nth-child(2n) { border-right: 0; }
+  .contribute-link:nth-last-child(-n+2) { border-bottom: 0; }
+  .contribute-link span { color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; }
+  .contribute-link strong { font-size: 16px; font-weight: 500; }
+  .contribute-link:hover { background: var(--heat-4); }
+  .contribute-link:hover strong { color: var(--heat-dark); }
 
-  /* ── load animation ── */
-  .reveal { opacity: 0; transform: translateY(14px); animation: rise .7s cubic-bezier(.2,.7,.3,1) forwards; }
-  @keyframes rise { to { opacity: 1; transform: none; } }
-  .d1 { animation-delay: .05s; } .d2 { animation-delay: .15s; } .d3 { animation-delay: .25s; }
-  .d4 { animation-delay: .35s; } .d5 { animation-delay: .45s; } .d6 { animation-delay: .55s; }
-  @media (prefers-reduced-motion: reduce) { .reveal { animation: none; opacity: 1; transform: none; } }
+  .footer-main { min-height: 168px; padding-top: 36px; padding-bottom: 36px; display: flex; justify-content: space-between; align-items: flex-end; gap: 28px; }
+  .footer-brand { display: flex; align-items: center; gap: 10px; color: var(--ink-48); font-size: 13px; }
+  .footer-brand img { width: 102px; height: auto; }
+  .footer-links { display: flex; gap: 20px; flex-wrap: wrap; color: var(--ink-48); font: 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .05em; }
+  .footer-links a:hover { color: var(--heat); }
+
+  a:focus-visible, label:focus-visible { outline: 2px solid var(--heat); outline-offset: 3px; }
+
+  @media (max-width: 900px) {
+    .hero-main { grid-template-columns: 1fr; gap: 44px; }
+    .terminal { max-width: 580px; }
+    .section-intro { grid-template-columns: 1fr; gap: 20px; }
+    .capability-grid { grid-template-columns: repeat(2, 1fr); }
+    .capability:nth-child(3n) { border-right: 1px solid var(--border); }
+    .capability:nth-child(2n) { border-right: 0; }
+    .capability:nth-last-child(-n+3) { border-bottom: 1px solid var(--border); }
+    .capability:nth-last-child(-n+2) { border-bottom: 0; }
+    .pipeline { grid-template-columns: 1fr; gap: 12px; }
+    .pipe-arrow { width: 1px; height: 24px; justify-self: center; }
+    .pipe-arrow::after { right: auto; bottom: -7px; top: auto; transform: rotate(90deg); }
+    .pipe-node { min-height: 130px; }
+    .contribute-grid { grid-template-columns: 1fr; }
+    .repo-map { border-right: 0; border-bottom: 1px solid var(--border); }
+  }
+
+  @media (max-width: 680px) {
+    .nav-links a:not(.github-link) { display: none; }
+    .project-brand small { display: none; }
+    .hero-main { min-height: auto; padding-top: 70px; }
+    h1 { font-size: clamp(47px, 14vw, 66px); }
+    .project-strip { grid-template-columns: repeat(2, 1fr); }
+    .project-stat:nth-child(2) { border-right: 0; }
+    .project-stat:nth-child(-n+2) { border-bottom: 1px solid var(--border); }
+    .package-row { grid-template-columns: 1fr; }
+    .package { border-right: 0; border-bottom: 1px solid var(--border); }
+    .package:last-child { border-bottom: 0; }
+    .capability-grid { grid-template-columns: 1fr; }
+    .capability, .capability:nth-child(3n), .capability:nth-child(2n) { min-height: 210px; border-right: 0; border-bottom: 1px solid var(--border); }
+    .capability:last-child { border-bottom: 0; }
+    .pipeline { padding: 20px; }
+    .benchmark-top { flex-direction: column; gap: 7px; }
+    .usage-grid { grid-template-columns: 1fr; }
+    .tab-list { display: grid; grid-template-columns: repeat(4, 1fr); border-right: 0; border-bottom: 1px solid var(--border); overflow-x: auto; }
+    .tab-list label { padding: 0 10px; border-right: 1px solid var(--border); border-bottom: 0; justify-content: center; }
+    .tab-list label::after { display: none; }
+    #rust:checked ~ .usage-grid .tab-list label[for=rust],
+    #python:checked ~ .usage-grid .tab-list label[for=python],
+    #node:checked ~ .usage-grid .tab-list label[for=node],
+    #cli:checked ~ .usage-grid .tab-list label[for=cli] { box-shadow: inset 0 -2px var(--heat); }
+    .code-panel { padding: 22px 20px; min-height: 330px; }
+    .repo-file { grid-template-columns: 1fr; gap: 4px; padding: 13px 4px; }
+    .contribute-links { grid-template-columns: 1fr; }
+    .contribute-link, .contribute-link:nth-child(2n), .contribute-link:nth-last-child(-n+2) { min-height: 112px; border-right: 0; border-bottom: 1px solid var(--border); }
+    .contribute-link:last-child { border-bottom: 0; }
+    .footer-main { align-items: flex-start; flex-direction: column; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    *, *::before, *::after { transition-duration: .01ms !important; }
+  }
 </style>
 </head>
 <body>
 
-<nav>
-  <div class="wrap nav-in">
-    <a href="#top" class="brand"><span class="dot"></span>pdf-inspector</a>
+<nav class="site-nav" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="project-brand" href="#top" aria-label="pdf-inspector home">
+      <img src="assets/firecrawl-mark.svg" alt="" width="15" height="22">
+      <span>pdf-inspector</span>
+      <small>Open source</small>
+    </a>
     <div class="nav-links">
-      <a href="#features" class="hide-sm">Features</a>
-      <a href="#benchmark" class="hide-sm">Benchmark</a>
-      <a href="#start">Quick start</a>
-      <a class="nav-gh" href="https://github.com/firecrawl/pdf-inspector">GitHub ↗</a>
+      <a href="#capabilities">Capabilities</a>
+      <a href="#architecture">Architecture</a>
+      <a href="#benchmark">Benchmark</a>
+      <a href="#usage">Usage</a>
+      <a class="github-link" href="https://github.com/firecrawl/pdf-inspector">GitHub <span aria-hidden="true">↗</span></a>
     </div>
   </div>
 </nav>
 
-<header id="top">
-  <div class="wrap hero-grid">
-    <div>
-      <div class="eyebrow reveal d1">Rust · Python · Node · CLI</div>
-      <h1 class="reveal d2">Classify PDFs. Extract Markdown. <span class="strike">No OCR.</span></h1>
-      <p class="lede reveal d3">A fast Rust library that tells text-based PDFs from scanned ones, then extracts position-aware text and clean Markdown — <b>locally, in milliseconds</b>. Skip the OCR bill for the ~54% of PDFs that never needed it.</p>
-    </div>
-    <div class="readout reveal d4" aria-hidden="true">
-      <div class="rlabel"><span>classify_pdf()</span><span>~12ms</span></div>
-      <div class="rrow"><span class="k">type</span><span class="v hot">TextBased</span></div>
-      <div class="rrow"><span class="k">confidence</span><span class="v">0.98</span></div>
-      <div class="rrow"><span class="k">needs_ocr</span><span class="v">false</span></div>
-      <div class="rrow"><span class="k">route</span><span class="v">local&nbsp;→&nbsp;md</span></div>
-      <div class="rrow" style="border-top:1px solid rgba(255,255,255,.09);padding-top:13px">
-        <span class="k">signal</span>
-        <span class="bar"><i style="width:98%"></i></span>
+<main id="top">
+  <div class="shell hero">
+    <div class="hero-main pad">
+      <div>
+        <div class="oss-label"><i aria-hidden="true"></i>Firecrawl open source · MIT</div>
+        <h1>PDF structure,<br><em>built for speed.</em></h1>
+        <p class="hero-copy">A Rust library that classifies PDFs and turns native text into clean, position-aware Markdown. Run it locally from Rust, Python, Node.js, or the command line.</p>
+        <div class="hero-actions">
+          <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View source <span class="arrow" aria-hidden="true">↗</span></a>
+          <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
+        </div>
+      </div>
+
+      <div class="terminal" aria-label="pdf-inspector command line example">
+        <div class="terminal-head">
+          <div class="term-dots" aria-hidden="true"><i></i><i></i><i></i></div>
+          <span>pdf2md · local</span>
+        </div>
+        <pre><span class="prompt">$</span> cargo install pdf-inspector
+<span class="term-muted">   Installed package `pdf-inspector`</span>
+
+<span class="prompt">$</span> pdf2md annual-report.pdf
+<span class="term-key"># Annual report 2025</span>
+
+## Financial highlights
+| Metric | 2025 | 2024 |
+|---|---:|---:|</pre>
+        <div class="terminal-result">
+          <span>document type</span><strong class="hot">TextBased</strong>
+          <span>output</span><strong>structured Markdown</strong>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="wrap">
-    <div class="installs">
-      <a class="inst reveal d4" href="https://crates.io/crates/pdf-inspector">
-        <div class="reg"><span>crates.io</span><span class="arrow">↗</span></div>
+    <div class="project-strip" aria-label="Project details">
+      <div class="project-stat"><span>Core</span><strong>Pure Rust</strong></div>
+      <div class="project-stat"><span>Interfaces</span><strong>Rust · Python · Node · CLI</strong></div>
+      <div class="project-stat"><span>Binaries</span><strong>pdf2md · detect-pdf</strong></div>
+      <div class="project-stat"><span>License</span><strong>MIT</strong></div>
+    </div>
+
+    <div class="package-row" aria-label="Package installation">
+      <a class="package" href="https://crates.io/crates/pdf-inspector">
+        <span class="package-top"><span>crates.io</span><span>Rust ↗</span></span>
         <code>cargo add pdf-inspector</code>
       </a>
-      <a class="inst reveal d5" href="https://pypi.org/project/pdf-inspector/">
-        <div class="reg"><span>PyPI</span><span class="arrow">↗</span></div>
+      <a class="package" href="https://pypi.org/project/pdf-inspector/">
+        <span class="package-top"><span>PyPI</span><span>Python ↗</span></span>
         <code>pip install pdf-inspector</code>
       </a>
-      <a class="inst reveal d6" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
-        <div class="reg"><span>npm</span><span class="arrow">↗</span></div>
+      <a class="package" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
+        <span class="package-top"><span>npm</span><span>Node.js ↗</span></span>
         <code>npm i @firecrawl/pdf-inspector</code>
       </a>
     </div>
   </div>
-</header>
 
-<section id="features">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="sec-num">01</span>
-      <h2 class="sec-title">Built for routing, not just reading</h2>
-    </div>
-    <div class="feat-grid">
-      <div class="feat"><div class="fn">01</div><h3>Smart classification</h3><p>TextBased, Scanned, ImageBased, or Mixed in ~10–50ms by sampling content streams. Returns a confidence score and per-page OCR routing.</p></div>
-      <div class="feat"><div class="fn">02</div><h3>Position-aware text</h3><p>Extraction with font info, X/Y coordinates, and automatic multi-column reading order.</p></div>
-      <div class="feat"><div class="fn">03</div><h3>Markdown conversion</h3><p>Headings, bullet/numbered lists, code blocks, tables, bold/italic, URL linking, and page breaks.</p></div>
-      <div class="feat"><div class="fn">04</div><h3>Table detection</h3><p>Rectangle-based detection from drawing ops plus heuristic alignment detection. Financial tables, footnotes, and cross-page continuations.</p></div>
-      <div class="feat"><div class="fn">05</div><h3>CID font support</h3><p>ToUnicode CMap decoding for Type0/Identity-H fonts, with UTF-16BE, UTF-8, and Latin-1 encodings.</p></div>
-      <div class="feat"><div class="fn">06</div><h3>Multi-column layout</h3><p>Newspaper-style column detection, sequential reading order, and right-to-left text support.</p></div>
-      <div class="feat"><div class="fn">07</div><h3>Encoding checks</h3><p>Flags broken font encodings automatically so callers can fall back to OCR only when it's actually needed.</p></div>
-      <div class="feat"><div class="fn">08</div><h3>Lightweight</h3><p>Pure Rust. No ML models, no external services. A single parse shared between detection and extraction.</p></div>
-    </div>
-  </div>
-</section>
-
-<section id="benchmark">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="sec-num">02</span>
-      <h2 class="sec-title">Fastest of the direct-text engines</h2>
-      <p class="sec-sub">Evaluated on the <a href="https://github.com/opendataloader-project/opendataloader-bench" style="color:var(--accent-deep);border-bottom:1px solid var(--line)">opendataloader-bench</a> corpus (200 PDFs). Local engines without model-based PDF parsing; OCR disabled. Higher is better.</p>
-    </div>
-    <div class="bench">
-      <div class="bench-wrap">
-      <table>
-        <thead>
-          <tr><th>Engine</th><th>Overall</th><th>Reading order</th><th>Tables</th><th>Headings</th><th>200 docs</th></tr>
-        </thead>
-        <tbody>
-          <tr class="us"><td>pdf-inspector</td><td>0.875</td><td>0.915</td><td>0.814</td><td>0.788</td><td>2.8s</td></tr>
-          <tr><td>liteparse</td><td>0.870</td><td>0.908</td><td>0.693</td><td>0.811</td><td>13.9s</td></tr>
-          <tr><td>opendataloader</td><td>0.843</td><td>0.912</td><td>0.489</td><td>0.760</td><td>9.8s</td></tr>
-          <tr><td>pymupdf4llm</td><td>0.735</td><td>0.886</td><td>0.401</td><td>0.424</td><td>15.5s</td></tr>
-          <tr><td>markitdown</td><td>0.583</td><td>0.879</td><td>0.000</td><td>0.000</td><td>6.7s</td></tr>
-        </tbody>
-      </table>
+  <section id="capabilities" class="full-rule">
+    <div class="shell">
+      <div class="section-label pad"><span>[ <b>01</b> / 05 ]</span><span>Core capabilities</span></div>
+      <div class="section-body pad">
+        <div class="section-intro">
+          <h2>A focused PDF<br>toolchain.</h2>
+          <p>Detection, extraction, layout analysis, and Markdown conversion live in one compact project. The document is parsed once and shared across stages, keeping the pipeline fast and easy to embed.</p>
+        </div>
+        <div class="capability-grid">
+          <article class="capability">
+            <div class="cap-id"><span>01</span><span>detector.rs</span></div>
+            <h3>Document classification</h3>
+            <p>Identify TextBased, Scanned, ImageBased, or Mixed PDFs, with confidence scores and per-page signals for downstream routing.</p>
+          </article>
+          <article class="capability">
+            <div class="cap-id"><span>02</span><span>layout.rs</span></div>
+            <h3>Reading order</h3>
+            <p>Reconstruct multi-column and newspaper layouts from positioned text while preserving logical flow across the page.</p>
+          </article>
+          <article class="capability">
+            <div class="cap-id"><span>03</span><span>tables/</span></div>
+            <h3>Table structure</h3>
+            <p>Combine rectangle, line-grid, and alignment heuristics to recover cells, financial tables, and continuations across pages.</p>
+          </article>
+          <article class="capability">
+            <div class="cap-id"><span>04</span><span>tounicode.rs</span></div>
+            <h3>Font decoding</h3>
+            <p>Decode CID and Type0 fonts through ToUnicode CMaps, with fallbacks for common embedded font and character encodings.</p>
+          </article>
+          <article class="capability">
+            <div class="cap-id"><span>05</span><span>markdown/</span></div>
+            <h3>Semantic Markdown</h3>
+            <p>Emit headings, lists, tables, links, code, emphasis, captions, page markers, and token-efficient cleanup.</p>
+          </article>
+          <article class="capability">
+            <div class="cap-id"><span>06</span><span>lib.rs</span></div>
+            <h3>Local by default</h3>
+            <p>No model weights or external services. Use the Rust API directly or ship the maintained Python, Node.js, and CLI interfaces.</p>
+          </article>
+        </div>
       </div>
-      <div class="bench-foot">Refreshed July 16, 2026, on Apple M4 Pro. Speed is the median of three complete corpus runs.</div>
     </div>
-    <div class="callouts">
-      <div class="callout"><div class="ct">Best fit</div><p>Native-text PDFs where speed, reading order, and table structure matter. pdf-inspector delivered the highest overall, reading-order, and table scores, along with the fastest complete run in this benchmark. That makes it a strong local default for reports, research papers, financial documents, invoices, and legal PDFs that need clean, structured Markdown without adding OCR latency or infrastructure.</p></div>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section id="start">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="sec-num">03</span>
-      <h2 class="sec-title">Three lines to Markdown</h2>
-    </div>
-    <div class="tabs">
-      <input type="radio" name="tab" id="t-rust" checked>
-      <input type="radio" name="tab" id="t-py">
-      <input type="radio" name="tab" id="t-node">
-      <input type="radio" name="tab" id="t-cli">
-      <div class="tablist">
-        <label for="t-rust">Rust</label>
-        <label for="t-py">Python</label>
-        <label for="t-node">Node.js</label>
-        <label for="t-cli">CLI</label>
+  <section id="architecture" class="full-rule">
+    <div class="shell">
+      <div class="section-label pad"><span>[ <b>02</b> / 05 ]</span><span>Architecture</span></div>
+      <div class="section-body pad">
+        <div class="section-intro">
+          <h2>One parse.<br>Clear stages.</h2>
+          <p>The pipeline keeps raw PDF concerns separate from layout and semantic conversion. Each stage has a narrow job, and the modules map directly to the repository structure.</p>
+        </div>
+        <div class="architecture">
+          <div class="arch-head"><span>PROCESS_PDF()</span><span>src/</span></div>
+          <div class="pipeline">
+            <div class="pipe-node source">
+              <span class="path-label">INPUT</span>
+              <div><h3>PDF bytes</h3><p>Loaded once from path or memory</p></div>
+            </div>
+            <div class="pipe-arrow" aria-hidden="true"></div>
+            <div class="pipe-node split">
+              <div class="mini-node"><strong>detector</strong><span>PDF type + confidence</span></div>
+              <div class="mini-node"><strong>extractor</strong><span>Text, fonts, rects, links</span></div>
+            </div>
+            <div class="pipe-arrow" aria-hidden="true"></div>
+            <div class="pipe-node split">
+              <div class="mini-node"><strong>layout</strong><span>Lines, columns, order</span></div>
+              <div class="mini-node"><strong>tables</strong><span>Rows, columns, cells</span></div>
+            </div>
+            <div class="pipe-arrow" aria-hidden="true"></div>
+            <div class="pipe-node">
+              <span class="path-label">markdown/convert.rs</span>
+              <h3>Structured output</h3>
+              <p>Clean Markdown plus classification and extraction metadata.</p>
+            </div>
+          </div>
+          <div class="arch-foot">Start in <code>src/lib.rs</code>, use <code>process_pdf</code>, and opt into JSON or positioned items when your pipeline needs more structure.</div>
+        </div>
       </div>
-      <div class="panels">
-        <div class="panel" id="p-rust"><pre class="code"><span class="kw">use</span> pdf_inspector::process_pdf;
+    </div>
+  </section>
 
-<span class="kw">let</span> result = <span class="fn">process_pdf</span>(<span class="st">"document.pdf"</span>)?;
-<span class="fn">println!</span>(<span class="st">"Type: {:?}"</span>, result.pdf_type);
+  <section id="benchmark" class="full-rule">
+    <div class="shell">
+      <div class="section-label pad"><span>[ <b>03</b> / 05 ]</span><span>Benchmark</span></div>
+      <div class="section-body pad">
+        <div class="section-intro">
+          <h2>Measured on<br>real documents.</h2>
+          <p>Evaluated on the <a class="text-link" href="https://github.com/opendataloader-project/opendataloader-bench">opendataloader-bench</a> corpus of 200 PDFs. This comparison covers local engines without model-based PDF parsing, with OCR disabled. Higher scores are better.</p>
+        </div>
+        <div class="benchmark-card">
+          <div class="benchmark-top"><span><strong>200 PDFs</strong> · OpenDataLoader benchmark</span><span>Apple M4 Pro · median of 3 runs</span></div>
+          <div class="table-scroll">
+            <table aria-label="PDF extraction benchmark results">
+              <thead>
+                <tr><th>Engine</th><th>Overall</th><th>Reading order</th><th>Tables</th><th>Headings</th><th>Complete run</th></tr>
+              </thead>
+              <tbody>
+                <tr class="highlight"><td>pdf-inspector</td><td>0.875</td><td>0.915</td><td>0.814</td><td>0.788</td><td>2.8s</td></tr>
+                <tr><td>LiteParse</td><td>0.870</td><td>0.908</td><td>0.693</td><td>0.811</td><td>13.9s</td></tr>
+                <tr><td>OpenDataLoader</td><td>0.843</td><td>0.912</td><td>0.489</td><td>0.760</td><td>9.8s</td></tr>
+                <tr><td>PyMuPDF4LLM</td><td>0.735</td><td>0.886</td><td>0.401</td><td>0.424</td><td>15.5s</td></tr>
+                <tr><td>MarkItDown</td><td>0.583</td><td>0.879</td><td>0.000</td><td>0.000</td><td>6.7s</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="benchmark-note">Refreshed July 16, 2026. Scores use the benchmark’s NID, TEDS, and MHS evaluators.</div>
+        </div>
+        <div class="best-fit">
+          <strong>Best fit</strong>
+          <p>Native-text PDFs where speed, reading order, and table structure matter. pdf-inspector delivered the highest overall, reading-order, and table scores, along with the fastest complete run in this benchmark. That makes it a strong local default for reports, research papers, financial documents, invoices, and legal PDFs that need clean, structured Markdown without adding OCR latency or infrastructure.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="usage" class="full-rule">
+    <div class="shell">
+      <div class="section-label pad"><span>[ <b>04</b> / 05 ]</span><span>Usage</span></div>
+      <div class="section-body pad">
+        <div class="section-intro">
+          <h2>Use it from<br>your stack.</h2>
+          <p>The same processing pipeline is available across every interface. Choose a package for application code or install the binaries for scripts, shell pipelines, and quick inspection.</p>
+        </div>
+        <div class="tabs">
+          <input type="radio" name="language" id="rust" checked>
+          <input type="radio" name="language" id="python">
+          <input type="radio" name="language" id="node">
+          <input type="radio" name="language" id="cli">
+          <div class="usage-grid">
+            <div class="tab-list" role="tablist" aria-label="Language examples">
+              <label for="rust" role="tab">Rust</label>
+              <label for="python" role="tab">Python</label>
+              <label for="node" role="tab">Node.js</label>
+              <label for="cli" role="tab">CLI</label>
+            </div>
+            <div class="panels">
+              <div class="code-panel" id="panel-rust" role="tabpanel"><pre><span class="cm">// cargo add pdf-inspector</span>
+<span class="kw">use</span> pdf_inspector::process_pdf;
+
+<span class="kw">let</span> result = <span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)?;
+<span class="fn">println!</span>(<span class="str">"Type: {:?}"</span>, result.pdf_type);
+
 <span class="kw">if let</span> <span class="kw">Some</span>(markdown) = &amp;result.markdown {
-    <span class="fn">println!</span>(<span class="st">"{}"</span>, markdown);
+    <span class="fn">println!</span>(<span class="str">"{}"</span>, markdown);
 }
-<span class="cm">// full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/rust-api.md">docs/rust-api.md</a></pre></div>
-        <div class="panel" id="p-py"><pre class="code"><span class="kw">import</span> pdf_inspector
 
-result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="st">"document.pdf"</span>)
-<span class="fn">print</span>(result.pdf_type)   <span class="cm"># "text_based" | "scanned" | "image_based" | "mixed"</span>
-<span class="fn">print</span>(result.markdown)   <span class="cm"># Markdown string or None</span>
-<span class="cm"># full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md">docs/python.md</a></pre></div>
-        <div class="panel" id="p-node"><pre class="code"><span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="st">'fs'</span>;
-<span class="kw">import</span> { processPdf } <span class="kw">from</span> <span class="st">'@firecrawl/pdf-inspector'</span>;
+<span class="cm">// </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/rust-api.md">Full Rust API reference ↗</a></pre></div>
+              <div class="code-panel" id="panel-python" role="tabpanel"><pre><span class="cm"># pip install pdf-inspector</span>
+<span class="kw">import</span> pdf_inspector
 
-<span class="kw">const</span> result = <span class="fn">processPdf</span>(<span class="fn">readFileSync</span>(<span class="st">'document.pdf'</span>));
-console.<span class="fn">log</span>(result.pdfType);   <span class="cm">// "TextBased" | "Scanned" | ...</span>
-console.<span class="fn">log</span>(result.markdown);  <span class="cm">// Markdown string or null</span>
-<span class="cm">// full reference → </span><a class="ref" href="https://github.com/firecrawl/pdf-inspector/blob/main/napi/README.md">napi/README.md</a></pre></div>
-        <div class="panel" id="p-cli"><pre class="code"><span class="cm"># install the CLI tools</span>
+result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="str">"document.pdf"</span>)
+
+<span class="fn">print</span>(result.pdf_type)
+<span class="fn">print</span>(result.markdown)
+<span class="fn">print</span>(result.pages_needing_ocr)
+
+<span class="cm"># </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/docs/python.md">Full Python API reference ↗</a></pre></div>
+              <div class="code-panel" id="panel-node" role="tabpanel"><pre><span class="cm">// npm i @firecrawl/pdf-inspector</span>
+<span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="str">'node:fs'</span>;
+<span class="kw">import</span> { processPdf } <span class="kw">from</span> <span class="str">'@firecrawl/pdf-inspector'</span>;
+
+<span class="kw">const</span> result = <span class="fn">processPdf</span>(
+  <span class="fn">readFileSync</span>(<span class="str">'document.pdf'</span>)
+);
+
+console.<span class="fn">log</span>(result.pdfType);
+console.<span class="fn">log</span>(result.markdown);
+
+<span class="cm">// </span><a href="https://github.com/firecrawl/pdf-inspector/blob/main/napi/README.md">Full Node.js API reference ↗</a></pre></div>
+              <div class="code-panel" id="panel-cli" role="tabpanel"><pre><span class="cm"># install both binaries</span>
 cargo <span class="fn">install</span> pdf-inspector
 
-<span class="cm"># convert a PDF to Markdown</span>
+<span class="cm"># PDF → Markdown</span>
 <span class="fn">pdf2md</span> document.pdf
 
-<span class="cm"># classify only — is it scanned?</span>
-<span class="fn">detect-pdf</span> document.pdf --analyze --json
+<span class="cm"># structured pipeline output</span>
+<span class="fn">pdf2md</span> document.pdf --json
 
-<span class="cm"># structured output for pipelines</span>
-<span class="fn">pdf2md</span> document.pdf --json</pre></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="close">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="sec-num">04</span>
-      <h2 class="sec-title">Two ways to parse</h2>
-      <p class="sec-sub">Run the classifier locally for text-based PDFs; hand the scanned, OCR, and at-scale work to Firecrawl.</p>
-    </div>
-    <div class="split">
-      <div class="path">
-        <div class="ptag">Open source · runs local</div>
-        <h3>Use pdf-inspector yourself</h3>
-        <p>Pure-Rust library and CLI. Classify and extract text-based PDFs on your own machine in milliseconds — no external calls, no OCR bill, MIT licensed.</p>
-        <div class="pbtns">
-          <a class="btn btn-p" href="https://github.com/firecrawl/pdf-inspector">Get started</a>
-          <a class="btn btn-s" href="https://crates.io/crates/pdf-inspector">crates.io</a>
-        </div>
-      </div>
-      <div class="path path-pro">
-        <img class="fc-mark" src="assets/firecrawl-mark.svg" alt="Firecrawl" width="24" height="34">
-        <div class="ptag"><b>Firecrawl Parse</b> · hosted API</div>
-        <h3>Or let Firecrawl handle the hard ones</h3>
-        <p>Scanned documents, OCR, DOCX / XLSX / HTML, and parsing at scale — clean, LLM-ready Markdown from one API call. The downstream route for everything local parsing can't reach.</p>
-        <div class="pbtns">
-          <a class="btn btn-pro" href="https://docs.firecrawl.dev/api-reference/endpoint/parse">Firecrawl Parse ↗</a>
-          <a class="btn btn-ghost" href="https://firecrawl.dev">firecrawl.dev</a>
+<span class="cm"># classification and layout analysis</span>
+<span class="fn">detect-pdf</span> document.pdf --analyze --json</pre></div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<footer>
-  <div class="wrap foot-in">
-    <div style="display:flex;align-items:center;gap:7px">Built by <a href="https://firecrawl.dev"><img class="fc-wordmark" src="assets/firecrawl-wordmark.svg" alt="Firecrawl"></a> · MIT licensed</div>
-    <div class="foot-links">
+  <section id="contribute" class="full-rule">
+    <div class="shell">
+      <div class="section-label pad"><span>[ <b>05</b> / 05 ]</span><span>Project</span></div>
+      <div class="section-body pad">
+        <div class="section-intro">
+          <h2>Read it. Run it.<br>Improve it.</h2>
+          <p>The codebase is organized around the extraction pipeline, with unit, integration, and regression coverage for the PDF edge cases that matter. Start with the module closest to the behavior you want to understand.</p>
+        </div>
+        <div class="contribute-grid">
+          <div class="repo-map">
+            <div class="repo-title"><span>REPOSITORY MAP</span><span>firecrawl/pdf-inspector</span></div>
+            <div class="repo-files">
+              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/extractor"><code>src/extractor/</code><span>Content streams, fonts, links, layout, reading order</span></a>
+              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/tables"><code>src/tables/</code><span>Grid, rectangle, line, and heuristic table detection</span></a>
+              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/src/markdown"><code>src/markdown/</code><span>Analysis, classification, conversion, and cleanup</span></a>
+              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/napi"><code>napi/</code><span>Node.js and Bun bindings via napi-rs</span></a>
+              <a class="repo-file" href="https://github.com/firecrawl/pdf-inspector/tree/main/tests"><code>tests/</code><span>Fixtures, integration coverage, and snapshots</span></a>
+            </div>
+          </div>
+          <div class="contribute-links">
+            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector"><span>Source</span><strong>Browse the repository ↗</strong></a>
+            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/issues"><span>Issues</span><strong>Report or pick up a bug ↗</strong></a>
+            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/pulls"><span>Contribute</span><strong>Open a pull request ↗</strong></a>
+            <a class="contribute-link" href="https://github.com/firecrawl/pdf-inspector/releases"><span>Releases</span><strong>See what changed ↗</strong></a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="full-rule">
+  <div class="shell footer-main pad">
+    <div class="footer-brand"><span>Built by</span><a href="https://firecrawl.dev"><img src="assets/firecrawl-wordmark.svg" alt="Firecrawl" width="102" height="24"></a><span>· MIT licensed</span></div>
+    <div class="footer-links">
       <a href="https://github.com/firecrawl/pdf-inspector">GitHub</a>
       <a href="https://crates.io/crates/pdf-inspector">crates.io</a>
       <a href="https://pypi.org/project/pdf-inspector/">PyPI</a>
       <a href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">npm</a>
+      <a href="#top">Back to top ↑</a>
     </div>
   </div>
 </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>pdf-inspector — fast, open-source PDF to Markdown</title>
-<meta name="description" content="A fast, open-source Node.js package and CLI for PDF classification and structured Markdown extraction, powered by a native Rust core.">
+<meta name="description" content="A fast, open-source PDF parser for structured Markdown extraction, available through npm, PyPI, crates.io, and the command line.">
 <meta name="theme-color" content="#f9f9f9">
 <meta property="og:title" content="pdf-inspector">
-<meta property="og:description" content="A fast Node.js package and bundled CLI for PDF classification and structured Markdown extraction, powered by Rust.">
+<meta property="og:description" content="Fast PDF classification and structured Markdown extraction for Node.js, Python, Rust, and the command line.">
 <meta property="og:type" content="website">
 <link rel="icon" href="assets/firecrawl-mark.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -192,8 +192,6 @@
   .button-primary { color: #fff; background: var(--heat); border-color: var(--heat); }
   .button-primary:hover, .button-primary:focus-visible { background: var(--heat-dark); border-color: var(--heat-dark); }
   .button code { font: inherit; }
-  .source-link { padding: 0 5px; color: var(--ink-48); font-size: 14px; text-decoration: underline; text-decoration-color: var(--ink-16); text-underline-offset: 4px; }
-  .source-link:hover, .source-link:focus-visible { color: var(--heat-dark); text-decoration-color: var(--heat); }
   .arrow { font-family: var(--mono); color: currentColor; }
 
   .terminal {
@@ -236,32 +234,31 @@
   .terminal-result strong { color: #fff; font-weight: 500; }
   .terminal-result strong.hot { color: #ff8b59; }
 
-  .project-strip {
-    min-height: 86px;
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    border-top: 1px solid var(--border);
-  }
-  .project-stat { padding: 20px 24px; border-right: 1px solid var(--border); }
-  .project-stat:last-child { border-right: 0; }
-  .project-stat span { display: block; color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
-  .project-stat strong { display: block; margin-top: 9px; font-size: 15px; font-weight: 500; letter-spacing: -.01em; }
-
-  .package-row { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--border); }
+  .package-row { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--border); background: var(--surface); }
   .package {
     min-width: 0;
-    padding: 22px 24px;
+    min-height: 154px;
+    padding: 23px 24px 20px;
     border-right: 1px solid var(--border);
-    background: var(--lighter);
-    transition: background .15s ease;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background: var(--surface);
+    transition: background .15s ease, box-shadow .15s ease;
   }
   .package:last-child { border-right: 0; }
-  .package:hover, .package:focus-visible { background: var(--heat-4); }
-  .package-top { display: flex; justify-content: space-between; color: var(--ink-32); font: 10px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
-  .package code { display: block; margin-top: 12px; overflow: hidden; text-overflow: ellipsis; color: var(--ink-88); font: 13px/1.4 var(--mono); white-space: nowrap; }
-  .package:hover .package-top, .package:focus-visible .package-top { color: var(--heat); }
-  .package-featured { background: var(--heat-4); box-shadow: inset 0 2px var(--heat); }
-  .package-featured .package-top { color: var(--heat-dark); }
+  .package:hover, .package:focus-visible { background: var(--heat-4); box-shadow: inset 0 2px var(--heat); }
+  .package-heading { display: flex; align-items: center; gap: 12px; }
+  .registry-icon { width: 42px; height: 38px; flex: 0 0 auto; border-radius: 7px; display: inline-flex; align-items: center; justify-content: center; font-family: var(--mono); font-weight: 600; }
+  .registry-npm { background: #cb3837; color: #fff; font-size: 11px; letter-spacing: -.08em; }
+  .registry-pypi { border: 1px solid #3775a9; background: #3775a9; color: #ffd343; font-size: 14px; }
+  .registry-crates { background: var(--ink); color: #fff; font-size: 13px; }
+  .registry-name { min-width: 0; }
+  .registry-name strong { display: block; font-size: 16px; line-height: 1.15; font-weight: 500; letter-spacing: -.02em; }
+  .registry-name small { display: block; margin-top: 4px; color: var(--ink-48); font: 10px/1.2 var(--mono); text-transform: uppercase; letter-spacing: .05em; }
+  .package-arrow { margin-left: auto; color: var(--ink-32); font: 14px/1 var(--mono); }
+  .package code { display: block; margin-top: 22px; padding-top: 13px; border-top: 1px solid var(--border); overflow: hidden; text-overflow: ellipsis; color: var(--ink-64); font: 12px/1.4 var(--mono); white-space: nowrap; }
+  .package:hover .package-arrow, .package:focus-visible .package-arrow { color: var(--heat); }
 
   section { scroll-margin-top: 68px; }
   .section-label {
@@ -408,9 +405,6 @@
     .project-brand small { display: none; }
     .hero-main { min-height: auto; padding-top: 70px; }
     h1 { font-size: clamp(47px, 14vw, 66px); }
-    .project-strip { grid-template-columns: repeat(2, 1fr); }
-    .project-stat:nth-child(2) { border-right: 0; }
-    .project-stat:nth-child(-n+2) { border-bottom: 1px solid var(--border); }
     .package-row { grid-template-columns: 1fr; }
     .package { border-right: 0; border-bottom: 1px solid var(--border); }
     .package:last-child { border-bottom: 0; }
@@ -447,6 +441,7 @@
       <small>Open source</small>
     </a>
     <div class="nav-links">
+      <a href="#packages">Packages</a>
       <a href="#capabilities">Capabilities</a>
       <a href="#architecture">Architecture</a>
       <a href="#benchmark">Benchmark</a>
@@ -462,12 +457,10 @@
       <div>
         <div class="oss-label"><i aria-hidden="true"></i>Firecrawl open source · MIT</div>
         <h1>PDF structure,<br><em>built for speed.</em></h1>
-        <p class="hero-copy">A native Node.js package and bundled CLI that classify PDFs and turn native text into clean, position-aware Markdown. Install once from npm, then use it in code or from your shell.</p>
+        <p class="hero-copy">An open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Install it from npm, PyPI, or crates.io, or use the bundled command line.</p>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">npm package <span class="arrow" aria-hidden="true">↗</span></a>
-          <a class="button" href="https://pypi.org/project/pdf-inspector/">PyPI <span class="arrow" aria-hidden="true">↗</span></a>
-          <a class="button" href="https://crates.io/crates/pdf-inspector">crates.io <span class="arrow" aria-hidden="true">↗</span></a>
-          <a class="source-link" href="https://github.com/firecrawl/pdf-inspector">View source</a>
+          <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View on GitHub <span class="arrow" aria-hidden="true">↗</span></a>
+          <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
 
@@ -492,24 +485,29 @@
       </div>
     </div>
 
-    <div class="project-strip" aria-label="Project details">
-      <div class="project-stat"><span>Primary API</span><strong>Node.js · TypeScript</strong></div>
-      <div class="project-stat"><span>Bundled CLI</span><strong>pdf-inspector</strong></div>
-      <div class="project-stat"><span>Native core</span><strong>Pure Rust</strong></div>
-      <div class="project-stat"><span>License</span><strong>MIT</strong></div>
-    </div>
-
-    <div class="package-row" aria-label="Package installation">
-      <a class="package package-featured" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
-        <span class="package-top"><span>npm · primary</span><span>Node.js + CLI ↗</span></span>
+    <div class="package-row" id="packages" aria-label="Package registries">
+      <a class="package" href="https://www.npmjs.com/package/@firecrawl/pdf-inspector">
+        <span class="package-heading">
+          <span class="registry-icon registry-npm" aria-hidden="true">npm</span>
+          <span class="registry-name"><strong>npm</strong><small>Node.js + CLI</small></span>
+          <span class="package-arrow" aria-hidden="true">↗</span>
+        </span>
         <code>npm i @firecrawl/pdf-inspector</code>
       </a>
       <a class="package" href="https://pypi.org/project/pdf-inspector/">
-        <span class="package-top"><span>PyPI</span><span>Python ↗</span></span>
+        <span class="package-heading">
+          <span class="registry-icon registry-pypi" aria-hidden="true">Py</span>
+          <span class="registry-name"><strong>PyPI</strong><small>Python</small></span>
+          <span class="package-arrow" aria-hidden="true">↗</span>
+        </span>
         <code>pip install pdf-inspector</code>
       </a>
       <a class="package" href="https://crates.io/crates/pdf-inspector">
-        <span class="package-top"><span>crates.io</span><span>Rust ↗</span></span>
+        <span class="package-heading">
+          <span class="registry-icon registry-crates" aria-hidden="true">Cr</span>
+          <span class="registry-name"><strong>crates.io</strong><small>Rust</small></span>
+          <span class="package-arrow" aria-hidden="true">↗</span>
+        </span>
         <code>cargo add pdf-inspector</code>
       </a>
     </div>
@@ -551,8 +549,8 @@
           </article>
           <article class="capability">
             <div class="cap-id"><span>06</span><span>napi/</span></div>
-            <h3>Node-first delivery</h3>
-            <p>Prebuilt native binaries, TypeScript definitions, and the bundled pdf-inspector CLI ship together through npm.</p>
+            <h3>Packaged for your stack</h3>
+            <p>Install from npm, PyPI, or crates.io. The npm package also includes TypeScript definitions and the bundled pdf-inspector CLI.</p>
           </article>
         </div>
       </div>
@@ -591,7 +589,7 @@
               <p>Clean Markdown plus classification and extraction metadata.</p>
             </div>
           </div>
-          <div class="arch-foot">Start with <code>@firecrawl/pdf-inspector</code> and <code>processPdf</code>, or run the bundled <code>pdf-inspector</code> CLI. Both use the same Rust pipeline.</div>
+          <div class="arch-foot">Call <code>processPdf</code> from Node.js, <code>process_pdf</code> from Python or Rust, or run the bundled <code>pdf-inspector</code> CLI. Every interface uses the same Rust pipeline.</div>
         </div>
       </div>
     </div>
@@ -637,7 +635,7 @@
       <div class="section-body pad">
         <div class="section-intro">
           <h2>Start with Node.<br>Use the CLI.</h2>
-          <p>The npm package is the main entry point: import the native Node.js API in application code or use the bundled pdf-inspector command for scripts and shell pipelines. Python and Rust packages expose the same core when you need them.</p>
+          <p>Import the native Node.js API in application code or use the bundled pdf-inspector command for scripts and shell pipelines. Python and Rust packages expose the same processing core.</p>
         </div>
         <div class="tabs">
           <input type="radio" name="language" id="node" checked>

--- a/site/index.html
+++ b/site/index.html
@@ -215,7 +215,7 @@
   }
   .term-dots { display: flex; gap: 5px; }
   .term-dots i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.17); }
-  .terminal pre { margin: 0; padding: 24px 22px 28px; overflow-x: auto; font: 13px/1.75 var(--mono); }
+  .terminal pre { margin: 0; padding: 24px 22px 28px; overflow-x: hidden; white-space: pre-wrap; overflow-wrap: anywhere; font: 13px/1.75 var(--mono); }
   .prompt { color: var(--heat); }
   .term-muted { color: rgba(255,255,255,.38); }
   .term-key { color: #ffb28f; }

--- a/site/index.html
+++ b/site/index.html
@@ -213,7 +213,7 @@
   .button code { font: inherit; }
   .arrow { font-family: var(--mono); color: currentColor; }
 
-  .playground {
+  .terminal {
     border: 1px solid rgba(255,255,255,.08);
     border-radius: 12px;
     background: var(--code);
@@ -222,99 +222,36 @@
     overflow: hidden;
     position: relative;
   }
-  .playground-switcher {
-    min-height: 53px;
-    padding: 9px 10px;
-    border-bottom: 1px solid rgba(255,255,255,.08);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    background: #181818;
-  }
-  .playground-switch {
-    padding: 3px;
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    border: 1px solid rgba(255,255,255,.08);
-    border-radius: 8px;
-    background: rgba(255,255,255,.035);
-  }
-  .playground-switch button {
-    height: 27px;
-    padding: 0 9px;
-    border: 0;
-    border-radius: 5px;
-    color: rgba(255,255,255,.48);
-    background: transparent;
-    cursor: pointer;
-    font: 500 10px/1 var(--mono);
-    transition: color .15s ease, background .15s ease, box-shadow .15s ease;
-  }
-  .playground-switch button:hover { color: #fff; }
-  .language-switch button[aria-pressed="true"] {
-    color: var(--ink);
-    background: #fff;
-    box-shadow: 0 1px 5px rgba(0,0,0,.25);
-  }
-  .mode-switch button[aria-pressed="true"] { color: #ff9c70; background: var(--heat-16); }
   .terminal-head {
-    height: 40px;
+    height: 42px;
     padding: 0 14px;
     border-bottom: 1px solid rgba(255,255,255,.08);
     display: flex;
     align-items: center;
-    gap: 9px;
+    justify-content: space-between;
     color: rgba(255,255,255,.42);
     font: 11px/1 var(--mono);
   }
   .term-dots { display: flex; gap: 5px; }
   .term-dots i { width: 7px; height: 7px; border-radius: 50%; background: rgba(255,255,255,.17); }
-  .example-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .copy-button {
-    margin-left: auto;
-    padding: 4px 6px;
-    border: 0;
-    border-radius: 4px;
-    color: rgba(255,255,255,.42);
-    background: transparent;
-    cursor: pointer;
-    font: 10px/1 var(--mono);
-  }
-  .copy-button:hover, .copy-button:focus-visible { color: #fff; background: rgba(255,255,255,.06); }
-  .playground-body { min-height: 245px; }
-  .playground-panel {
-    min-height: 245px;
-    margin: 0;
-    padding: 22px 18px 24px;
-    overflow-x: hidden;
-    white-space: pre;
-    font: 11px/1.75 var(--mono);
-  }
-  .playground-panel[hidden] { display: none; }
-  .playground .cm { color: rgba(255,255,255,.34); }
-  .playground .kw { color: #ff9c70; }
-  .playground .str { color: #d5bea9; }
-  .playground .fn { color: #fff; font-weight: 600; }
+  .terminal pre { margin: 0; padding: 24px 18px 28px; overflow-x: hidden; white-space: pre; font: 12px/1.75 var(--mono); }
   .prompt { color: var(--heat); }
   .term-muted { color: rgba(255,255,255,.38); }
   .term-key { color: #ffb28f; }
-  .playground-meta {
-    min-height: 42px;
-    padding: 0 14px;
-    border-top: 1px solid rgba(255,255,255,.08);
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    flex-wrap: wrap;
+  .terminal-result {
+    margin: 0 18px 18px;
+    padding: 12px 13px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 7px 16px;
+    border: 1px solid rgba(255,255,255,.08);
+    border-radius: 7px;
+    background: rgba(255,255,255,.035);
     color: rgba(255,255,255,.52);
-    font: 10px/1.3 var(--mono);
+    font: 11px/1.3 var(--mono);
   }
-  .playground-meta span { display: inline-flex; align-items: center; gap: 6px; }
-  .playground-meta span::before { content: ""; width: 4px; height: 4px; background: rgba(255,255,255,.24); }
-  .playground-meta span:first-child { color: #ff9c70; }
-  .playground-meta span:first-child::before { background: var(--heat); }
+  .terminal-result strong { color: #fff; font-weight: 500; }
+  .terminal-result strong.hot { color: #ff8b59; }
 
   .package-row { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--border); background: var(--surface); }
   .package {
@@ -466,11 +403,11 @@
   .footer-links { display: flex; gap: 20px; flex-wrap: wrap; color: var(--ink-48); font: 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .05em; }
   .footer-links a:hover { color: var(--heat); }
 
-  a:focus-visible, button:focus-visible, label:focus-visible { outline: 2px solid var(--heat); outline-offset: 3px; }
+  a:focus-visible, label:focus-visible { outline: 2px solid var(--heat); outline-offset: 3px; }
 
   @media (max-width: 900px) {
     .hero-main { grid-template-columns: 1fr; gap: 44px; }
-    .playground { max-width: 580px; }
+    .terminal { max-width: 580px; }
     .section-intro { grid-template-columns: 1fr; gap: 20px; }
     .capability-grid { grid-template-columns: repeat(2, 1fr); }
     .capability:nth-child(3n) { border-right: 1px solid var(--border); }
@@ -488,12 +425,7 @@
     .project-brand small { display: none; }
     .hero-main { min-height: auto; padding-top: 70px; }
     h1 { font-size: clamp(47px, 14vw, 66px); }
-    .playground-switcher { align-items: stretch; flex-direction: column; }
-    .playground-switch { display: grid; }
-    .language-switch { grid-template-columns: repeat(3, 1fr); }
-    .mode-switch { grid-template-columns: repeat(2, 1fr); }
-    .playground-switch button { width: 100%; }
-    .playground-panel { padding: 20px 16px 22px; font-size: 10.5px; }
+    .terminal pre { padding: 20px 16px 24px; font-size: 11px; }
     .package-row { grid-template-columns: 1fr; }
     .package { border-right: 0; border-bottom: 1px solid var(--border); }
     .package:last-child { border-bottom: 0; }
@@ -549,85 +481,31 @@
           <div class="rust-label"><i aria-hidden="true">RS</i>Rust core</div>
         </div>
         <h1>PDF structure,<br><em>built for speed.</em></h1>
-        <p class="hero-copy">A Rust-powered, open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Use the native core from Node.js, Python, or Rust, or drop into the bundled CLI.</p>
+        <p class="hero-copy">A Rust-powered, open-source parser that classifies PDFs and turns native text into clean, position-aware Markdown. Use it from Node.js or the bundled CLI, with packages also available from PyPI and crates.io.</p>
         <div class="hero-actions">
           <a class="button button-primary" href="https://github.com/firecrawl/pdf-inspector">View on GitHub <span class="arrow" aria-hidden="true">↗</span></a>
           <a class="button" href="https://github.com/firecrawl/pdf-inspector#quick-start">Read the docs <span class="arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
 
-      <div class="playground" data-playground aria-label="Interactive pdf-inspector examples">
-        <div class="playground-switcher">
-          <div class="playground-switch language-switch" role="group" aria-label="Language">
-            <button type="button" data-language="node" aria-pressed="true">Node.js</button>
-            <button type="button" data-language="python" aria-pressed="false">Python</button>
-            <button type="button" data-language="rust" aria-pressed="false">Rust</button>
-          </div>
-          <div class="playground-switch mode-switch" role="group" aria-label="Example type">
-            <button type="button" data-mode="code" aria-pressed="true">Code</button>
-            <button type="button" data-mode="cli" aria-pressed="false">CLI</button>
-          </div>
-        </div>
+      <div class="terminal" aria-label="pdf-inspector command line example">
         <div class="terminal-head">
           <div class="term-dots" aria-hidden="true"><i></i><i></i><i></i></div>
-          <span class="example-title">npm · Node.js code</span>
-          <button class="copy-button" type="button" aria-label="Copy example">Copy</button>
+          <span>npm CLI · local</span>
         </div>
-        <div class="playground-body" aria-live="polite">
-          <pre class="playground-panel" data-example="node-code" data-title="npm · Node.js code"><span class="kw">import</span> { readFileSync } <span class="kw">from</span> <span class="str">'node:fs'</span>;
-<span class="kw">import</span> {
-  processPdf
-} <span class="kw">from</span> <span class="str">'@firecrawl/pdf-inspector'</span>;
-
-<span class="kw">const</span> pdf = <span class="fn">readFileSync</span>(<span class="str">'annual-report.pdf'</span>);
-<span class="kw">const</span> result = <span class="fn">processPdf</span>(pdf);
-
-console.<span class="fn">log</span>(result.markdown);</pre>
-          <pre class="playground-panel" data-example="node-cli" data-title="npm · bundled CLI" hidden><span class="prompt">$</span> npm i -g @firecrawl/pdf-inspector
-<span class="term-muted">   installed native package + CLI</span>
+        <pre><span class="prompt">$</span> npm i -g @firecrawl/pdf-inspector
+<span class="term-muted">   installed the native package + CLI</span>
 
 <span class="prompt">$</span> pdf-inspector annual-report.pdf
 <span class="term-key"># Annual report 2025</span>
 
 ## Financial highlights
-| Metric | 2025 | 2024 |</pre>
-          <pre class="playground-panel" data-example="python-code" data-title="PyPI · Python code" hidden><span class="kw">import</span> pdf_inspector
-
-result = pdf_inspector.<span class="fn">process_pdf</span>(
-    <span class="str">"annual-report.pdf"</span>
-)
-
-<span class="fn">print</span>(result.pdf_type)
-<span class="fn">print</span>(result.markdown)</pre>
-          <pre class="playground-panel" data-example="python-cli" data-title="PyPI · Python shell" hidden><span class="prompt">$</span> pip install pdf-inspector
-<span class="prompt">$</span> python
-
-<span class="term-key">&gt;&gt;&gt;</span> import pdf_inspector as pdf
-<span class="term-key">&gt;&gt;&gt;</span> result = pdf.process_pdf(<span class="str">"report.pdf"</span>)
-<span class="term-key">&gt;&gt;&gt;</span> print(result.markdown)
-<span class="term-key"># Annual report 2025</span></pre>
-          <pre class="playground-panel" data-example="rust-code" data-title="crates.io · Rust code" hidden><span class="kw">use</span> pdf_inspector::process_pdf;
-
-<span class="kw">let</span> result = <span class="fn">process_pdf</span>(
-    <span class="str">"annual-report.pdf"</span>
-)?;
-
-<span class="kw">if let Some</span>(markdown) = result.markdown {
-    <span class="fn">println!</span>(<span class="str">"{markdown}"</span>);
-}</pre>
-          <pre class="playground-panel" data-example="rust-cli" data-title="crates.io · Rust CLI" hidden><span class="prompt">$</span> cargo install pdf-inspector
-<span class="term-muted">   installed pdf2md + detect-pdf</span>
-
-<span class="prompt">$</span> pdf2md annual-report.pdf
-<span class="term-key"># Annual report 2025</span>
-
-## Financial highlights
-| Metric | 2025 | 2024 |</pre>
-        </div>
-        <div class="playground-meta" aria-label="Runtime details">
-          <span>Rust core</span>
-          <span>Runs locally</span>
-          <span>Structured Markdown</span>
+| Metric | 2025 | 2024 |
+|---|---:|---:|</pre>
+        <div class="terminal-result">
+          <span>document type</span><strong class="hot">TextBased</strong>
+          <span>output</span><strong>structured Markdown</strong>
+          <span>engine</span><strong>Rust</strong>
         </div>
       </div>
     </div>
@@ -864,82 +742,6 @@ result = pdf_inspector.<span class="fn">process_pdf</span>(<span class="str">"do
     </div>
   </div>
 </footer>
-
-<script>
-  (() => {
-    const playground = document.querySelector('[data-playground]');
-    if (!playground) return;
-
-    const languageButtons = [...playground.querySelectorAll('[data-language]')];
-    const modeButtons = [...playground.querySelectorAll('[data-mode]')];
-    const panels = [...playground.querySelectorAll('[data-example]')];
-    const title = playground.querySelector('.example-title');
-    const copyButton = playground.querySelector('.copy-button');
-    let language = 'node';
-    let mode = 'code';
-
-    const update = () => {
-      const key = `${language}-${mode}`;
-      const activePanel = panels.find((panel) => panel.dataset.example === key);
-
-      languageButtons.forEach((button) => {
-        button.setAttribute('aria-pressed', String(button.dataset.language === language));
-      });
-      modeButtons.forEach((button) => {
-        button.setAttribute('aria-pressed', String(button.dataset.mode === mode));
-      });
-      panels.forEach((panel) => { panel.hidden = panel !== activePanel; });
-
-      if (activePanel) title.textContent = activePanel.dataset.title;
-      copyButton.textContent = 'Copy';
-    };
-
-    const copyText = async (text) => {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-        return;
-      }
-
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      textArea.setAttribute('readonly', '');
-      textArea.style.position = 'fixed';
-      textArea.style.opacity = '0';
-      document.body.appendChild(textArea);
-      textArea.select();
-      const copied = document.execCommand('copy');
-      textArea.remove();
-      if (!copied) throw new Error('Copy failed');
-    };
-
-    languageButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        language = button.dataset.language;
-        update();
-      });
-    });
-
-    modeButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        mode = button.dataset.mode;
-        update();
-      });
-    });
-
-    copyButton.addEventListener('click', async () => {
-      const activePanel = panels.find((panel) => !panel.hidden);
-      if (!activePanel) return;
-
-      try {
-        await copyText(activePanel.textContent.trim());
-        copyButton.textContent = 'Copied';
-        window.setTimeout(() => { copyButton.textContent = 'Copy'; }, 1400);
-      } catch {
-        copyButton.textContent = 'Select to copy';
-      }
-    });
-  })();
-</script>
 
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -377,9 +377,10 @@
   #node:checked ~ .usage-grid #panel-node,
   #cli:checked ~ .usage-grid #panel-cli { display: block; }
 
-  .footer-main { min-height: 168px; padding-top: 36px; padding-bottom: 36px; display: flex; justify-content: space-between; align-items: flex-end; gap: 28px; }
-  .footer-brand { display: flex; align-items: center; gap: 10px; color: var(--ink-48); font-size: 13px; }
-  .footer-brand img { width: 102px; height: auto; }
+  .footer-main { min-height: 168px; padding-top: 36px; padding-bottom: 36px; display: flex; justify-content: space-between; align-items: center; gap: 28px; }
+  .footer-brand { min-height: 24px; display: flex; align-items: center; gap: 8px; color: var(--ink-48); font-size: 13px; line-height: 1; }
+  .footer-brand > span, .footer-brand > a { height: 24px; display: inline-flex; align-items: center; }
+  .footer-brand img { width: 102px; height: 24px; object-fit: contain; transform: translateY(-1px); }
   .footer-links { display: flex; gap: 20px; flex-wrap: wrap; color: var(--ink-48); font: 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .05em; }
   .footer-links a:hover { color: var(--heat); }
 


### PR DESCRIPTION
## Summary

Redesign the pdf-inspector site around Firecrawl’s current visual system and reorganize it as an open-source project page. The new structure gives npm, PyPI, and crates.io equal, prominent registry cards in the hero, presents the Node API and bundled CLI through working examples without declaring one interface primary, and makes the Rust-powered core visible in the project positioning and command output.

The page also covers the project’s capabilities, architecture, benchmark evidence, and language examples without the previous hosted-product or generic project sections.