### PR TITLE
feat(napi): accept an optional password on classifyPdf/detectPdf/processPdf

### DIFF
--- a/napi/README.md
+++ b/napi/README.md
@@ -38,7 +38,7 @@ Prebuilt binaries for **Linux x64**, **macOS ARM64**, and **Windows x64** — np
 
 ## API
 
-### `classifyPdf(buffer: Buffer): PdfClassification`
+### `classifyPdf(buffer: Buffer, password?: string): PdfClassification`
 
 Classify a PDF as TextBased, Scanned, Mixed, or ImageBased (~10-50ms). Returns which pages need OCR.
 
@@ -53,6 +53,19 @@ console.log(result.pdfType)        // "TextBased" | "Scanned" | "Mixed" | "Image
 console.log(result.pageCount)      // 42
 console.log(result.pagesNeedingOcr) // [5, 12, 15] (0-indexed)
 console.log(result.confidence)     // 0.875
+```
+
+### Encrypted PDFs
+
+`classifyPdf`, `detectPdf`, and `processPdf` take an optional `password` for
+encrypted files. Without it — or with the wrong one — they throw
+`PDF is encrypted`.
+
+```typescript
+import { classifyPdf, processPdf } from '@firecrawl/pdf-inspector'
+
+const result = classifyPdf(encryptedPdf, 'secret123')
+const full = processPdf(encryptedPdf, undefined, 'secret123')
 ```
 
 ### `extractTextInRegions(buffer: Buffer, pageRegions: PageRegions[]): PageRegionTexts[]`

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -207,13 +207,22 @@ where
 // ---------------------------------------------------------------------------
 
 /// Process a PDF from a Buffer: detect type, extract text, and convert to Markdown.
+///
+/// `password` decrypts an encrypted PDF; omit it for unencrypted files.
 #[napi]
-pub fn process_pdf(buffer: Buffer, pages: Option<Vec<u32>>) -> Result<PdfResult> {
+pub fn process_pdf(
+    buffer: Buffer,
+    pages: Option<Vec<u32>>,
+    password: Option<String>,
+) -> Result<PdfResult> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("process_pdf", move || {
         let mut opts = pdf_inspector::PdfOptions::new();
         if let Some(p) = pages {
             opts = opts.pages(p);
+        }
+        if let Some(pw) = password {
+            opts = opts.password(pw);
         }
         let result = pdf_inspector::process_pdf_mem_with_options(&bytes, opts)
             .map_err(|e| to_napi_err(e, "process_pdf"))?;
@@ -222,12 +231,18 @@ pub fn process_pdf(buffer: Buffer, pages: Option<Vec<u32>>) -> Result<PdfResult>
 }
 
 /// Fast detection only — no text extraction or markdown.
+///
+/// `password` decrypts an encrypted PDF; omit it for unencrypted files.
 #[napi]
-pub fn detect_pdf(buffer: Buffer) -> Result<PdfResult> {
+pub fn detect_pdf(buffer: Buffer, password: Option<String>) -> Result<PdfResult> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("detect_pdf", move || {
-        let result =
-            pdf_inspector::detect_pdf_mem(&bytes).map_err(|e| to_napi_err(e, "detect_pdf"))?;
+        let mut opts = pdf_inspector::PdfOptions::detect_only();
+        if let Some(pw) = password {
+            opts = opts.password(pw);
+        }
+        let result = pdf_inspector::process_pdf_mem_with_options(&bytes, opts)
+            .map_err(|e| to_napi_err(e, "detect_pdf"))?;
         Ok(to_napi_result(result))
     })
 }
@@ -235,12 +250,15 @@ pub fn detect_pdf(buffer: Buffer) -> Result<PdfResult> {
 /// Lightweight PDF classification — returns type, page count, and OCR pages.
 /// Faster than detectPdf as it skips building the full PdfResult.
 /// Pages in pagesNeedingOcr are 0-indexed.
+///
+/// `password` decrypts an encrypted PDF; omit it for unencrypted files.
 #[napi]
-pub fn classify_pdf(buffer: Buffer) -> Result<PdfClassification> {
+pub fn classify_pdf(buffer: Buffer, password: Option<String>) -> Result<PdfClassification> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("classify_pdf", move || {
         let result =
-            pdf_inspector::classify_pdf_mem(&bytes).map_err(|e| to_napi_err(e, "classify_pdf"))?;
+            pdf_inspector::classify_pdf_mem_with_password(&bytes, password.as_deref())
+                .map_err(|e| to_napi_err(e, "classify_pdf"))?;
         Ok(PdfClassification {
             pdf_type: convert_pdf_type(result.pdf_type),
             page_count: result.page_count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,9 +388,25 @@ pub struct PdfClassification {
 
 /// Classify a PDF from a memory buffer without extracting text.
 /// Returns the PDF type and which pages need OCR (~10-50ms).
+///
+/// Equivalent to `classify_pdf_mem_with_password(buffer, None)`.
 pub fn classify_pdf_mem(buffer: &[u8]) -> Result<PdfClassification, PdfError> {
+    classify_pdf_mem_with_password(buffer, None)
+}
+
+/// Classify a PDF from a memory buffer, decrypting with `password` if the
+/// file is encrypted.
+///
+/// `process_pdf_mem_with_options` already accepts a password via
+/// [`PdfOptions::password`]; this is the equivalent for the lightweight
+/// classification path, so a caller routing encrypted PDFs through OCR
+/// doesn't have to pay for a full parse just to reach the password.
+pub fn classify_pdf_mem_with_password(
+    buffer: &[u8],
+    password: Option<&str>,
+) -> Result<PdfClassification, PdfError> {
     validate_pdf_bytes(buffer)?;
-    let (doc, page_count) = load_document_from_mem(buffer)?;
+    let (doc, page_count) = load_document_from_mem_with_password(buffer, password)?;
     let detection = detector::detect_from_document(&doc, page_count, &DetectionConfig::default())?;
     Ok(PdfClassification {
         pdf_type: detection.pdf_type,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3643,6 +3643,39 @@ fn encrypted_pdf_decrypts_with_correct_password() {
 }
 
 #[test]
+fn classify_pdf_mem_decrypts_with_correct_password() {
+    let bytes = std::fs::read("tests/fixtures/encrypted-secret123.pdf")
+        .expect("encrypted fixture should be readable");
+
+    // No password: classification can't get past the encryption.
+    let no_pw = pdf_inspector::classify_pdf_mem(&bytes);
+    assert!(
+        matches!(no_pw, Err(PdfError::Encrypted)),
+        "expected Encrypted without a password, got {no_pw:?}"
+    );
+
+    // Wrong password: still rejected.
+    let wrong = pdf_inspector::classify_pdf_mem_with_password(&bytes, Some("wrong"));
+    assert!(
+        matches!(wrong, Err(PdfError::Encrypted)),
+        "expected Encrypted with a wrong password, got {wrong:?}"
+    );
+
+    // Correct password: classifies the decrypted document.
+    let ok = pdf_inspector::classify_pdf_mem_with_password(&bytes, Some("secret123"))
+        .expect("correct password should decrypt");
+    assert!(
+        ok.page_count > 0,
+        "decrypted classification should see pages"
+    );
+    assert_eq!(
+        ok.pdf_type,
+        PdfType::TextBased,
+        "the fixture has a real text layer once decrypted"
+    );
+}
+
+#[test]
 fn pdf_options_debug_redacts_password() {
     let opts = PdfOptions::new().password("secret123");
     let dbg = format!("{opts:?}");


### PR DESCRIPTION
## Problem

The Rust core already decrypts encrypted PDFs via `PdfOptions::password` (`src/lib.rs`, `load_document_from_mem_with_password`), but the Node binding exposes no way to supply one. From JavaScript an encrypted PDF is simply unreadable, even when the caller has the password.

This bites hardest in the smart-routing use case the README describes. In our pipeline the documents with the richest table structure — bank statements — are also the ones most likely to arrive password-protected, so they were exactly the files that couldn't reach the parser at all.

## Change

- **Core:** adds `classify_pdf_mem_with_password`, mirroring what `process_pdf_mem_with_options` already does, so the lightweight classification path can reach a password without paying for a full parse. `classify_pdf_mem` delegates to it with `None`.
- **napi:** threads an optional trailing `password` through `classifyPdf`, `detectPdf`, and `processPdf`.
  `detect_pdf` now calls `process_pdf_mem_with_options` with `PdfOptions::detect_only()` instead of `detect_pdf_mem` — the same call `detect_pdf_mem` makes internally, just with the password attached.
- **README:** documents the parameter with an "Encrypted PDFs" section.

## Backwards compatibility

The parameter is optional and trailing, so existing call shapes are untouched. The generated types:

```typescript
export declare function classifyPdf(buffer: Buffer, password?: string | undefined | null): PdfClassification
export declare function detectPdf(buffer: Buffer, password?: string | undefined | null): PdfResult
export declare function processPdf(buffer: Buffer, pages?: Array<number> | undefined | null, password?: string | undefined | null): PdfResult
```

## Verification

Against a `napi build --release` build, using the existing `tests/fixtures/encrypted-secret123.pdf`:

```
classifyPdf (no password)    -> throws "PDF is encrypted"
classifyPdf (wrong password) -> throws "PDF is encrypted"
classifyPdf (right password) -> { pdfType: "TextBased", pageCount: 8, pagesNeedingOcr: [], confidence: 1 }
detectPdf   (right password) -> { pdfType: "TextBased", pageCount: 8 }
processPdf  (right password) -> markdown contains "Procurement"   (the fixture's real text)

back-compat classifyPdf(buf) -> TextBased    (1-arg form, plain PDF)
back-compat processPdf(buf)  -> TextBased    (1-arg form, plain PDF)
```

New integration test `classify_pdf_mem_decrypts_with_correct_password` covers the core path, asserting the no-password and wrong-password cases still return `PdfError::Encrypted` — so this can't silently start accepting the empty password.

Per CLAUDE.md, all three gates pass:

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings` (lib) and `cargo clippy --manifest-path napi/Cargo.toml -- -D warnings`
- `cargo test` — 716 unit, 142 integration, 2 doc

I left `napi/package.json` version alone so you control the release, and reverted the incidental `napi/Cargo.lock` churn my local build produced.

## Notes

Happy to extend the same parameter to the region/table extraction functions (`extractTextInRegions`, `extractTablesInRegions`, …) if you'd like it applied consistently — I kept this PR to the three main entry points to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788236404&installation_model_id=11126&pr_number=199&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F199&signature=9291dbb61c1ac0152a5fab5bab0a794e3a777d030d97c2a830cf11698882606a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional password support to `classifyPdf`, `detectPdf`, and `processPdf` so encrypted PDFs can be processed from Node. Backward compatible and improves smart routing for password-protected documents.

- **New Features**
  - Optional trailing `password` parameter for `classifyPdf`, `detectPdf`, and `processPdf`.
  - Added `classify_pdf_mem_with_password` in the Rust core; `detectPdf` now uses `process_pdf_mem_with_options(PdfOptions::detect_only())` to honor passwords.
  - Updated README with an "Encrypted PDFs" section and added an integration test covering no/wrong/correct password cases.

<sup>Written for commit 737f97d2c8859a283a252da23fc45150f3224acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

