### PR TITLE
fix(deps): bump lopdf to 0.42.0 for nesting-depth DoS (RUSTSEC-2026-0187)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,14 +46,14 @@ ttf-parser = "0.25"
 # Native builds keep lopdf's parallel parser and CLI logging. Browser WASM is
 # deliberately single-threaded so it works without cross-origin isolation.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-lopdf = { version = "0.41.0", features = ["rayon"] }
+lopdf = { version = "0.42.0", features = ["rayon"] }
 rayon = "1.10"
 env_logger = "0.11"
 
 # Browser builds use JavaScript randomness for encrypted PDFs and embed the
 # bundled CMaps because there is no filesystem at runtime.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-lopdf = { version = "0.41.0", default-features = false, features = ["wasm_js"] }
+lopdf = { version = "0.42.0", default-features = false, features = ["wasm_js"] }
 include_dir = "0.7"
 
 [dev-dependencies]

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -672,9 +672,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lopdf"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -605,9 +605,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags 2.13.1",


### PR DESCRIPTION
## Summary

Bumps `lopdf` from 0.41.0 to 0.42.0 to pick up the fix for **[RUSTSEC-2026-0187](https://rustsec.org/advisories/RUSTSEC-2026-0187.html)** — an unbounded-recursion stack overflow reachable from any untrusted PDF.

`lopdf <= 0.41.0` parses nested PDF arrays and dictionaries with unbounded recursion. A ~21 KB PDF whose Catalog holds a ~10,000-deep nested array exhausts the call stack and **aborts the process**. `lopdf` 0.42.0 caps nesting via `MAX_NESTING_DEPTH` and returns an `Err` instead.

> Filing this publicly rather than via SECURITY.md because the advisory, the [upstream issue](https://github.com/J-F-Liu/lopdf/issues/502), and the fix have all been public since June 2026 — and `SECURITY.md` lists upstream-dependency bugs as out of scope for private reporting. Happy to move it if you'd prefer.

## Why this one matters more than a typical dep bump

It is a **stack-overflow abort, not a `panic!`**, so it is not recoverable by any of the existing guards:

- the `catch_panic` / `catch_unwind` wrapper in `napi/src/lib.rs` cannot intercept it
- a JavaScript `try`/`catch` around `processPdf()` does not either

I confirmed this against the published npm package (`@firecrawl/pdf-inspector@1.11.2`) before patching — the Node process dies with `SIGILL`, `try`/`catch` never fires, and execution never reaches the line after the call. For anyone running pdf-inspector server-side on user-uploaded PDFs, one upload takes down the whole process and every in-flight request with it.

All entry points share the affected `Document::load_mem` path, so the cheap routing calls (`classifyPdf` / `detectPdf`) are just as exposed as `processPdf`.

## Why the bump is safe

Despite being a semver-breaking `0.x` bump, it is source-compatible with this crate:

| Check | Result |
|---|---|
| `lopdf` public API delta 0.41.0 → 0.42.0 | **purely additive** — `MAX_NESTING_DEPTH`, `Content::decode_strict`, `content_strict`; 0 removals, 0 signature changes |
| `src/error.rs` | **byte-identical** (this crate matches on many `Error` variants) |
| `lopdf` own dependency requirements | unchanged |
| Features used (`rayon`, `wasm_js`) | both still present |
| Fix surface | private parser fns only (`array`, `_dictionary`, `inner_dictionary`) |

I deliberately went to 0.42.0 rather than 0.44.0 to keep this a minimal, reviewable security fix. 0.44.0 also looks worthwhile later — it adds a decompression-bomb size limit and makes `ttf-parser` optional (relevant to [RUSTSEC-2026-0192](https://rustsec.org/advisories/RUSTSEC-2026-0192.html), `ttf-parser` unmaintained) — but it changes `Document::get_page_content`'s return type and touches 55 files, so it deserves its own PR with benchmark re-validation.

## Verification

Ran the full `AGENTS.md` gate locally on `aarch64-apple-darwin`:

```
cargo fmt --all -- --check                                                    pass
cargo clippy -- -D warnings                                                   pass
cargo test                                                                    860 passed, 0 failed
cargo check --target wasm32-unknown-unknown                                   pass
cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown   pass
```

Before/after with the same `pdf2md` release binary, only the `lopdf` version differing:

```
# lopdf 0.41.0 (current main)
$ ./target/release/pdf2md poc.pdf
thread '<unknown>' has overflowed its stack
fatal runtime error: stack overflow, aborting
>>> exit 134 (SIGABRT)

# lopdf 0.42.0 (this PR)
$ ./target/release/pdf2md poc.pdf
[ERROR lopdf::reader] Object load error at offset 9: IndirectObject { offset: 9 }
Type: SCANNED (OCR required)
>>> exits normally
```

A normal text PDF still extracts identically after the bump, and the 860-test suite is green, so there is no extraction-quality regression.

## Note for maintainers (not addressed here)

`napi/Cargo.lock` is already stale on `main` independent of this change — `cargo check --manifest-path napi/Cargo.toml` wants to add `include_dir` / `include_dir_macros` and `js-sys` + `wasm-bindgen` under `getrandom`, presumably left over from #180. I kept it out of this diff to keep the security fix single-purpose, but it's probably worth a follow-up regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788214689&installation_model_id=11126&pr_number=198&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F198&signature=755411dae652aba38ff8979192fbc1910b45c5934c5a57d9bcbc9b6cf1cd64b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `lopdf` to 0.42.0 to fix RUSTSEC-2026-0187 (nesting-depth DoS). This prevents stack-overflow aborts on deeply nested PDFs by capping array/dictionary depth and returning a clean error.

- **Dependencies**
  - Bump `lopdf` 0.41.0 → 0.42.0 (`rayon` and `wasm_js` features unchanged).
  - Source-compatible for this crate; only additive API changes.
  - Verified: builds and tests pass; PoC now errors cleanly instead of crashing.

<sup>Written for commit f86decf82d72e4bc318aaf54c04f854763cbed1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

