### PR TITLE
feat(extractor): expose from_font_without_tounicode on TextItem

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -86,6 +86,9 @@ pub struct TextItem {
     /// Strikeout detected geometrically (rule crossing the glyphs at mid
     /// x-height).
     pub is_strikeout: bool,
+    /// True when this run used a Type0 Identity-H/V or Type3 font with no
+    /// `/ToUnicode` entry. Presence ≠ validity; use with encoding heuristics.
+    pub from_font_without_tounicode: bool,
     pub item_type: ItemType,
     /// URL for link items, `None` for other types.
     pub link_url: Option<String>,
@@ -298,6 +301,7 @@ pub fn extract_text_with_positions(
                     is_italic: item.is_italic,
                     is_underline: item.is_underline,
                     is_strikeout: item.is_strikeout,
+                    from_font_without_tounicode: item.from_font_without_tounicode,
                     item_type,
                     link_url,
                 }

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -40,6 +40,8 @@ class TextItem:
     is_italic: bool
     is_underline: bool
     is_strikeout: bool
+    from_font_without_tounicode: bool
+    """True when the run used a font with no /ToUnicode entry."""
     item_type: str
 
 class RegionText:

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -124,6 +124,7 @@ mod tests {
             is_italic: true,
             is_underline: true,
             is_strikeout: true,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: Some(7),
         }];

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -176,6 +176,12 @@ pub(crate) fn extract_page_text_items(
         std::collections::HashMap::new();
     let mut font_style_flags: std::collections::HashMap<String, (bool, bool)> =
         std::collections::HashMap::new();
+    // True when a font that needs ToUnicode for reliable decode lacks it.
+    // Type1/TrueType with standard encodings are fine without ToUnicode;
+    // Type0 Identity-H/V and Type3 are not. FontFile2 fallbacks do not count
+    // as having ToUnicode — consumers want the explicit map signal.
+    let mut font_missing_required_tounicode: std::collections::HashMap<String, bool> =
+        std::collections::HashMap::new();
     for (font_name, font_dict) in &fonts {
         let resource_name = String::from_utf8_lossy(font_name).to_string();
         if let Ok(base_font) = font_dict.get(b"BaseFont") {
@@ -192,8 +198,21 @@ pub(crate) fn extract_page_text_items(
         }
         // Track ToUnicode object reference, with FontFile2 fallback for Identity-H/V.
         // Also handle inline ToUnicode streams.
+        let subtype = font_dict
+            .get(b"Subtype")
+            .ok()
+            .and_then(|o| o.as_name().ok());
+        let encoding = font_dict
+            .get(b"Encoding")
+            .ok()
+            .and_then(|o| o.as_name().ok());
+        let needs_tounicode = matches!(subtype, Some(b"Type3"))
+            || (matches!(subtype, Some(b"Type0"))
+                && matches!(encoding, Some(b"Identity-H") | Some(b"Identity-V")));
+
         match font_dict.get(b"ToUnicode") {
             Ok(tounicode) => {
+                font_missing_required_tounicode.insert(resource_name.clone(), false);
                 if let Ok(obj_ref) = tounicode.as_reference() {
                     font_tounicode_refs.insert(resource_name, obj_ref.0);
                 } else if let Object::Stream(s) = tounicode {
@@ -208,6 +227,7 @@ pub(crate) fn extract_page_text_items(
                 }
             }
             Err(_) => {
+                font_missing_required_tounicode.insert(resource_name.clone(), needs_tounicode);
                 if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
                     font_tounicode_refs.insert(resource_name, ff2_obj_num);
                 }
@@ -540,6 +560,10 @@ pub(crate) fn extract_page_text_items(
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
+                                from_font_without_tounicode: font_missing_required_tounicode
+                                    .get(&current_font)
+                                    .copied()
+                                    .unwrap_or(false),
                                 item_type: ItemType::Text,
                                 mcid: current_mcid(&marked_content_stack),
                             });
@@ -713,6 +737,10 @@ pub(crate) fn extract_page_text_items(
                                     is_italic: is_italic_font(base_font) || desc_italic,
                                     is_underline: false,
                                     is_strikeout: false,
+                                    from_font_without_tounicode: font_missing_required_tounicode
+                                        .get(&current_font)
+                                        .copied()
+                                        .unwrap_or(false),
                                     item_type: ItemType::Text,
                                     mcid: current_mcid(&marked_content_stack),
                                 });
@@ -809,6 +837,10 @@ pub(crate) fn extract_page_text_items(
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
+                                from_font_without_tounicode: font_missing_required_tounicode
+                                    .get(&current_font)
+                                    .copied()
+                                    .unwrap_or(false),
                                 item_type: ItemType::Text,
                                 mcid: current_mcid(&marked_content_stack),
                             });
@@ -853,6 +885,7 @@ pub(crate) fn extract_page_text_items(
                                         is_italic: false,
                                         is_underline: false,
                                         is_strikeout: false,
+                                        from_font_without_tounicode: false,
                                         item_type: ItemType::Image,
                                         mcid: current_mcid(&marked_content_stack),
                                     });
@@ -960,6 +993,10 @@ pub(crate) fn extract_page_text_items(
                                     is_italic: is_italic_font(base_font) || desc_italic,
                                     is_underline: false,
                                     is_strikeout: false,
+                                    from_font_without_tounicode: font_missing_required_tounicode
+                                        .get(&current_font)
+                                        .copied()
+                                        .unwrap_or(false),
                                     item_type: ItemType::Text,
                                     mcid: entry
                                         .mcid

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1706,6 +1706,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -1860,6 +1861,7 @@ mod tests {
                     is_italic: false,
                     is_underline: false,
                     is_strikeout: false,
+                    from_font_without_tounicode: false,
                     item_type: ItemType::Text,
                     mcid: None,
                 });

--- a/src/extractor/links.rs
+++ b/src/extractor/links.rs
@@ -80,6 +80,7 @@ pub fn extract_page_links(doc: &Document, page_id: ObjectId, page_num: u32) -> V
                             is_italic: false,
                             is_underline: false,
                             is_strikeout: false,
+                            from_font_without_tounicode: false,
                             item_type: ItemType::Link(url),
                             mcid: None,
                         });
@@ -320,6 +321,7 @@ pub(crate) fn walk_form_fields(
         is_italic: false,
         is_underline: false,
         is_strikeout: false,
+        from_font_without_tounicode: false,
         item_type: ItemType::FormField,
         mcid: None,
     });

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -68,6 +68,32 @@ fn extract_text_from_doc(doc: &Document) -> Result<String, PdfError> {
         .map_err(|e| PdfError::Parse(e.to_string()))
 }
 
+/// Fraction of text-run width drawn with fonts that lack a required `/ToUnicode`
+/// map (Type0 Identity-H/V or Type3 without ToUnicode).
+///
+/// Returns `0.0` when there is no measurable text width. Image/link/form items
+/// are ignored. Useful as a page-level summary of
+/// [`TextItem::from_font_without_tounicode`].
+pub fn tounicode_missing_width_fraction(items: &[TextItem]) -> f32 {
+    let mut total = 0.0f32;
+    let mut missing = 0.0f32;
+    for item in items {
+        if !matches!(item.item_type, ItemType::Text) || item.text.trim().is_empty() {
+            continue;
+        }
+        let w = item.width.max(0.0);
+        total += w;
+        if item.from_font_without_tounicode {
+            missing += w;
+        }
+    }
+    if total <= f32::EPSILON {
+        0.0
+    } else {
+        missing / total
+    }
+}
+
 /// Extract text with position information from PDF file
 pub fn extract_text_with_positions<P: AsRef<Path>>(path: P) -> Result<Vec<TextItem>, PdfError> {
     extract_text_with_positions_pages(path, None)
@@ -822,6 +848,7 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
             let first = group[i];
             let mut text = first.text.clone();
             let mut end_x = first.x + effective_merge_width(first);
+            let mut from_font_without_tounicode = first.from_font_without_tounicode;
 
             // Tracked display text: run-local space floor overrides the
             // fixed thresholds for this run's junctions (see helper).
@@ -893,6 +920,7 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                     text.push(' ');
                 }
                 text.push_str(&next.text);
+                from_font_without_tounicode |= next.from_font_without_tounicode;
                 let next_end = next.x + effective_merge_width(next);
                 end_x = if *preserve_stream_order {
                     end_x.max(next_end)
@@ -915,6 +943,7 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 is_italic: first.is_italic,
                 is_underline: first.is_underline,
                 is_strikeout: first.is_strikeout,
+                from_font_without_tounicode,
                 item_type: first.item_type.clone(),
                 mcid: first.mcid,
             });
@@ -1019,6 +1048,7 @@ pub(crate) fn merge_subscript_items(items: Vec<TextItem>) -> Vec<TextItem> {
                             let raised = item.y > parent.y + parent.font_size * 0.1;
                             parent.text.push_str(&map_script_digits(&item.text, raised));
                             parent.width = (item.x + item.width) - parent.x;
+                            parent.from_font_without_tounicode |= item.from_font_without_tounicode;
                             continue;
                         }
                     }
@@ -1218,6 +1248,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -1476,6 +1507,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1492,6 +1524,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1508,6 +1541,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1576,6 +1610,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1592,6 +1627,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1608,6 +1644,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1635,6 +1672,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1651,6 +1689,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1667,6 +1706,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1696,6 +1736,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }
@@ -1732,6 +1773,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }
@@ -1769,6 +1811,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1785,6 +1828,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1801,6 +1845,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1825,6 +1870,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -1939,6 +1985,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1955,6 +2002,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1981,6 +2029,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -1997,6 +2046,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             },
@@ -2039,6 +2089,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }],
@@ -2085,6 +2136,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }],
@@ -2131,6 +2183,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }],
@@ -2170,6 +2223,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/extractor/reading_order.rs
+++ b/src/extractor/reading_order.rs
@@ -446,6 +446,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -484,6 +484,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -173,6 +173,7 @@ fn extract_form_xobject_text_inner(
     let mut inline_cmaps: HashMap<String, crate::tounicode::CMapEntry> = HashMap::new();
 
     let mut font_style_flags: HashMap<String, (bool, bool)> = HashMap::new();
+    let mut font_missing_required_tounicode: HashMap<String, bool> = HashMap::new();
     for (font_name, font_dict) in &form_fonts {
         let resource_name = String::from_utf8_lossy(font_name).to_string();
         if let Ok(base_font) = font_dict.get(b"BaseFont") {
@@ -185,8 +186,21 @@ fn extract_form_xobject_text_inner(
         if style != (false, false) {
             font_style_flags.insert(resource_name.clone(), style);
         }
+        let subtype = font_dict
+            .get(b"Subtype")
+            .ok()
+            .and_then(|o| o.as_name().ok());
+        let encoding = font_dict
+            .get(b"Encoding")
+            .ok()
+            .and_then(|o| o.as_name().ok());
+        let needs_tounicode = matches!(subtype, Some(b"Type3"))
+            || (matches!(subtype, Some(b"Type0"))
+                && matches!(encoding, Some(b"Identity-H") | Some(b"Identity-V")));
+
         match font_dict.get(b"ToUnicode") {
             Ok(tounicode) => {
+                font_missing_required_tounicode.insert(resource_name.clone(), false);
                 if let Ok(obj_ref) = tounicode.as_reference() {
                     font_tounicode_refs.insert(resource_name, obj_ref.0);
                 } else if let Object::Stream(s) = tounicode {
@@ -201,6 +215,7 @@ fn extract_form_xobject_text_inner(
                 }
             }
             Err(_) => {
+                font_missing_required_tounicode.insert(resource_name.clone(), needs_tounicode);
                 if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
                     font_tounicode_refs.insert(resource_name, ff2_obj_num);
                 }
@@ -307,6 +322,7 @@ fn extract_form_xobject_text_inner(
                                     is_italic: false,
                                     is_underline: false,
                                     is_strikeout: false,
+                                    from_font_without_tounicode: false,
                                     item_type: ItemType::Image,
                                     mcid: None,
                                 });
@@ -457,6 +473,10 @@ fn extract_form_xobject_text_inner(
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
+                                from_font_without_tounicode: font_missing_required_tounicode
+                                    .get(&current_font)
+                                    .copied()
+                                    .unwrap_or(false),
                                 item_type: ItemType::Text,
                                 mcid: None,
                             });
@@ -611,6 +631,10 @@ fn extract_form_xobject_text_inner(
                                     is_italic: is_italic_font(base_font) || desc_italic,
                                     is_underline: false,
                                     is_strikeout: false,
+                                    from_font_without_tounicode: font_missing_required_tounicode
+                                        .get(&current_font)
+                                        .copied()
+                                        .unwrap_or(false),
                                     item_type: ItemType::Text,
                                     mcid: None,
                                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use detector::{
 };
 pub use extractor::{
     extract_text, extract_text_with_positions, extract_text_with_positions_mem,
-    extract_text_with_positions_pages,
+    extract_text_with_positions_pages, tounicode_missing_width_fraction,
 };
 pub use markdown::{
     to_markdown, to_markdown_from_items, to_markdown_from_items_with_rects, MarkdownOptions,
@@ -4767,6 +4767,7 @@ mod text_cluster_column_undercount_tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -5043,6 +5044,7 @@ mod table_candidate_selection_tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -5791,6 +5793,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -511,6 +511,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: crate::types::ItemType::Text,
             mcid: None,
         };

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1549,6 +1549,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: crate::types::ItemType::Text,
             mcid,
         }

--- a/src/markdown/heading.rs
+++ b/src/markdown/heading.rs
@@ -521,6 +521,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             }],
@@ -679,6 +680,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         });

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1910,6 +1910,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: crate::types::ItemType::Text,
             mcid: None,
         }

--- a/src/markdown/preprocess.rs
+++ b/src/markdown/preprocess.rs
@@ -584,6 +584,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid,
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -270,6 +270,8 @@ pub struct PyTextItem {
     #[pyo3(get)]
     pub is_strikeout: bool,
     #[pyo3(get)]
+    pub from_font_without_tounicode: bool,
+    #[pyo3(get)]
     pub item_type: String,
 }
 
@@ -355,6 +357,7 @@ fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
             is_italic: item.is_italic,
             is_underline: item.is_underline,
             is_strikeout: item.is_strikeout,
+            from_font_without_tounicode: item.from_font_without_tounicode,
             item_type: item_type_str(&item.item_type),
         })
         .collect()

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -106,6 +106,7 @@ pub(crate) fn merge_adjacent_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<Ve
                 is_italic: first_item.is_italic,
                 is_underline: first_item.is_underline,
                 is_strikeout: first_item.is_strikeout,
+                from_font_without_tounicode: false,
                 item_type: first_item.item_type.clone(),
                 mcid: first_item.mcid,
             });

--- a/src/tables/detect_lines.rs
+++ b/src/tables/detect_lines.rs
@@ -1596,6 +1596,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -2983,6 +2983,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -4265,6 +4266,7 @@ mod tests {
                     is_italic: false,
                     is_underline: false,
                     is_strikeout: false,
+                    from_font_without_tounicode: false,
                     item_type: crate::types::ItemType::Text,
                     mcid: None,
                 });
@@ -4576,6 +4578,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: crate::types::ItemType::Text,
                 mcid: None,
             });

--- a/src/tables/detect_struct.rs
+++ b/src/tables/detect_struct.rs
@@ -588,6 +588,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid,
         }

--- a/src/tables/financial.rs
+++ b/src/tables/financial.rs
@@ -110,6 +110,7 @@ pub(crate) fn try_split_financial_item(item: &TextItem) -> Option<Vec<TextItem>>
             is_italic: item.is_italic,
             is_underline: item.is_underline,
             is_strikeout: item.is_strikeout,
+            from_font_without_tounicode: false,
             item_type: item.item_type.clone(),
             mcid: item.mcid,
         });

--- a/src/tables/grid.rs
+++ b/src/tables/grid.rs
@@ -522,6 +522,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -888,6 +889,7 @@ mod tests {
                         is_italic: false,
                         is_underline: false,
                         is_strikeout: false,
+                        from_font_without_tounicode: false,
                         item_type: ItemType::Text,
                         mcid: None,
                         page: 1,
@@ -926,6 +928,7 @@ mod tests {
                         is_italic: false,
                         is_underline: false,
                         is_strikeout: false,
+                        from_font_without_tounicode: false,
                         item_type: ItemType::Text,
                         mcid: None,
                         page: 1,

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -292,6 +292,7 @@ fn split_merged_numbers(item: &TextItem, col_boundaries: &[f32]) -> Vec<TextItem
             is_italic: item.is_italic,
             is_underline: item.is_underline,
             is_strikeout: item.is_strikeout,
+            from_font_without_tounicode: false,
             item_type: item.item_type.clone(),
             mcid: item.mcid,
         });
@@ -314,6 +315,7 @@ fn split_merged_numbers(item: &TextItem, col_boundaries: &[f32]) -> Vec<TextItem
             is_italic: item.is_italic,
             is_underline: item.is_underline,
             is_strikeout: item.is_strikeout,
+            from_font_without_tounicode: false,
             item_type: item.item_type.clone(),
             mcid: item.mcid,
         });
@@ -1490,6 +1492,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -1509,6 +1512,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -899,6 +899,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }
@@ -1020,6 +1021,7 @@ mod tests {
                 is_italic: false,
                 is_underline: false,
                 is_strikeout: false,
+                from_font_without_tounicode: false,
                 item_type: ItemType::Text,
                 mcid: None,
             });
@@ -1098,6 +1100,7 @@ mod tests {
             is_italic: false,
             is_underline: false,
             is_strikeout: false,
+            from_font_without_tounicode: false,
             item_type: ItemType::Text,
             mcid: None,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,6 +124,12 @@ pub struct TextItem {
     /// glyphs at mid x-height). Same geometric detection as underline,
     /// different vertical window; see `extractor::underline`.
     pub is_strikeout: bool,
+    /// True when this run was drawn with a Type0 Identity-H/V or Type3 font
+    /// that has no `/ToUnicode` entry. Standard Type1/TrueType encodings are
+    /// not flagged. Presence of ToUnicode does not guarantee a *valid* map
+    /// (shifted/broken CMaps still need `has_encoding_issues`); this flag is
+    /// the deterministic "map missing" signal for OCR routing.
+    pub from_font_without_tounicode: bool,
     /// Type of item (text, image, link)
     pub item_type: ItemType,
     /// Marked Content ID from the content stream's BDC/BMC operator.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,8 +8,8 @@ use pdf_inspector::{
     detect_pdf_type, detect_vector_grid_in_region_mem, extract_pages_markdown,
     extract_pages_markdown_mem, extract_tables_in_regions_mem, extract_text,
     extract_text_in_regions_mem, extract_text_with_positions, extract_text_with_positions_mem,
-    process_pdf_mem, process_pdf_with_options, to_markdown, MarkdownOptions, PdfError, PdfOptions,
-    PdfType, TextItem,
+    process_pdf_mem, process_pdf_with_options, to_markdown, tounicode_missing_width_fraction,
+    MarkdownOptions, PdfError, PdfOptions, PdfType, TextItem,
 };
 use std::collections::HashSet;
 
@@ -106,6 +106,7 @@ fn make_text_item(text: &str, x: f32, y: f32, font_size: f32, page: u32) -> Text
         is_italic: false,
         is_underline: false,
         is_strikeout: false,
+        from_font_without_tounicode: false,
         item_type: ItemType::Text,
         mcid: None,
     }
@@ -133,6 +134,7 @@ fn make_text_item_with_font(
         is_italic: is_italic_font(font),
         is_underline: false,
         is_strikeout: false,
+        from_font_without_tounicode: false,
         item_type: ItemType::Text,
         mcid: None,
     }
@@ -3651,4 +3653,87 @@ fn pdf_options_debug_redacts_password() {
         "password leaked in Debug: {dbg}"
     );
     assert!(dbg.contains("REDACTED"), "expected redaction marker: {dbg}");
+}
+
+// ============================================================================
+// Per-TextItem ToUnicode presence (#122)
+// ============================================================================
+
+#[test]
+fn test_shinagawa_identity_h_marks_from_font_without_tounicode() {
+    // Fixture: YuGothic Identity-H with no ToUnicode — deterministic OCR signal.
+    let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
+    let items = extract_text_with_positions_mem(&buf).expect("extract");
+    let text_items: Vec<_> = items
+        .iter()
+        .filter(|i| matches!(i.item_type, ItemType::Text) && !i.text.trim().is_empty())
+        .collect();
+    assert!(
+        !text_items.is_empty(),
+        "expected text items from shinagawa fixture"
+    );
+    assert!(
+        text_items.iter().any(|i| i.from_font_without_tounicode),
+        "Identity-H font without ToUnicode should set from_font_without_tounicode; sample={:?}",
+        text_items
+            .iter()
+            .take(3)
+            .map(|i| (&i.text, i.from_font_without_tounicode, &i.font))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_broken_tounicode_present_does_not_set_missing_flag() {
+    // Font has a /ToUnicode entry (malformed) — missing-map flag stays false;
+    // garbled decode is still caught by encoding-issue heuristics.
+    let buf = synthetic_type0_broken_tounicode_pdf();
+    let items = extract_text_with_positions_mem(&buf).expect("extract");
+    let text_items: Vec<_> = items
+        .iter()
+        .filter(|i| matches!(i.item_type, ItemType::Text))
+        .collect();
+    assert!(
+        !text_items.is_empty(),
+        "expected text items from synthetic Type0 PDF"
+    );
+    assert!(
+        text_items.iter().all(|i| !i.from_font_without_tounicode),
+        "broken-but-present ToUnicode must not set from_font_without_tounicode; items={:?}",
+        text_items
+            .iter()
+            .map(|i| (&i.text, i.from_font_without_tounicode))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_standard_type1_helvetica_not_flagged_without_tounicode() {
+    // Helvetica Type1 typically has no ToUnicode and does not need one.
+    let buf = make_minimal_text_pdf();
+    let items = extract_text_with_positions_mem(&buf).expect("extract");
+    let text_items: Vec<_> = items
+        .iter()
+        .filter(|i| matches!(i.item_type, ItemType::Text) && !i.text.trim().is_empty())
+        .collect();
+    assert!(!text_items.is_empty(), "expected text from minimal PDF");
+    assert!(
+        text_items.iter().all(|i| !i.from_font_without_tounicode),
+        "standard Type1 must not be flagged; items={:?}",
+        text_items
+            .iter()
+            .map(|i| (&i.text, i.from_font_without_tounicode, &i.font))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_tounicode_missing_width_fraction_shinagawa() {
+    let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
+    let items = extract_text_with_positions_mem(&buf).expect("extract");
+    let frac = tounicode_missing_width_fraction(&items);
+    assert!(
+        frac > 0.5,
+        "most shinagawa text width should lack required ToUnicode, got {frac}"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #122.

`classifyPdf` / encoding heuristics can already hint at garbled text, but consumers of `extractTextWithPositions` had no **deterministic per-run** signal that a glyph stream came from a font lacking `/ToUnicode`. Identity-H / Type3 pages without a map still report as text-based with high confidence while decoding garbage.

## Changes

- Add `TextItem.from_font_without_tounicode`
  - Set for **Type0 Identity-H/V** and **Type3** fonts with no `/ToUnicode` entry
  - **Not** set for standard Type1/TrueType (Helvetica etc. are fine without ToUnicode)
  - Broken-but-present ToUnicode stays `false` (use existing encoding-issue heuristics for validity)
- Propagate through merge / subscript merge (OR across merged runs)
- Add `tounicode_missing_width_fraction(items)` for page-level coverage (issue option 3)
- Wire napi + Python (`pdf_inspector.pyi`)

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo test --lib` → 716 passed
- [x] `cargo test --test integration_tests` → 145 passed
- [x] `shinagawa_identity_h.pdf` → flag true + width fraction > 0.5
- [x] Synthetic Type0 with broken ToUnicode present → flag false
- [x] Minimal Helvetica Type1 → flag false

## Notes

Does not compete with #193 (Form underline), #184 (wasm strategy), or #182 (bindings refactor). Field addition is additive for napi/Python.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788204000&installation_model_id=11126&pr_number=195&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F195&signature=aff95883d7a99f4a8c3af4c800f0dc11f43c66c8905a9d76354bb92be5ae7997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a deterministic flag on each text run to indicate when it was rendered with a font that lacks a required `/ToUnicode` map (Type0 Identity-H/V or Type3), plus a helper to summarize page-level coverage. This enables reliable OCR routing and avoids guessing from garbled text.

- **New Features**
  - Added TextItem.from_font_without_tounicode; set for Type0 Identity-H/V and Type3 fonts missing `/ToUnicode`, not set for standard Type1/TrueType; remains false if a (broken) map exists.
  - Preserved across run merges and sub/superscript merges (OR across merged runs).
  - Added tounicode_missing_width_fraction(items) to measure width affected on a page.
  - Exposed in `napi` and Python (`pdf_inspector.pyi`) bindings; tests added for Identity-H, broken-map, and Type1 cases.

<sup>Written for commit ed99f5f010346403cdc1ca54b2849d3a121e7c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

