### PR TITLE
fix(extractor): don't flag gid Differences names covered by ToUnicode

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -162,7 +162,7 @@ pub(crate) fn extract_page_text_items(
     let fonts = doc.get_page_fonts(page_id).unwrap_or_default();
 
     // Build font encoding maps from Differences arrays
-    let (font_encodings, has_gid_fonts) = build_font_encodings(doc, &fonts);
+    let (font_encodings, has_gid_fonts) = build_font_encodings(doc, &fonts, font_cmaps);
 
     // Build font width info for accurate text positioning
     let font_widths = build_font_widths(doc, &fonts);

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -539,14 +539,19 @@ fn tounicode_maps_codes(font_dict: &lopdf::Dictionary, cmaps: &FontCMaps, codes:
     let Some(entry) = cmaps.get_by_obj(obj_ref.0) else {
         return false;
     };
-    // At least one gid code mapped means the CMap addresses these codes;
-    // remaining unmapped codes are subset leftovers (e.g. the component
-    // glyphs of an emoji ZWJ sequence mapped whole on its first code).
-    // Fonts whose CMap ignores the gid codes entirely stay flagged, and
-    // the downstream garbage/encoding checks still catch partial damage.
-    codes
-        .iter()
-        .any(|&code| entry.primary.lookup(code as u16).is_some())
+    // At least one gid code usably mapped means the CMap addresses these
+    // codes; remaining unmapped codes are subset leftovers (e.g. the
+    // component glyphs of an emoji ZWJ sequence mapped whole on its first
+    // code). A mapping is usable only when extraction would accept it —
+    // empty or U+FFFD results are rejected there as invalid. Fonts whose
+    // CMap ignores the gid codes entirely stay flagged, and the downstream
+    // garbage/encoding checks still catch partial damage.
+    codes.iter().any(|&code| {
+        entry
+            .primary
+            .lookup(code as u16)
+            .is_some_and(|s| !s.is_empty() && !s.contains('\u{FFFD}'))
+    })
 }
 
 /// Parse font encoding from a font dictionary
@@ -2067,5 +2072,12 @@ end",
         // A ToUnicode that never addresses the gid codes leaves them
         // unresolvable.
         assert!(gid_flagged(Some("<10> <0041>")));
+    }
+
+    #[test]
+    fn gid_differences_with_replacement_char_tounicode_are_flagged() {
+        // A mapping to U+FFFD is not usable — extraction rejects it as an
+        // invalid CMap result — so it must not clear the gid flag.
+        assert!(gid_flagged(Some("<01> <FFFD>\n<02> <FFFD>")));
     }
 }

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -497,9 +497,13 @@ pub(crate) fn get_operand_bytes(obj: &Object) -> Option<&[u8]> {
 /// Build encoding maps for all fonts on a page.
 /// Returns `(encodings, has_gid_fonts)` where `has_gid_fonts` is true when
 /// any font uses raw glyph ID names (gidNNNNN) that can't be decoded.
+/// Gid names whose codes the font's own ToUnicode CMap maps are decodable
+/// and do not set the flag (LibreOffice subsets write /gidNNNN Differences
+/// names alongside a complete ToUnicode CMap).
 pub(crate) fn build_font_encodings(
     doc: &Document,
     fonts: &std::collections::BTreeMap<Vec<u8>, &lopdf::Dictionary>,
+    cmaps: &FontCMaps,
 ) -> (PageFontEncodings, bool) {
     let mut encodings = PageFontEncodings::new();
     let mut has_gid_fonts = false;
@@ -508,7 +512,9 @@ pub(crate) fn build_font_encodings(
         let resource_name = String::from_utf8_lossy(font_name).to_string();
 
         if let Some(result) = parse_font_encoding(doc, font_dict) {
-            if result.gid_glyph_count > 0 {
+            if !result.gid_codes.is_empty()
+                && !tounicode_maps_codes(font_dict, cmaps, &result.gid_codes)
+            {
                 has_gid_fonts = true;
             }
             if !result.map.is_empty() {
@@ -518,6 +524,29 @@ pub(crate) fn build_font_encodings(
     }
 
     (encodings, has_gid_fonts)
+}
+
+/// True when the font's ToUnicode CMap maps the gid-named character codes,
+/// so the Differences entries still decode through the CMap.
+fn tounicode_maps_codes(font_dict: &lopdf::Dictionary, cmaps: &FontCMaps, codes: &[u8]) -> bool {
+    let Some(obj_ref) = font_dict
+        .get(b"ToUnicode")
+        .ok()
+        .and_then(|o| o.as_reference().ok())
+    else {
+        return false;
+    };
+    let Some(entry) = cmaps.get_by_obj(obj_ref.0) else {
+        return false;
+    };
+    // At least one gid code mapped means the CMap addresses these codes;
+    // remaining unmapped codes are subset leftovers (e.g. the component
+    // glyphs of an emoji ZWJ sequence mapped whole on its first code).
+    // Fonts whose CMap ignores the gid codes entirely stay flagged, and
+    // the downstream garbage/encoding checks still catch partial damage.
+    codes
+        .iter()
+        .any(|&code| entry.primary.lookup(code as u16).is_some())
 }
 
 /// Parse font encoding from a font dictionary
@@ -558,11 +587,10 @@ pub(crate) fn parse_font_encoding(
 /// Result of parsing an encoding dictionary's Differences array.
 pub(crate) struct EncodingResult {
     pub map: FontEncodingMap,
-    /// Number of glyph names matching the `gidNNNNN` pattern (raw glyph IDs).
-    /// These indicate a font with unresolvable encoding — the glyph IDs
-    /// reference the original font's glyph table, but without the original
-    /// font's cmap there is no way to map them to Unicode.
-    pub gid_glyph_count: u32,
+    /// Character codes whose glyph names match the `gidNNNNN` pattern (raw
+    /// glyph IDs). These reference the original font's glyph table and are
+    /// only decodable when the font's ToUnicode CMap maps the code.
+    pub gid_codes: Vec<u8>,
 }
 
 /// Parse an encoding dictionary with Differences array
@@ -588,7 +616,7 @@ pub(crate) fn parse_encoding_dictionary(
     let mut encoding_map = FontEncodingMap::new();
     let mut current_code: u8 = 0;
     let mut ligature_count = 0u32;
-    let mut gid_glyph_count = 0u32;
+    let mut gid_codes: Vec<u8> = Vec::new();
 
     for item in diff_array {
         match item {
@@ -614,7 +642,7 @@ pub(crate) fn parse_encoding_dictionary(
                     && glyph_name.len() >= 4
                     && glyph_name[3..].chars().all(|c| c.is_ascii_digit())
                 {
-                    gid_glyph_count += 1;
+                    gid_codes.push(current_code);
                 }
                 if let Some(ch) = mapped_char {
                     encoding_map.insert(current_code, ch);
@@ -638,16 +666,16 @@ pub(crate) fn parse_encoding_dictionary(
         );
     }
 
-    if gid_glyph_count > 0 {
+    if !gid_codes.is_empty() {
         debug!(
-            "  Differences: {} gid-encoded glyphs (unresolvable without original font)",
-            gid_glyph_count
+            "  Differences: {} gid-encoded glyphs (decodable only via ToUnicode)",
+            gid_codes.len()
         );
     }
 
     Some(EncodingResult {
         map: encoding_map,
-        gid_glyph_count,
+        gid_codes,
     })
 }
 
@@ -1937,5 +1965,107 @@ mod tests {
             Some("BJPQNQ+Times-Roman"),
             false
         ));
+    }
+
+    fn gid_font_doc(bfchar: Option<&str>) -> (Document, lopdf::ObjectId) {
+        use lopdf::Stream;
+        let mut doc = Document::with_version("1.4");
+        let cmap = format!(
+            "/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfchar
+{}
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end",
+            bfchar.unwrap_or_default()
+        );
+        let tounicode_id = doc.add_object(Object::Stream(Stream::new(
+            dictionary! {},
+            cmap.into_bytes(),
+        )));
+        let enc_id = doc.add_object(dictionary! {
+            "Type" => "Encoding",
+            "Differences" => vec![
+                1.into(),
+                Object::Name(b"gid1283".to_vec()),
+                Object::Name(b"gid1464".to_vec()),
+            ],
+        });
+        let mut font = dictionary! {
+            "Type" => "Font",
+            "Subtype" => "TrueType",
+            "BaseFont" => "ABCDEF+OpenSymbol",
+            "Encoding" => Object::Reference(enc_id),
+        };
+        if bfchar.is_some() {
+            font.set("ToUnicode", Object::Reference(tounicode_id));
+        }
+        let font_id = doc.add_object(font);
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Resources" => dictionary! {
+                "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+            },
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        });
+        let pages_id = doc.add_object(dictionary! {
+            "Type" => "Pages",
+            "Count" => Object::Integer(1),
+            "Kids" => vec![Object::Reference(page_id)],
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => Object::Reference(pages_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        (doc, page_id)
+    }
+
+    fn gid_flagged(bfchar: Option<&str>) -> bool {
+        let (doc, page_id) = gid_font_doc(bfchar);
+        let cmaps = FontCMaps::from_doc(&doc);
+        let fonts = doc.get_page_fonts(page_id).unwrap();
+        let (_, has_gid_fonts) = build_font_encodings(&doc, &fonts, &cmaps);
+        has_gid_fonts
+    }
+
+    #[test]
+    fn gid_differences_with_covering_tounicode_are_not_flagged() {
+        // LibreOffice subsets write /gidNNNN Differences names alongside a
+        // ToUnicode CMap that decodes those codes; the page must not be
+        // flagged as unresolvable (which would suppress the whole document's
+        // markdown when every page carries such a font).
+        assert!(!gid_flagged(Some("<01> <2022>\n<02> <25E6>")));
+    }
+
+    #[test]
+    fn gid_differences_with_partial_tounicode_are_not_flagged() {
+        // An emoji ZWJ sequence maps whole on its first code; the remaining
+        // component-glyph codes are subset leftovers, not damage.
+        assert!(!gid_flagged(Some(
+            "<01> <D83DDC68200DD83DDC69200DD83DDC67>"
+        )));
+    }
+
+    #[test]
+    fn gid_differences_without_tounicode_are_flagged() {
+        assert!(
+            gid_flagged(None),
+            "gid glyphs without ToUnicode are unresolvable"
+        );
+    }
+
+    #[test]
+    fn gid_differences_with_disjoint_tounicode_are_flagged() {
+        // A ToUnicode that never addresses the gid codes leaves them
+        // unresolvable.
+        assert!(gid_flagged(Some("<10> <0041>")));
     }
 }

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -162,7 +162,7 @@ fn extract_form_xobject_text_inner(
 
     // Get fonts from the Form's Resources
     let form_fonts = get_form_fonts(doc, &stream.dict);
-    let (font_encodings, _has_gid_fonts) = build_font_encodings(doc, &form_fonts);
+    let (font_encodings, _has_gid_fonts) = build_font_encodings(doc, &form_fonts, font_cmaps);
 
     // Build font width info for the form
     let font_widths = build_font_widths(doc, &form_fonts);


### PR DESCRIPTION
Pages were marked as having unresolvable gid-encoded fonts whenever any font's /Differences array used gidNNNN glyph names, and when every page carried such a font the whole document's markdown was suppressed. LibreOffice exports do exactly this: subset fonts get /gidNNNN names in Differences alongside a complete ToUnicode CMap that decodes them, so ordinary text documents lost their entire markdown output even though extraction decoded every glyph.

Track the character codes behind the gid names and only flag the font when its ToUnicode CMap addresses none of them. Partially mapped codes stay unflagged: an emoji ZWJ sequence maps whole on its first code, and the remaining component-glyph codes are subset leftovers, not damage. Fonts without ToUnicode, or whose CMap ignores the gid codes, are flagged as before, and the downstream garbage/encoding checks still catch partial breakage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788106173&installation_model_id=11126&pr_number=186&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F186&signature=a879ac171bcd62105ff1f4172da54cffd9825bb6891316d94c80ca9cd06452ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives when fonts use gidNNNN names by honoring the font’s ToUnicode CMap, so LibreOffice PDFs now produce markdown normally. A font is only flagged when none of its gid codes have a usable ToUnicode mapping; partial mappings are allowed.

- **Bug Fixes**
  - Track character codes for gidNNNN entries in Differences and check the font’s ToUnicode CMap.
  - Only clear the gid flag when at least one gid code has a usable ToUnicode mapping; empty or U+FFFD do not count. Partial mappings (e.g., emoji ZWJ) are fine.
  - Pass `font_cmaps` into `build_font_encodings` for pages and form XObjects.
  - Add tests for covered, partial, missing, disjoint, and U+FFFD/empty ToUnicode cases.

<sup>Written for commit 13409859c9cabec7ca2f85398c4dda4fc4d0abc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

