### PR TITLE
fix(extractor): feed Form XObject path/paint into underline detection

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -836,6 +836,7 @@ pub(crate) fn extract_page_text_items(
                                         page_num,
                                         font_cmaps,
                                         &ctm,
+                                        line_width,
                                         &mut cmap_decisions,
                                         style_cache,
                                     );

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -18,7 +18,7 @@ use super::fonts::{
     extract_text_from_operand, get_font_file2_obj_num, get_operand_bytes, CMapDecisionCache,
     FontStyleCache,
 };
-use super::underline::UnderlineLine;
+use super::underline::{transform_path_point, transformed_stroke_width, UnderlineLine};
 use super::xobjects::{extract_form_xobject_text, get_page_xobjects, XObjectType};
 use super::{get_number, image_bbox_from_ctm, multiply_matrices};
 
@@ -74,37 +74,6 @@ fn strip_pdf_comments(data: &[u8]) -> Vec<u8> {
     }
 
     result
-}
-
-fn transform_path_point(x: f32, y: f32, ctm: &[f32; 6]) -> (f32, f32) {
-    (
-        x * ctm[0] + y * ctm[2] + ctm[4],
-        x * ctm[1] + y * ctm[3] + ctm[5],
-    )
-}
-
-fn transformed_stroke_width(
-    line_width: f32,
-    ctm: &[f32; 6],
-    x1: f32,
-    y1: f32,
-    x2: f32,
-    y2: f32,
-) -> f32 {
-    let user_width = line_width.abs();
-    let dx = x2 - x1;
-    let dy = y2 - y1;
-    let len = (dx * dx + dy * dy).sqrt();
-    if len <= f32::EPSILON {
-        return user_width;
-    }
-
-    // PDF stroke width scales perpendicular to the path direction.
-    let nx = -dy / len;
-    let ny = dx / len;
-    let ndx = nx * ctm[0] + ny * ctm[2];
-    let ndy = nx * ctm[1] + ny * ctm[3];
-    user_width * (ndx * ndx + ndy * ndy).sqrt()
 }
 
 /// Text rise (Ts) displaces the glyph origin by (0, rise) in unscaled text
@@ -858,8 +827,10 @@ pub(crate) fn extract_page_text_items(
                                     });
                                 }
                                 XObjectType::Form(form_id) => {
-                                    // Extract text from Form XObject
-                                    let form_items = extract_form_xobject_text(
+                                    // Extract text + painted underline graphics
+                                    // from the Form XObject (rules drawn inside
+                                    // forms never reached the page-level pass).
+                                    let form = extract_form_xobject_text(
                                         doc,
                                         *form_id,
                                         page_num,
@@ -868,7 +839,9 @@ pub(crate) fn extract_page_text_items(
                                         &mut cmap_decisions,
                                         style_cache,
                                     );
-                                    items.extend(form_items);
+                                    items.extend(form.items);
+                                    painted_rects.extend(form.painted_rects);
+                                    underline_lines.extend(form.underline_lines);
                                 }
                             }
                         }

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -63,6 +63,11 @@ pub(crate) fn transform_path_point(x: f32, y: f32, ctm: &[f32; 6]) -> (f32, f32)
 }
 
 /// Scale a stroke width by the CTM component perpendicular to the segment.
+///
+/// PDF stroke thickness is measured perpendicular to the path in user space.
+/// Under an affine CTM the device-space thickness is
+/// `user_width * |det(CTM)| / ||CTM · tangent||` — not the length of the
+/// transformed source normal (which overstates thickness under shear).
 pub(crate) fn transformed_stroke_width(
     line_width: f32,
     ctm: &[f32; 6],
@@ -79,12 +84,52 @@ pub(crate) fn transformed_stroke_width(
         return user_width;
     }
 
-    // PDF stroke width scales perpendicular to the path direction.
-    let nx = -dy / len;
-    let ny = dx / len;
-    let ndx = nx * ctm[0] + ny * ctm[2];
-    let ndy = nx * ctm[1] + ny * ctm[3];
-    user_width * (ndx * ndx + ndy * ndy).sqrt()
+    let tx = dx / len;
+    let ty = dy / len;
+    let tdx = tx * ctm[0] + ty * ctm[2];
+    let tdy = tx * ctm[1] + ty * ctm[3];
+    let transformed_len = (tdx * tdx + tdy * tdy).sqrt();
+    if transformed_len <= f32::EPSILON {
+        return 0.0;
+    }
+    user_width * (ctm[0] * ctm[3] - ctm[1] * ctm[2]).abs() / transformed_len
+}
+
+/// Transform a user-space axis-aligned rect through `ctm`, returning the
+/// axis-aligned bounding box `(x, y, width, height)` in device space.
+///
+/// Uses all four corners so shear/rotation Forms keep correct extents
+/// (diagonal CTM components alone are wrong for non-orthogonal matrices).
+pub(crate) fn transform_user_rect(
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    ctm: &[f32; 6],
+) -> (f32, f32, f32, f32) {
+    let corners = [
+        transform_path_point(x, y, ctm),
+        transform_path_point(x + w, y, ctm),
+        transform_path_point(x, y + h, ctm),
+        transform_path_point(x + w, y + h, ctm),
+    ];
+    let min_x = corners
+        .iter()
+        .map(|c| c.0)
+        .fold(f32::INFINITY, f32::min);
+    let max_x = corners
+        .iter()
+        .map(|c| c.0)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let min_y = corners
+        .iter()
+        .map(|c| c.1)
+        .fold(f32::INFINITY, f32::min);
+    let max_y = corners
+        .iter()
+        .map(|c| c.1)
+        .fold(f32::NEG_INFINITY, f32::max);
+    (min_x, min_y, max_x - min_x, max_y - min_y)
 }
 
 /// A horizontal rule candidate in page coordinates (PDF y-up).
@@ -873,5 +918,27 @@ mod tests {
         mark_underlined_items(&mut items, &[], &lines, 1);
 
         assert!(items.iter().all(|item| !item.is_underline));
+    }
+
+    #[test]
+    fn sheared_ctm_preserves_horizontal_stroke_thickness() {
+        // CTM [1, 0, 100, 1, 0, 0]: horizontal unit tangent stays length 1,
+        // |det| = 1, so a 1-pt stroke must stay ~1 pt (not ~100).
+        let ctm = [1.0, 0.0, 100.0, 1.0, 0.0, 0.0];
+        let w = transformed_stroke_width(1.0, &ctm, 0.0, 0.0, 10.0, 0.0);
+        assert!(
+            (w - 1.0).abs() < 1e-4,
+            "sheared horizontal stroke thickness should stay 1.0, got {w}"
+        );
+    }
+
+    #[test]
+    fn transform_user_rect_uses_all_corners_under_shear() {
+        let ctm = [1.0, 0.0, 100.0, 1.0, 0.0, 0.0];
+        // User rect (0,0)–(10,1) maps corners to (0,0), (10,0), (100,1), (110,1).
+        let (x, y, w, h) = transform_user_rect(0.0, 0.0, 10.0, 1.0, &ctm);
+        assert!((x - 0.0).abs() < 1e-4 && (y - 0.0).abs() < 1e-4);
+        assert!((w - 110.0).abs() < 1e-4, "expected width 110, got {w}");
+        assert!((h - 1.0).abs() < 1e-4, "expected height 1, got {h}");
     }
 }

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -54,6 +54,39 @@ pub(crate) struct UnderlineLine {
     pub(crate) page: u32,
 }
 
+/// Transform a user-space point through a CTM.
+pub(crate) fn transform_path_point(x: f32, y: f32, ctm: &[f32; 6]) -> (f32, f32) {
+    (
+        x * ctm[0] + y * ctm[2] + ctm[4],
+        x * ctm[1] + y * ctm[3] + ctm[5],
+    )
+}
+
+/// Scale a stroke width by the CTM component perpendicular to the segment.
+pub(crate) fn transformed_stroke_width(
+    line_width: f32,
+    ctm: &[f32; 6],
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+) -> f32 {
+    let user_width = line_width.abs();
+    let dx = x2 - x1;
+    let dy = y2 - y1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len <= f32::EPSILON {
+        return user_width;
+    }
+
+    // PDF stroke width scales perpendicular to the path direction.
+    let nx = -dy / len;
+    let ny = dx / len;
+    let ndx = nx * ctm[0] + ny * ctm[2];
+    let ndy = nx * ctm[1] + ny * ctm[3];
+    user_width * (ndx * ndx + ndy * ndy).sqrt()
+}
+
 /// A horizontal rule candidate in page coordinates (PDF y-up).
 #[derive(Clone)]
 struct Rule {

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -3,7 +3,7 @@
 use super::fonts::descriptor_style_flags;
 use crate::text_utils::{effective_font_size, expand_ligatures, is_bold_font, is_italic_font};
 use crate::tounicode::FontCMaps;
-use crate::types::{ItemType, TextItem};
+use crate::types::{ItemType, PdfRect, TextItem};
 use lopdf::{Document, Encoding, Object, ObjectId};
 use std::collections::HashMap;
 
@@ -11,6 +11,7 @@ use super::fonts::{
     build_font_encodings, build_font_widths, compute_string_width_ts, extract_text_from_operand,
     get_font_file2_obj_num, get_operand_bytes, CMapDecisionCache, FontStyleCache,
 };
+use super::underline::{transform_path_point, transformed_stroke_width, UnderlineLine};
 use super::{get_number, image_bbox_from_ctm, multiply_matrices};
 
 const MAX_FORM_XOBJECT_DEPTH: u8 = 5;
@@ -107,7 +108,25 @@ fn collect_xobjects_from_dict(
     }
 }
 
-/// Extract text items from a Form XObject
+/// Text plus underline/strikeout graphics extracted from a Form XObject.
+#[derive(Default)]
+pub(crate) struct FormXObjectExtract {
+    pub(crate) items: Vec<TextItem>,
+    /// Painted `re`/`f` rectangles in page device space (for underline detection).
+    pub(crate) painted_rects: Vec<PdfRect>,
+    /// Stroked horizontal segments in page device space.
+    pub(crate) underline_lines: Vec<UnderlineLine>,
+}
+
+impl FormXObjectExtract {
+    fn append(&mut self, other: FormXObjectExtract) {
+        self.items.extend(other.items);
+        self.painted_rects.extend(other.painted_rects);
+        self.underline_lines.extend(other.underline_lines);
+    }
+}
+
+/// Extract text items and painted underline graphics from a Form XObject.
 pub(crate) fn extract_form_xobject_text(
     doc: &Document,
     form_id: ObjectId,
@@ -116,7 +135,7 @@ pub(crate) fn extract_form_xobject_text(
     parent_ctm: &[f32; 6],
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
-) -> Vec<TextItem> {
+) -> FormXObjectExtract {
     extract_form_xobject_text_inner(
         doc,
         form_id,
@@ -139,14 +158,14 @@ fn extract_form_xobject_text_inner(
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     depth: u8,
-) -> Vec<TextItem> {
+) -> FormXObjectExtract {
     use lopdf::content::Content;
 
-    let mut items = Vec::new();
+    let mut extract = FormXObjectExtract::default();
 
     // Get the Form XObject stream
     let Ok(Object::Stream(stream)) = doc.get_object(form_id) else {
-        return items;
+        return extract;
     };
 
     // Decompress the content stream (fall back to raw bytes for uncompressed streams)
@@ -157,7 +176,7 @@ fn extract_form_xobject_text_inner(
 
     // Decode the content stream
     let Ok(content) = Content::decode(&content_data) else {
-        return items;
+        return extract;
     };
 
     // Get fonts from the Form's Resources
@@ -249,6 +268,16 @@ fn extract_form_xobject_text_inner(
     let mut ctm = base_ctm;
     let mut ctm_stack: Vec<[f32; 6]> = Vec::new();
 
+    // Path / paint state — mirrors the page-level underline collectors so
+    // rules drawn inside Form XObjects reach mark_underlined_items.
+    let mut line_width: f32 = 1.0;
+    let mut path_subpath_start: Option<(f32, f32)> = None;
+    let mut path_current: Option<(f32, f32)> = None;
+    let mut pending_lines: Vec<(f32, f32, f32, f32)> = Vec::new();
+    let mut pending_subpaths: Vec<Vec<(f32, f32, f32, f32)>> = Vec::new();
+    let mut pending_re_rects: Vec<PdfRect> = Vec::new();
+    let mut fill_rects: Vec<PdfRect> = Vec::new();
+
     for op in &content.operations {
         match op.operator.as_str() {
             "q" => {
@@ -275,7 +304,7 @@ fn extract_form_xobject_text_inner(
                         match form_xobjects.get(&xobj_name) {
                             Some(XObjectType::Form(nested_id)) => {
                                 if depth < MAX_FORM_XOBJECT_DEPTH {
-                                    let nested_items = extract_form_xobject_text_inner(
+                                    let nested = extract_form_xobject_text_inner(
                                         doc,
                                         *nested_id,
                                         page_num,
@@ -285,7 +314,7 @@ fn extract_form_xobject_text_inner(
                                         style_cache,
                                         depth + 1,
                                     );
-                                    items.extend(nested_items);
+                                    extract.append(nested);
                                 }
                             }
                             Some(XObjectType::Image) => {
@@ -294,7 +323,7 @@ fn extract_form_xobject_text_inner(
                                 // inside Form XObjects (common in print-to-PDF
                                 // workflows) aren't silently dropped.
                                 let (x, y, width, height) = image_bbox_from_ctm(&ctm);
-                                items.push(TextItem {
+                                extract.items.push(TextItem {
                                     text: format!("[Image: {}]", xobj_name),
                                     x,
                                     y,
@@ -444,7 +473,7 @@ fn extract_form_xobject_text_inner(
                                 .get(&current_font)
                                 .copied()
                                 .unwrap_or((false, false));
-                            items.push(TextItem {
+                            extract.items.push(TextItem {
                                 text: expand_ligatures(&text),
                                 x,
                                 y,
@@ -598,7 +627,7 @@ fn extract_form_xobject_text_inner(
                                 } else {
                                     0.0
                                 };
-                                items.push(TextItem {
+                                extract.items.push(TextItem {
                                     text: expand_ligatures(text),
                                     x,
                                     y,
@@ -624,11 +653,179 @@ fn extract_form_xobject_text_inner(
                     }
                 }
             }
+            // ── Path construction / painting (underline graphics) ──
+            "w" => {
+                if let Some(width) = op.operands.first().and_then(get_number) {
+                    line_width = width;
+                }
+            }
+            "re" => {
+                if op.operands.len() >= 4 {
+                    let rx = get_number(&op.operands[0]).unwrap_or(0.0);
+                    let ry = get_number(&op.operands[1]).unwrap_or(0.0);
+                    let rw = get_number(&op.operands[2]).unwrap_or(0.0);
+                    let rh = get_number(&op.operands[3]).unwrap_or(0.0);
+                    let x_dev = rx * ctm[0] + ry * ctm[2] + ctm[4];
+                    let y_dev = rx * ctm[1] + ry * ctm[3] + ctm[5];
+                    let w_dev = rw * ctm[0];
+                    let h_dev = rh * ctm[3];
+                    pending_re_rects.push(PdfRect {
+                        x: x_dev,
+                        y: y_dev,
+                        width: w_dev,
+                        height: h_dev,
+                        page: page_num,
+                    });
+                }
+            }
+            "m" => {
+                if op.operands.len() >= 2 {
+                    let px = get_number(&op.operands[0]).unwrap_or(0.0);
+                    let py = get_number(&op.operands[1]).unwrap_or(0.0);
+                    path_subpath_start = Some((px, py));
+                    path_current = Some((px, py));
+                }
+            }
+            "l" => {
+                if op.operands.len() >= 2 {
+                    if let Some((cx, cy)) = path_current {
+                        let px = get_number(&op.operands[0]).unwrap_or(0.0);
+                        let py = get_number(&op.operands[1]).unwrap_or(0.0);
+                        pending_lines.push((cx, cy, px, py));
+                        path_current = Some((px, py));
+                    }
+                }
+            }
+            "h" => {
+                if let (Some((cx, cy)), Some((sx, sy))) = (path_current, path_subpath_start) {
+                    if (cx - sx).abs() > 0.01 || (cy - sy).abs() > 0.01 {
+                        pending_lines.push((cx, cy, sx, sy));
+                    }
+                    path_current = path_subpath_start;
+                }
+                if !pending_lines.is_empty() {
+                    pending_subpaths.push(std::mem::take(&mut pending_lines));
+                }
+            }
+            "S" | "s" => {
+                if op.operator == "s" {
+                    if let (Some((cx, cy)), Some((sx, sy))) = (path_current, path_subpath_start) {
+                        if (cx - sx).abs() > 0.01 || (cy - sy).abs() > 0.01 {
+                            pending_lines.push((cx, cy, sx, sy));
+                        }
+                    }
+                }
+                for (x1, y1, x2, y2) in pending_lines.drain(..) {
+                    let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
+                    let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
+                    extract.underline_lines.push(UnderlineLine {
+                        x1: x1d,
+                        y1: y1d,
+                        x2: x2d,
+                        y2: y2d,
+                        stroke_width: transformed_stroke_width(line_width, &ctm, x1, y1, x2, y2),
+                        page: page_num,
+                    });
+                }
+                extract.painted_rects.append(&mut pending_re_rects);
+                pending_subpaths.clear();
+                path_subpath_start = None;
+                path_current = None;
+            }
+            "B" | "B*" | "b" | "b*" => {
+                if op.operator == "b" || op.operator == "b*" {
+                    if let (Some((cx, cy)), Some((sx, sy))) = (path_current, path_subpath_start) {
+                        if (cx - sx).abs() > 0.01 || (cy - sy).abs() > 0.01 {
+                            pending_lines.push((cx, cy, sx, sy));
+                        }
+                    }
+                }
+                for (x1, y1, x2, y2) in pending_lines.drain(..) {
+                    let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
+                    let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
+                    extract.underline_lines.push(UnderlineLine {
+                        x1: x1d,
+                        y1: y1d,
+                        x2: x2d,
+                        y2: y2d,
+                        stroke_width: transformed_stroke_width(line_width, &ctm, x1, y1, x2, y2),
+                        page: page_num,
+                    });
+                }
+                extract.painted_rects.append(&mut pending_re_rects);
+                pending_subpaths.clear();
+                path_subpath_start = None;
+                path_current = None;
+            }
+            "f" | "F" | "f*" => {
+                if !pending_lines.is_empty() {
+                    pending_subpaths.push(std::mem::take(&mut pending_lines));
+                }
+                for subpath in pending_subpaths.drain(..) {
+                    let mut segs = subpath;
+                    if segs.len() == 3 {
+                        let (x0, y0, _, _) = segs[0];
+                        let (_, _, ex, ey) = segs[2];
+                        if (ex - x0).abs() > 0.01 || (ey - y0).abs() > 0.01 {
+                            segs.push((ex, ey, x0, y0));
+                        }
+                    }
+                    if segs.len() == 4 {
+                        let mut xs = Vec::with_capacity(8);
+                        let mut ys = Vec::with_capacity(8);
+                        for &(x1, y1, x2, y2) in &segs {
+                            xs.push(x1);
+                            xs.push(x2);
+                            ys.push(y1);
+                            ys.push(y2);
+                        }
+                        let min_x = xs.iter().copied().fold(f32::INFINITY, f32::min);
+                        let max_x = xs.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                        let min_y = ys.iter().copied().fold(f32::INFINITY, f32::min);
+                        let max_y = ys.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                        let w = max_x - min_x;
+                        let h = max_y - min_y;
+                        let eps: f32 = 0.5;
+                        let axis_aligned = xs
+                            .iter()
+                            .all(|&x| (x - min_x).abs() < eps || (x - max_x).abs() < eps)
+                            && ys
+                                .iter()
+                                .all(|&y| (y - min_y).abs() < eps || (y - max_y).abs() < eps);
+                        if axis_aligned && w > 1.0 && h > 1.0 {
+                            let x_dev = min_x * ctm[0] + min_y * ctm[2] + ctm[4];
+                            let y_dev = min_x * ctm[1] + min_y * ctm[3] + ctm[5];
+                            let w_dev = w * ctm[0];
+                            let h_dev = h * ctm[3];
+                            fill_rects.push(PdfRect {
+                                x: x_dev,
+                                y: y_dev,
+                                width: w_dev,
+                                height: h_dev,
+                                page: page_num,
+                            });
+                        }
+                    }
+                }
+                extract.painted_rects.append(&mut pending_re_rects);
+                pending_lines.clear();
+                path_subpath_start = None;
+                path_current = None;
+            }
+            "n" => {
+                // Discard unpainted paths — clip-only `re W n` must not underline.
+                pending_re_rects.clear();
+                pending_lines.clear();
+                pending_subpaths.clear();
+                path_subpath_start = None;
+                path_current = None;
+            }
             _ => {}
         }
     }
 
-    items
+    extract.painted_rects.extend(fill_rects);
+    extract
 }
 
 /// Get fonts from a Form XObject's Resources

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -11,7 +11,9 @@ use super::fonts::{
     build_font_encodings, build_font_widths, compute_string_width_ts, extract_text_from_operand,
     get_font_file2_obj_num, get_operand_bytes, CMapDecisionCache, FontStyleCache,
 };
-use super::underline::{transform_path_point, transformed_stroke_width, UnderlineLine};
+use super::underline::{
+    transform_path_point, transform_user_rect, transformed_stroke_width, UnderlineLine,
+};
 use super::{get_number, image_bbox_from_ctm, multiply_matrices};
 
 const MAX_FORM_XOBJECT_DEPTH: u8 = 5;
@@ -127,12 +129,14 @@ impl FormXObjectExtract {
 }
 
 /// Extract text items and painted underline graphics from a Form XObject.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_form_xobject_text(
     doc: &Document,
     form_id: ObjectId,
     page_num: u32,
     font_cmaps: &FontCMaps,
     parent_ctm: &[f32; 6],
+    parent_line_width: f32,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
 ) -> FormXObjectExtract {
@@ -142,6 +146,7 @@ pub(crate) fn extract_form_xobject_text(
         page_num,
         font_cmaps,
         parent_ctm,
+        parent_line_width,
         cmap_decisions,
         style_cache,
         0,
@@ -155,6 +160,7 @@ fn extract_form_xobject_text_inner(
     page_num: u32,
     font_cmaps: &FontCMaps,
     parent_ctm: &[f32; 6],
+    parent_line_width: f32,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     depth: u8,
@@ -266,11 +272,17 @@ fn extract_form_xobject_text_inner(
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
-    let mut ctm_stack: Vec<[f32; 6]> = Vec::new();
+    // Inherit the caller's stroke width — Form XObjects do not reset it —
+    // and restore it across q/Q with the CTM (PDF graphics state).
+    let mut line_width: f32 = parent_line_width;
+    struct FormGraphicsState {
+        ctm: [f32; 6],
+        line_width: f32,
+    }
+    let mut gstate_stack: Vec<FormGraphicsState> = Vec::new();
 
     // Path / paint state — mirrors the page-level underline collectors so
     // rules drawn inside Form XObjects reach mark_underlined_items.
-    let mut line_width: f32 = 1.0;
     let mut path_subpath_start: Option<(f32, f32)> = None;
     let mut path_current: Option<(f32, f32)> = None;
     let mut pending_lines: Vec<(f32, f32, f32, f32)> = Vec::new();
@@ -281,11 +293,12 @@ fn extract_form_xobject_text_inner(
     for op in &content.operations {
         match op.operator.as_str() {
             "q" => {
-                ctm_stack.push(ctm);
+                gstate_stack.push(FormGraphicsState { ctm, line_width });
             }
             "Q" => {
-                if let Some(saved) = ctm_stack.pop() {
-                    ctm = saved;
+                if let Some(saved) = gstate_stack.pop() {
+                    ctm = saved.ctm;
+                    line_width = saved.line_width;
                 }
             }
             "cm" => {
@@ -310,6 +323,7 @@ fn extract_form_xobject_text_inner(
                                         page_num,
                                         font_cmaps,
                                         &ctm,
+                                        line_width,
                                         cmap_decisions,
                                         style_cache,
                                         depth + 1,
@@ -665,10 +679,8 @@ fn extract_form_xobject_text_inner(
                     let ry = get_number(&op.operands[1]).unwrap_or(0.0);
                     let rw = get_number(&op.operands[2]).unwrap_or(0.0);
                     let rh = get_number(&op.operands[3]).unwrap_or(0.0);
-                    let x_dev = rx * ctm[0] + ry * ctm[2] + ctm[4];
-                    let y_dev = rx * ctm[1] + ry * ctm[3] + ctm[5];
-                    let w_dev = rw * ctm[0];
-                    let h_dev = rh * ctm[3];
+                    let (x_dev, y_dev, w_dev, h_dev) =
+                        transform_user_rect(rx, ry, rw, rh, &ctm);
                     pending_re_rects.push(PdfRect {
                         x: x_dev,
                         y: y_dev,
@@ -715,20 +727,28 @@ fn extract_form_xobject_text_inner(
                         }
                     }
                 }
-                for (x1, y1, x2, y2) in pending_lines.drain(..) {
-                    let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
-                    let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
-                    extract.underline_lines.push(UnderlineLine {
-                        x1: x1d,
-                        y1: y1d,
-                        x2: x2d,
-                        y2: y2d,
-                        stroke_width: transformed_stroke_width(line_width, &ctm, x1, y1, x2, y2),
-                        page: page_num,
-                    });
+                // `h` already moved closed subpaths into pending_subpaths —
+                // drain those too so closed stroked rules are not dropped.
+                if !pending_lines.is_empty() {
+                    pending_subpaths.push(std::mem::take(&mut pending_lines));
+                }
+                for subpath in pending_subpaths.drain(..) {
+                    for (x1, y1, x2, y2) in subpath {
+                        let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
+                        let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
+                        extract.underline_lines.push(UnderlineLine {
+                            x1: x1d,
+                            y1: y1d,
+                            x2: x2d,
+                            y2: y2d,
+                            stroke_width: transformed_stroke_width(
+                                line_width, &ctm, x1, y1, x2, y2,
+                            ),
+                            page: page_num,
+                        });
+                    }
                 }
                 extract.painted_rects.append(&mut pending_re_rects);
-                pending_subpaths.clear();
                 path_subpath_start = None;
                 path_current = None;
             }
@@ -740,20 +760,26 @@ fn extract_form_xobject_text_inner(
                         }
                     }
                 }
-                for (x1, y1, x2, y2) in pending_lines.drain(..) {
-                    let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
-                    let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
-                    extract.underline_lines.push(UnderlineLine {
-                        x1: x1d,
-                        y1: y1d,
-                        x2: x2d,
-                        y2: y2d,
-                        stroke_width: transformed_stroke_width(line_width, &ctm, x1, y1, x2, y2),
-                        page: page_num,
-                    });
+                if !pending_lines.is_empty() {
+                    pending_subpaths.push(std::mem::take(&mut pending_lines));
+                }
+                for subpath in pending_subpaths.drain(..) {
+                    for (x1, y1, x2, y2) in subpath {
+                        let (x1d, y1d) = transform_path_point(x1, y1, &ctm);
+                        let (x2d, y2d) = transform_path_point(x2, y2, &ctm);
+                        extract.underline_lines.push(UnderlineLine {
+                            x1: x1d,
+                            y1: y1d,
+                            x2: x2d,
+                            y2: y2d,
+                            stroke_width: transformed_stroke_width(
+                                line_width, &ctm, x1, y1, x2, y2,
+                            ),
+                            page: page_num,
+                        });
+                    }
                 }
                 extract.painted_rects.append(&mut pending_re_rects);
-                pending_subpaths.clear();
                 path_subpath_start = None;
                 path_current = None;
             }
@@ -793,10 +819,8 @@ fn extract_form_xobject_text_inner(
                                 .iter()
                                 .all(|&y| (y - min_y).abs() < eps || (y - max_y).abs() < eps);
                         if axis_aligned && w > 1.0 && h > 1.0 {
-                            let x_dev = min_x * ctm[0] + min_y * ctm[2] + ctm[4];
-                            let y_dev = min_x * ctm[1] + min_y * ctm[3] + ctm[5];
-                            let w_dev = w * ctm[0];
-                            let h_dev = h * ctm[3];
+                            let (x_dev, y_dev, w_dev, h_dev) =
+                                transform_user_rect(min_x, min_y, w, h, &ctm);
                             fill_rects.push(PdfRect {
                                 x: x_dev,
                                 y: y_dev,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3660,9 +3660,22 @@ fn pdf_options_debug_redacts_password() {
 /// Build a PDF whose Form XObject draws text plus a painted underline rule.
 /// `paint` selects how the rule is drawn:
 /// - `"stroke"` — `m`/`l`/`S` under the baseline
+/// - `"closed_stroke"` — `m`/`l`/`h`/`S` (closed path; segments live in subpaths)
 /// - `"rect"` — thin filled `re`/`f` under the baseline
 /// - `"clip"` — `re W n` clip-only (must NOT underline)
+/// - `"inherit_stroke"` — form strokes without its own `w` (uses page line width)
 fn make_pdf_with_form_underline(paint: &str) -> Vec<u8> {
+    make_pdf_with_form_underline_ex(paint, None, "Underlined", None)
+}
+
+/// Same as [`make_pdf_with_form_underline`], with optional Form `/Matrix`,
+/// text label, and page-level content ops prepended before `Do`.
+fn make_pdf_with_form_underline_ex(
+    paint: &str,
+    form_matrix: Option<[lopdf::Object; 6]>,
+    label: &str,
+    page_prefix_ops: Option<Vec<lopdf::content::Operation>>,
+) -> Vec<u8> {
     use lopdf::content::{Content, Operation};
     use lopdf::{dictionary, Document, Object, Stream};
 
@@ -3681,35 +3694,45 @@ fn make_pdf_with_form_underline(paint: &str) -> Vec<u8> {
             "BaseFont" => "Helvetica",
             "FirstChar" => 32,
             "LastChar" => 126,
-            // Uniform 600-unit advance so "Underlined" (10 chars) ≈ 72pt at size 12.
+            // Uniform 600-unit advance so 10 chars ≈ 72pt at size 12.
             "Widths" => Object::Array(vec![Object::Integer(600); 95]),
         }
         .into(),
     );
 
-    // Form content: text at (100, 500) with width ~60 for "Underlined"
+    // Form content: text at (100, 500); rule span sized for the label width
+    // (Widths=600 units → advance = n * 0.6 * font_size).
+    let label_width = ((label.len() as i64) * 600 * 12 / 1000).max(60);
     let mut form_ops = vec![
         Operation::new("BT", vec![]),
         Operation::new("Tf", vec!["F1".into(), 12.into()]),
         Operation::new("Td", vec![100.into(), 500.into()]),
-        Operation::new("Tj", vec![Object::string_literal("Underlined")]),
+        Operation::new("Tj", vec![Object::string_literal(label)]),
         Operation::new("ET", vec![]),
     ];
     match paint {
-        "stroke" => {
+        "stroke" | "inherit_stroke" => {
+            if paint == "stroke" {
+                form_ops.push(Operation::new("w", vec![Object::Real(0.5)]));
+            }
+            form_ops.push(Operation::new("m", vec![100.into(), 498.into()]));
+            form_ops.push(Operation::new("l", vec![Object::Integer(100 + label_width), 498.into()]));
+            form_ops.push(Operation::new("S", vec![]));
+        }
+        "closed_stroke" => {
             form_ops.push(Operation::new("w", vec![Object::Real(0.5)]));
             form_ops.push(Operation::new("m", vec![100.into(), 498.into()]));
-            form_ops.push(Operation::new("l", vec![160.into(), 498.into()]));
+            form_ops.push(Operation::new("l", vec![Object::Integer(100 + label_width), 498.into()]));
+            form_ops.push(Operation::new("h", vec![]));
             form_ops.push(Operation::new("S", vec![]));
         }
         "rect" => {
-            // Thin filled rect just under the baseline.
             form_ops.push(Operation::new(
                 "re",
                 vec![
                     100.into(),
                     Object::Real(497.5),
-                    60.into(),
+                    Object::Integer(label_width),
                     Object::Real(1.0),
                 ],
             ));
@@ -3721,7 +3744,7 @@ fn make_pdf_with_form_underline(paint: &str) -> Vec<u8> {
                 vec![
                     100.into(),
                     Object::Real(497.5),
-                    60.into(),
+                    Object::Integer(label_width),
                     Object::Real(1.0),
                 ],
             ));
@@ -3736,26 +3759,26 @@ fn make_pdf_with_form_underline(paint: &str) -> Vec<u8> {
     }
     .encode()
     .unwrap();
+    let mut form_dict = dictionary! {
+        "Type" => "XObject",
+        "Subtype" => "Form",
+        "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Resources" => dictionary! {
+            "Font" => dictionary! {
+                "F1" => font_id,
+            },
+        },
+    };
+    if let Some(m) = form_matrix {
+        form_dict.set("Matrix", Object::Array(m.to_vec()));
+    }
     doc.objects.insert(
         form_id,
-        Stream::new(
-            dictionary! {
-                "Type" => "XObject",
-                "Subtype" => "Form",
-                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
-                "Resources" => dictionary! {
-                    "Font" => dictionary! {
-                        "F1" => font_id,
-                    },
-                },
-            },
-            form_content,
-        )
-        .into(),
+        Stream::new(form_dict, form_content).into(),
     );
 
-    // Page merely invokes the form.
-    let page_ops = vec![Operation::new("Do", vec!["Fm0".into()])];
+    let mut page_ops = page_prefix_ops.unwrap_or_default();
+    page_ops.push(Operation::new("Do", vec!["Fm0".into()]));
     let page_content = Content {
         operations: page_ops,
     }
@@ -3848,107 +3871,22 @@ fn test_form_xobject_clip_only_rect_does_not_underline() {
 fn test_form_xobject_matrix_transforms_underline() {
     // Form Matrix translates content by (+40, -20). Text at local (100,500)
     // lands at (140,480); underline stroke must transform with it.
-    use lopdf::content::{Content, Operation};
-    use lopdf::{dictionary, Document, Object, Stream};
+    use lopdf::Object;
 
-    let mut doc = Document::with_version("1.5");
-    let pages_id = doc.new_object_id();
-    let page_id = doc.new_object_id();
-    let font_id = doc.new_object_id();
-    let content_id = doc.new_object_id();
-    let form_id = doc.new_object_id();
-
-    doc.objects.insert(
-        font_id,
-        dictionary! {
-            "Type" => "Font",
-            "Subtype" => "Type1",
-            "BaseFont" => "Helvetica",
-            "FirstChar" => 32,
-            "LastChar" => 126,
-            // Uniform 600-unit advance so "Underlined" (10 chars) ≈ 72pt at size 12.
-            "Widths" => Object::Array(vec![Object::Integer(600); 95]),
-        }
-        .into(),
+    let pdf = make_pdf_with_form_underline_ex(
+        "stroke",
+        Some([
+            1.into(),
+            0.into(),
+            0.into(),
+            1.into(),
+            40.into(),
+            Object::Integer(-20),
+        ]),
+        "Shifted",
+        None,
     );
-
-    let form_ops = vec![
-        Operation::new("BT", vec![]),
-        Operation::new("Tf", vec!["F1".into(), 12.into()]),
-        Operation::new("Td", vec![100.into(), 500.into()]),
-        Operation::new("Tj", vec![Object::string_literal("Shifted")]),
-        Operation::new("ET", vec![]),
-        Operation::new("w", vec![Object::Real(0.5)]),
-        Operation::new("m", vec![100.into(), 498.into()]),
-        Operation::new("l", vec![150.into(), 498.into()]),
-        Operation::new("S", vec![]),
-    ];
-    let form_content = Content {
-        operations: form_ops,
-    }
-    .encode()
-    .unwrap();
-    doc.objects.insert(
-        form_id,
-        Stream::new(
-            dictionary! {
-                "Type" => "XObject",
-                "Subtype" => "Form",
-                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
-                "Matrix" => vec![1.into(), 0.into(), 0.into(), 1.into(), 40.into(), Object::Integer(-20)],
-                "Resources" => dictionary! {
-                    "Font" => dictionary! {
-                        "F1" => font_id,
-                    },
-                },
-            },
-            form_content,
-        )
-        .into(),
-    );
-
-    let page_ops = vec![Operation::new("Do", vec!["Fm0".into()])];
-    let page_content = Content {
-        operations: page_ops,
-    }
-    .encode()
-    .unwrap();
-    doc.objects
-        .insert(content_id, Stream::new(dictionary! {}, page_content).into());
-    doc.objects.insert(
-        page_id,
-        dictionary! {
-            "Type" => "Page",
-            "Parent" => pages_id,
-            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
-            "Resources" => dictionary! {
-                "XObject" => dictionary! {
-                    "Fm0" => form_id,
-                },
-            },
-            "Contents" => content_id,
-        }
-        .into(),
-    );
-    doc.objects.insert(
-        pages_id,
-        dictionary! {
-            "Type" => "Pages",
-            "Kids" => vec![page_id.into()],
-            "Count" => 1,
-        }
-        .into(),
-    );
-    let catalog_id = doc.add_object(dictionary! {
-        "Type" => "Catalog",
-        "Pages" => pages_id,
-    });
-    doc.trailer.set("Root", catalog_id);
-
-    let mut bytes = Vec::new();
-    doc.save_to(&mut bytes).unwrap();
-
-    let items = extract_text_with_positions_mem(&bytes).expect("extract");
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
     let hit = items
         .iter()
         .find(|i| i.text.contains("Shifted"))
@@ -3966,5 +3904,43 @@ fn test_form_xobject_matrix_transforms_underline() {
     assert!(
         hit.is_underline,
         "underline transformed by Form Matrix should still match; item={hit:?}"
+    );
+}
+
+#[test]
+fn test_form_xobject_closed_stroke_underline_marks_text() {
+    let pdf = make_pdf_with_form_underline("closed_stroke");
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Underlined"))
+        .expect("text item from form");
+    assert!(
+        hit.is_underline,
+        "closed h/S stroke inside Form should mark underline; item={hit:?}"
+    );
+}
+
+#[test]
+fn test_form_xobject_inherits_page_line_width() {
+    // Page sets a thick stroke (10pt). Form strokes without its own `w`, so
+    // the inherited width must reject the rule as an underline.
+    use lopdf::content::Operation;
+    use lopdf::Object;
+
+    let pdf = make_pdf_with_form_underline_ex(
+        "inherit_stroke",
+        None,
+        "Underlined",
+        Some(vec![Operation::new("w", vec![Object::Real(10.0)])]),
+    );
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Underlined"))
+        .expect("text item from form");
+    assert!(
+        !hit.is_underline,
+        "thick inherited page line width must not mark underline; item={hit:?}"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3652,3 +3652,319 @@ fn pdf_options_debug_redacts_password() {
     );
     assert!(dbg.contains("REDACTED"), "expected redaction marker: {dbg}");
 }
+
+// ============================================================================
+// Form XObject underline / strikeout graphics (#126)
+// ============================================================================
+
+/// Build a PDF whose Form XObject draws text plus a painted underline rule.
+/// `paint` selects how the rule is drawn:
+/// - `"stroke"` — `m`/`l`/`S` under the baseline
+/// - `"rect"` — thin filled `re`/`f` under the baseline
+/// - `"clip"` — `re W n` clip-only (must NOT underline)
+fn make_pdf_with_form_underline(paint: &str) -> Vec<u8> {
+    use lopdf::content::{Content, Operation};
+    use lopdf::{dictionary, Document, Object, Stream};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let page_id = doc.new_object_id();
+    let font_id = doc.new_object_id();
+    let content_id = doc.new_object_id();
+    let form_id = doc.new_object_id();
+
+    doc.objects.insert(
+        font_id,
+        dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "FirstChar" => 32,
+            "LastChar" => 126,
+            // Uniform 600-unit advance so "Underlined" (10 chars) ≈ 72pt at size 12.
+            "Widths" => Object::Array(vec![Object::Integer(600); 95]),
+        }
+        .into(),
+    );
+
+    // Form content: text at (100, 500) with width ~60 for "Underlined"
+    let mut form_ops = vec![
+        Operation::new("BT", vec![]),
+        Operation::new("Tf", vec!["F1".into(), 12.into()]),
+        Operation::new("Td", vec![100.into(), 500.into()]),
+        Operation::new("Tj", vec![Object::string_literal("Underlined")]),
+        Operation::new("ET", vec![]),
+    ];
+    match paint {
+        "stroke" => {
+            form_ops.push(Operation::new("w", vec![Object::Real(0.5)]));
+            form_ops.push(Operation::new("m", vec![100.into(), 498.into()]));
+            form_ops.push(Operation::new("l", vec![160.into(), 498.into()]));
+            form_ops.push(Operation::new("S", vec![]));
+        }
+        "rect" => {
+            // Thin filled rect just under the baseline.
+            form_ops.push(Operation::new(
+                "re",
+                vec![
+                    100.into(),
+                    Object::Real(497.5),
+                    60.into(),
+                    Object::Real(1.0),
+                ],
+            ));
+            form_ops.push(Operation::new("f", vec![]));
+        }
+        "clip" => {
+            form_ops.push(Operation::new(
+                "re",
+                vec![
+                    100.into(),
+                    Object::Real(497.5),
+                    60.into(),
+                    Object::Real(1.0),
+                ],
+            ));
+            form_ops.push(Operation::new("W", vec![]));
+            form_ops.push(Operation::new("n", vec![]));
+        }
+        other => panic!("unknown paint mode: {other}"),
+    }
+
+    let form_content = Content {
+        operations: form_ops,
+    }
+    .encode()
+    .unwrap();
+    doc.objects.insert(
+        form_id,
+        Stream::new(
+            dictionary! {
+                "Type" => "XObject",
+                "Subtype" => "Form",
+                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                "Resources" => dictionary! {
+                    "Font" => dictionary! {
+                        "F1" => font_id,
+                    },
+                },
+            },
+            form_content,
+        )
+        .into(),
+    );
+
+    // Page merely invokes the form.
+    let page_ops = vec![Operation::new("Do", vec!["Fm0".into()])];
+    let page_content = Content {
+        operations: page_ops,
+    }
+    .encode()
+    .unwrap();
+    doc.objects
+        .insert(content_id, Stream::new(dictionary! {}, page_content).into());
+
+    doc.objects.insert(
+        page_id,
+        dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+            "Resources" => dictionary! {
+                "Font" => dictionary! {
+                    "F1" => font_id,
+                },
+                "XObject" => dictionary! {
+                    "Fm0" => form_id,
+                },
+            },
+            "Contents" => content_id,
+        }
+        .into(),
+    );
+    doc.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1,
+        }
+        .into(),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    bytes
+}
+
+#[test]
+fn test_form_xobject_stroked_underline_marks_text() {
+    let pdf = make_pdf_with_form_underline("stroke");
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Underlined"))
+        .expect("text item from form");
+    assert!(
+        hit.is_underline,
+        "stroked rule inside Form XObject should mark underline; item={hit:?}"
+    );
+}
+
+#[test]
+fn test_form_xobject_filled_rect_underline_marks_text() {
+    let pdf = make_pdf_with_form_underline("rect");
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Underlined"))
+        .expect("text item from form");
+    assert!(
+        hit.is_underline,
+        "filled thin rect inside Form XObject should mark underline; item={hit:?}"
+    );
+}
+
+#[test]
+fn test_form_xobject_clip_only_rect_does_not_underline() {
+    let pdf = make_pdf_with_form_underline("clip");
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Underlined"))
+        .expect("text item from form");
+    assert!(
+        !hit.is_underline,
+        "clip-only re W n inside Form must not underline; item={hit:?}"
+    );
+}
+
+#[test]
+fn test_form_xobject_matrix_transforms_underline() {
+    // Form Matrix translates content by (+40, -20). Text at local (100,500)
+    // lands at (140,480); underline stroke must transform with it.
+    use lopdf::content::{Content, Operation};
+    use lopdf::{dictionary, Document, Object, Stream};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let page_id = doc.new_object_id();
+    let font_id = doc.new_object_id();
+    let content_id = doc.new_object_id();
+    let form_id = doc.new_object_id();
+
+    doc.objects.insert(
+        font_id,
+        dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "FirstChar" => 32,
+            "LastChar" => 126,
+            // Uniform 600-unit advance so "Underlined" (10 chars) ≈ 72pt at size 12.
+            "Widths" => Object::Array(vec![Object::Integer(600); 95]),
+        }
+        .into(),
+    );
+
+    let form_ops = vec![
+        Operation::new("BT", vec![]),
+        Operation::new("Tf", vec!["F1".into(), 12.into()]),
+        Operation::new("Td", vec![100.into(), 500.into()]),
+        Operation::new("Tj", vec![Object::string_literal("Shifted")]),
+        Operation::new("ET", vec![]),
+        Operation::new("w", vec![Object::Real(0.5)]),
+        Operation::new("m", vec![100.into(), 498.into()]),
+        Operation::new("l", vec![150.into(), 498.into()]),
+        Operation::new("S", vec![]),
+    ];
+    let form_content = Content {
+        operations: form_ops,
+    }
+    .encode()
+    .unwrap();
+    doc.objects.insert(
+        form_id,
+        Stream::new(
+            dictionary! {
+                "Type" => "XObject",
+                "Subtype" => "Form",
+                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                "Matrix" => vec![1.into(), 0.into(), 0.into(), 1.into(), 40.into(), Object::Integer(-20)],
+                "Resources" => dictionary! {
+                    "Font" => dictionary! {
+                        "F1" => font_id,
+                    },
+                },
+            },
+            form_content,
+        )
+        .into(),
+    );
+
+    let page_ops = vec![Operation::new("Do", vec!["Fm0".into()])];
+    let page_content = Content {
+        operations: page_ops,
+    }
+    .encode()
+    .unwrap();
+    doc.objects
+        .insert(content_id, Stream::new(dictionary! {}, page_content).into());
+    doc.objects.insert(
+        page_id,
+        dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+            "Resources" => dictionary! {
+                "XObject" => dictionary! {
+                    "Fm0" => form_id,
+                },
+            },
+            "Contents" => content_id,
+        }
+        .into(),
+    );
+    doc.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1,
+        }
+        .into(),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+
+    let items = extract_text_with_positions_mem(&bytes).expect("extract");
+    let hit = items
+        .iter()
+        .find(|i| i.text.contains("Shifted"))
+        .expect("text item");
+    assert!(
+        (hit.x - 140.0).abs() < 1.0,
+        "form Matrix should shift x to ~140, got {}",
+        hit.x
+    );
+    assert!(
+        (hit.y - 480.0).abs() < 1.0,
+        "form Matrix should shift y to ~480, got {}",
+        hit.y
+    );
+    assert!(
+        hit.is_underline,
+        "underline transformed by Form Matrix should still match; item={hit:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #126.

Form XObject extraction only returned `Vec<TextItem>`. Path/paint operators (`re`, `m`, `l`, `S`, `f`, `w`, …) were ignored, so underline/strikeout rules drawn inside forms never reached `mark_underlined_items` (page content collected `painted_rects` / `underline_lines` exclusively from the page stream).

## Changes

- Return `FormXObjectExtract { items, painted_rects, underline_lines }` from the form walker
- Handle path construction + painting in the form content stream (same paint-vs-clip rule as the page: `n` discards pending `re`)
- Apply Form `/Matrix` × CTM (and stroke-width transform) so nested placement stays correct
- Merge form graphics into the page-level collectors at `Do`
- Move shared `transform_path_point` / `transformed_stroke_width` next to `UnderlineLine`

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo test --lib` → 716 passed
- [x] `cargo test --test integration_tests` → 145 passed
- [x] New regressions:
  - stroked underline inside Form → `is_underline`
  - thin filled `re`/`f` inside Form → `is_underline`
  - clip-only `re W n` inside Form → **not** underlined
  - Form `/Matrix` translates text + underline together

## Notes

Does not touch wasm/napi packaging paths claimed by open PRs (#184, #182, #111). Nested Form depth limit (`MAX_FORM_XOBJECT_DEPTH`) unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788203678&installation_model_id=11126&pr_number=193&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F193&signature=1e8c54145316cd117e75d548847fb5ca56d56ab0f8e7f6c39ed3d39f692fa5fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Underline detection now includes rules drawn inside Form XObjects by collecting path/paint ops from form streams and merging them at `Do`. Geometry and stroke widths are correctly transformed by the Form `/Matrix` and page CTM, including shear cases.

- **Bug Fixes**
  - Return `FormXObjectExtract` with `items`, `painted_rects`, and `underline_lines`.
  - Handle `re`, `m`, `l`, `h`, `S`, `s`, `B`, `B*`, `b`, `b*`, `f`, `w`; inherit page stroke width into forms and restore across `q`/`Q`; discard clip-only paths via `n`.
  - Transform rects using all four corners and scale stroke thickness with `|det|/||CTM·tangent||`; share helpers in `underline.rs`.

<sup>Written for commit 1fdaca3c3f02731e4e77addaf5c257e4d9df18f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

