### PR TITLE
chore(pypi): bump pdf-inspector to 0.2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "pdf-inspector"
 # Bump this to publish to PyPI — CI publishes automatically when the version
 # changes on main (same flow as napi/package.json for npm).
-version = "0.2.5"
+version = "0.2.6"
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"
 readme = "docs/python.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Bump the `pdf-inspector` Python package from `0.2.5` to `0.2.6` so the merged extraction, layout, table, and Markdown improvements can be published to PyPI as fresh ABI3 wheels and an sdist.

Changes since `0.2.5` include:

- Markdown fidelity output, document-wide heading sequence classification, stronger bold-heading recovery, chart-aware gating, and flattened page-number tables of contents (#142, #162, #164, #167–#170).
- Stacked-box tables, horizontal-rule text anchors, competing chart/table hypotheses, candidate scoring, and chart-bar masking (#157, #159, #171, #172, #177).
- Visible-page clipping, corrected link clipping, independent-column unfusing, and image-anchored region ordering (#160, #161, #163, #174).
- TeXCMMathsSymbols remapping and fewer false OCR flags for GID Differences already covered by ToUnicode (#165, #186).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127893&installation_model_id=11126&pr_number=188&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F188&signature=c29edf5173cf34eb283f7f4d138c599cef1bb1c5e1b8bfb28991b6b576c0aa4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `pdf-inspector` 0.2.6 to PyPI by bumping the version in `pyproject.toml`. This release ships recent extraction, layout, table, and Markdown improvements as ABI3 wheels and an sdist.

<sup>Written for commit c3879ba53ea6f33cb37252582f91cbe20f13ba6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

