### PR TITLE
chore(npm): bump @firecrawl/pdf-inspector to 1.11.2

### DIFF
--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firecrawl/pdf-inspector",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Fast PDF classification and text extraction. Detect text-based vs scanned PDFs, extract text by region with quality checks. Native Rust performance via napi-rs.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -49,8 +49,8 @@
     "@napi-rs/cli": "^3.4.1"
   },
   "optionalDependencies": {
-    "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.1",
-    "@firecrawl/pdf-inspector-darwin-arm64": "1.11.1",
-    "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.1"
+    "@firecrawl/pdf-inspector-linux-x64-gnu": "1.11.2",
+    "@firecrawl/pdf-inspector-darwin-arm64": "1.11.2",
+    "@firecrawl/pdf-inspector-win32-x64-msvc": "1.11.2"
   }
 }


### PR DESCRIPTION
## Summary

Bump `@firecrawl/pdf-inspector` from `1.11.1` to `1.11.2` and keep every platform-specific optional dependency pinned to the same version so the merged native extraction, layout, table, and Markdown improvements can be published to npm.

Changes since `1.11.1` include:

- Markdown fidelity output, document-wide heading sequence classification, stronger bold-heading recovery, chart-aware gating, and flattened page-number tables of contents (#142, #162, #164, #167–#170).
- Stacked-box tables, horizontal-rule text anchors, competing chart/table hypotheses, candidate scoring, and chart-bar masking (#157, #159, #171, #172, #177).
- Visible-page clipping, corrected link clipping, independent-column unfusing, and image-anchored region ordering (#160, #161, #163, #174).
- TeXCMMathsSymbols remapping and fewer false OCR flags for GID Differences already covered by ToUnicode (#165, #186).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127965&installation_model_id=11126&pr_number=189&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F189&signature=887af54d4a2a15c621c32a6d9366b7e8b909038d38512921d31c8af8e7c18cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@firecrawl/pdf-inspector` to `1.11.2` and pin platform-specific optional deps to the same version. This releases recent extraction, layout, table, and Markdown improvements to npm.

- **New Features**
  - Markdown: higher fidelity, heading sequencing, stronger bold-heading recovery, chart-aware gating, flat page-number TOCs.
  - Tables/charts: stacked-box tables, competing hypotheses with scoring, chart-bar masking, horizontal-rule anchors.
  - Layout: visible-page and link clipping fixes, independent-column unfusing, image-anchored region ordering.
  - Text mapping: TeXCMMathsSymbols remap; fewer false OCR flags when GID Differences are covered by ToUnicode.

<sup>Written for commit f23857362c6d387bf894f58e46b60538c148be6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

