### PR TITLE
chore(wasm): bump @firecrawl/pdf-inspector-wasm to 0.1.3

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-inspector-wasm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf-inspector-wasm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Firecrawl Team"]
 description = "Browser WebAssembly bindings for pdf-inspector"


### PR DESCRIPTION
## Summary

Bump `@firecrawl/pdf-inspector-wasm` from the repository manifest version `0.1.2` to `0.1.3`. npm’s public latest is still `0.1.1`, so this version safely supersedes the unpublished `0.1.2` manifest state and triggers a fresh browser package publish.

Changes since the public `0.1.1` package include:

- Preserve numeric plain-text content in browser extraction and carry the final reviewed WASM binding behavior from #180.
- Avoid false OCR flags when GID-style Differences names are already covered by a valid ToUnicode map (#186).
- Report the new package version through the exported `version()` API.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788128171&installation_model_id=11126&pr_number=190&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F190&signature=9f11ea1730d597354602b6c849be895d06b1dfd0c40878d4cb187636d7c01af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `@firecrawl/pdf-inspector-wasm` to 0.1.3 to publish the latest browser WASM build. This release preserves numeric plain text, avoids false OCR flags when Differences are covered by ToUnicode, and exposes a `version()` API.

<sup>Written for commit 6e904696a378c2b374c43d4821604ea6d0c9ed6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

