### PR TITLE
docs(readme): refresh local parser benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,18 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 
 ## Benchmark
 
-Evaluated on the [opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs). Only local engines without model-based PDF parsing are shown; OCR was disabled. Scores are 0-1, higher is better.
+Evaluated on the [opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs). This head-to-head comparison uses each parser's Python API in a single process with one worker and OCR disabled. Scores are 0-1, higher is better.
 
 | Engine | Overall | Reading Order (NID) | Tables (TEDS) | Headings (MHS) | Speed (200 docs) |
 |---|---|---|---|---|---|
-| pdf-inspector | **0.875** | **0.915** | **0.814** | 0.788 | **2.8s** |
-| liteparse | 0.870 | 0.908 | 0.693 | **0.811** | 13.9s |
-| opendataloader | 0.843 | 0.912 | 0.489 | 0.760 | 9.8s |
-| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 15.5s |
-| markitdown | 0.583 | 0.879 | 0.000 | 0.000 | 6.7s |
+| pdf-inspector | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
+| liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
 
-Results were refreshed on July 16, 2026, on an Apple M4 Pro. Engine versions were pdf-inspector 0.1.6, LiteParse 2.6.0, OpenDataLoader 2.1.1, PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.4. Speed is the median of three complete corpus runs.
+Results were refreshed on July 31, 2026, on an Apple M4 Pro using pdf-inspector 0.2.6 and LiteParse 2.10.1. Speed is the median of five alternating complete corpus runs after an excluded warm-up run. pdf-inspector completed the corpus 1.60x faster, with 37.3% lower runtime.
 
-For context, engines that use OCR or model-based document parsing (docling, marker, mineru) score 0.83-0.88 overall but take 2-180 minutes on the same corpus — pdf-inspector reaches the top of that range without either, in 2.8 seconds.
+The complete parser configuration, per-document predictions, evaluator output, and generated charts are available in the [reproducible results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
-**Best fit:** Native-text PDFs where speed, reading order, and table structure matter. pdf-inspector delivered the highest overall, reading-order, and table scores, along with the fastest complete run in this benchmark. That makes it a strong local default for reports, research papers, financial documents, invoices, and legal PDFs that need clean, structured Markdown without adding OCR latency or infrastructure.
+**Best fit:** Native-text PDFs where speed, reading order, and table structure matter. In this comparison, pdf-inspector delivered the higher overall, reading-order, and table scores, along with the fastest complete run. That makes it a strong local default for reports, research papers, financial documents, invoices, and legal PDFs that need clean, structured Markdown without adding OCR latency or infrastructure.
 
 Use the [paired benchmark harness](docs/benchmarking.md) to compare two local builds against the exact same corpus and evaluator revision.
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Evaluated on the [opendataloader-bench](https://github.com/opendataloader-projec
 |---|---|---|---|---|---|
 | pdf-inspector | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
 | liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
-| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 3.000s |
-| pymupdf4llm | 0.732 | 0.885 | 0.401 | 0.412 | 18.173s |
-| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 22.790s |
+| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 2.569s |
+| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 17.117s |
+| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 16.165s |
 
-pdf-inspector 0.2.6 and LiteParse 2.10.1 were refreshed on July 31, 2026, on an Apple M4 Pro. Their speed is the median of five alternating complete corpus runs after an excluded warm-up run; pdf-inspector completed the corpus 1.60x faster, with 37.3% lower runtime. The remaining rows use the latest stored results for OpenDataLoader 2.2.1, PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.5 from the results repository. Their Apple M4 timings are included as reference rather than as part of the same timed run.
+Results were refreshed on July 31, 2026, on an Apple M4 Pro. Engine versions were pdf-inspector 0.2.6, LiteParse 2.10.1, OpenDataLoader 2.2.1, PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.5. Speed is the median of five alternating or rotating complete corpus runs after an excluded warm-up run, with each parser processing documents sequentially in a single process.
 
 The complete parser configuration, per-document predictions, evaluator output, and generated charts are available in the [reproducible results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 
 ## Benchmark
 
-Evaluated on the [opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs). This head-to-head comparison uses each parser's Python API in a single process with one worker and OCR disabled. Scores are 0-1, higher is better.
+Evaluated on the [opendataloader-bench](https://github.com/opendataloader-project/opendataloader-bench) corpus (200 PDFs). Only local engines without model-based PDF parsing are shown; OCR was disabled. Scores are 0-1, higher is better.
 
 | Engine | Overall | Reading Order (NID) | Tables (TEDS) | Headings (MHS) | Speed (200 docs) |
 |---|---|---|---|---|---|
 | pdf-inspector | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
 | liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
+| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 3.000s |
+| pymupdf4llm | 0.732 | 0.885 | 0.401 | 0.412 | 18.173s |
+| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 22.790s |
 
-Results were refreshed on July 31, 2026, on an Apple M4 Pro using pdf-inspector 0.2.6 and LiteParse 2.10.1. Speed is the median of five alternating complete corpus runs after an excluded warm-up run. pdf-inspector completed the corpus 1.60x faster, with 37.3% lower runtime.
+pdf-inspector 0.2.6 and LiteParse 2.10.1 were refreshed on July 31, 2026, on an Apple M4 Pro. Their speed is the median of five alternating complete corpus runs after an excluded warm-up run; pdf-inspector completed the corpus 1.60x faster, with 37.3% lower runtime. The remaining rows use the latest stored results for OpenDataLoader 2.2.1, PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.5 from the results repository. Their Apple M4 timings are included as reference rather than as part of the same timed run.
 
 The complete parser configuration, per-document predictions, evaluator output, and generated charts are available in the [reproducible results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -30,11 +30,14 @@ overwrite one another.
 
 ## Published comparison protocol
 
-The public benchmark table was refreshed on July 16, 2026, on an Apple M4 Pro
-using pdf-inspector 0.1.6, LiteParse 2.6.0, OpenDataLoader 2.1.1,
-PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.4. Every engine processed the same 200
-PDFs with OCR disabled. Reported speed is the median of three complete corpus
-runs; quality scores come from the benchmark evaluator over all 200 outputs.
+The public benchmark table was refreshed on July 31, 2026, on an Apple M4 Pro
+using pdf-inspector 0.2.6, LiteParse 2.10.1, OpenDataLoader 2.2.1,
+PyMuPDF4LLM 0.2.0, and MarkItDown 0.1.5. Every engine processed the same 200
+PDFs sequentially in a single process with OCR disabled. Reported speed is the
+median of five alternating or rotating complete corpus runs after an excluded
+warm-up run; quality scores come from the benchmark evaluator over all 200
+outputs. Raw timings, predictions, evaluations, and charts are available in the
+[results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
 ## Optional backend evidence probe
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -18,13 +18,13 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 
 | Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
 |---|---|---|---|---|---|
-| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **2.8s** |
-| liteparse | 0.870 | 0.908 | 0.693 | **0.811** | 13.9s |
-| opendataloader | 0.843 | 0.912 | 0.489 | 0.760 | 9.8s |
-| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 15.5s |
-| markitdown | 0.583 | 0.879 | 0.000 | 0.000 | 6.7s |
+| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
+| liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
+| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 2.569s |
+| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 17.117s |
+| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 16.165s |
 
-Refreshed July 16, 2026, on Apple M4 Pro; speed is the median of three complete corpus runs. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+Refreshed July 31, 2026, on Apple M4 Pro; speed is the median of five complete corpus runs after an excluded warm-up. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark), with raw timings and artifacts in the [results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
 ## Install
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -18,13 +18,13 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 
 | Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
 |---|---|---|---|---|---|
-| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **2.8s** |
-| liteparse | 0.870 | 0.908 | 0.693 | **0.811** | 13.9s |
-| opendataloader | 0.843 | 0.912 | 0.489 | 0.760 | 9.8s |
-| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 15.5s |
-| markitdown | 0.583 | 0.879 | 0.000 | 0.000 | 6.7s |
+| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
+| liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
+| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 2.569s |
+| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 17.117s |
+| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 16.165s |
 
-Refreshed July 16, 2026, on Apple M4 Pro; speed is the median of three complete corpus runs. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+Refreshed July 31, 2026, on Apple M4 Pro; speed is the median of five complete corpus runs after an excluded warm-up. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark), with raw timings and artifacts in the [results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
 ## Install
 

--- a/napi/README.md
+++ b/napi/README.md
@@ -18,13 +18,13 @@ Built by [Firecrawl](https://firecrawl.dev) for hybrid OCR pipelines — extract
 
 | Engine | Overall | Reading order | Tables (TEDS) | Headings | Speed |
 |---|---|---|---|---|---|
-| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **2.8s** |
-| liteparse | 0.870 | 0.908 | 0.693 | **0.811** | 13.9s |
-| opendataloader | 0.843 | 0.912 | 0.489 | 0.760 | 9.8s |
-| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 15.5s |
-| markitdown | 0.583 | 0.879 | 0.000 | 0.000 | 6.7s |
+| **pdf-inspector** | **0.875** | **0.915** | **0.814** | 0.788 | **0.470s** |
+| liteparse | 0.873 | 0.913 | 0.693 | **0.811** | 0.750s |
+| opendataloader | 0.831 | 0.902 | 0.489 | 0.739 | 2.569s |
+| pymupdf4llm | 0.735 | 0.886 | 0.401 | 0.424 | 17.117s |
+| markitdown | 0.589 | 0.844 | 0.273 | 0.000 | 16.165s |
 
-Refreshed July 16, 2026, on Apple M4 Pro; speed is the median of three complete corpus runs. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark).
+Refreshed July 31, 2026, on Apple M4 Pro; speed is the median of five complete corpus runs after an excluded warm-up. Full methodology and versions are in the [repo README](https://github.com/firecrawl/pdf-inspector#benchmark), with raw timings and artifacts in the [results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
 ## Install
 


### PR DESCRIPTION
## Summary

Refreshes benchmark references across the root README, benchmarking guide, and Node, Python, and Rust documentation with new July 31, 2026 results for pdf-inspector, LiteParse, OpenDataLoader, PyMuPDF4LLM, and MarkItDown. The updated documentation records the five-run median timings and reevaluated quality scores, explains the single-process measurement protocol, and links to the opendataloader-bench branch containing the raw timings, parser configuration, predictions, evaluator output, and generated charts.
