### PR TITLE
chore(crate): bump pdf-inspector to 0.1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf-inspector"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 autobins = false
 authors = ["Firecrawl Team"]

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "env_logger",
  "log",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -724,7 +724,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "env_logger",
  "include_dir",


### PR DESCRIPTION
## Summary

Bump the `pdf-inspector` crate from `0.1.6` to `0.1.7` and refresh the nested binding lockfiles so the merged extraction, layout, table, and Markdown improvements can be published to crates.io.

Changes since `0.1.6` include:

- Markdown fidelity output, document-wide heading sequence classification, stronger bold-heading recovery, chart-aware gating, and flattened page-number tables of contents (#142, #162, #164, #167–#170).
- Stacked-box tables, horizontal-rule text anchors, competing chart/table hypotheses, candidate scoring, and chart-bar masking (#157, #159, #171, #172, #177).
- Visible-page clipping, corrected link clipping, independent-column unfusing, and image-anchored region ordering (#160, #161, #163, #174).
- TeXCMMathsSymbols remapping and fewer false OCR flags for GID Differences already covered by ToUnicode (#165, #186).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127828&installation_model_id=11126&pr_number=187&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F187&signature=4f083eb556615fab8b47f4e8d1741543696a9e0851c27e7354568935e5b40c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `pdf-inspector` to 0.1.7 and refresh `napi` and `wasm` lockfiles to publish recent extraction, layout, table, and Markdown improvements.

- **New Features**
  - Higher-fidelity Markdown (heading sequence, bold-heading recovery, page-number TOCs).
  - Better tables and charts (stacked-box tables, hypothesis scoring, chart-bar masking).
  - Layout/link fixes (visible-page and link clipping, independent-column unfusing, image-anchored ordering).
  - Text/OCR tweaks (TeXCMMathsSymbols remap, fewer false OCR flags with ToUnicode).

<sup>Written for commit 103b6de427323bcc698e0c8c1fd61450edcdbd9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

