### PR TITLE
feat(python): accept a DetectionConfig in detection and classification functions

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -65,6 +65,10 @@ if result.pdf_type == "text_based":
 else:
     print(f"Pages needing OCR: {result.pages_needing_ocr}")
 
+# Scan every page instead of sampling 8 (most accurate for mixed/scanned)
+config = pdf_inspector.DetectionConfig(strategy="full")
+result = pdf_inspector.detect_pdf("document.pdf", detection=config)
+
 # Plain text extraction
 text = pdf_inspector.extract_text("document.pdf")
 
@@ -86,12 +90,12 @@ result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 
 | Function | Description |
 |---|---|
-| `process_pdf(path, pages=None)` | Full processing (detect + extract + markdown) |
-| `process_pdf_bytes(data, pages=None)` | Full processing from bytes |
-| `detect_pdf(path)` | Fast detection only (returns PdfResult) |
-| `detect_pdf_bytes(data)` | Fast detection from bytes |
-| `classify_pdf(path)` | Lightweight classification (returns PdfClassification) |
-| `classify_pdf_bytes(data)` | Lightweight classification from bytes |
+| `process_pdf(path, pages=None, detection=None)` | Full processing (detect + extract + markdown) |
+| `process_pdf_bytes(data, pages=None, detection=None)` | Full processing from bytes |
+| `detect_pdf(path, detection=None)` | Fast detection only (returns PdfResult) |
+| `detect_pdf_bytes(data, detection=None)` | Fast detection from bytes |
+| `classify_pdf(path, detection=None)` | Lightweight classification (returns PdfClassification) |
+| `classify_pdf_bytes(data, detection=None)` | Lightweight classification from bytes |
 | `extract_text(path)` | Plain text extraction |
 | `extract_text_bytes(data)` | Plain text extraction from bytes |
 | `extract_text_with_positions(path, pages=None)` | Text with X/Y coords and font info |
@@ -124,6 +128,16 @@ class PdfClassification:             # classify_pdf
     page_count: int
     pages_needing_ocr: list[int]     # 0-indexed
     confidence: float
+
+class DetectionConfig:               # optional `detection=` argument
+    def __init__(
+        self,
+        strategy: str = "sample",            # "sample" | "full" | "early_exit" | "pages"
+        sample_pages: int = 8,               # page budget for "sample"
+        pages: list[int] | None = None,      # 1-indexed pages, only for "pages"
+        min_text_ops_per_page: int = 3,
+        text_page_ratio_threshold: float = 0.6,
+    ) -> None: ...
 
 class TextItem:                      # extract_text_with_positions
     text: str

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -2,6 +2,22 @@
 
 from typing import Optional
 
+class DetectionConfig:
+    """Configuration for PDF type detection.
+
+    strategy is 'sample' (up to sample_pages evenly distributed pages),
+    'full' (every page), 'early_exit' (stop at the first non-text page),
+    or 'pages' (only the given 1-indexed pages).
+    """
+    def __init__(
+        self,
+        strategy: str = "sample",
+        sample_pages: int = 8,
+        pages: Optional[list[int]] = None,
+        min_text_ops_per_page: int = 3,
+        text_page_ratio_threshold: float = 0.6,
+    ) -> None: ...
+
 class PdfResult:
     """Result of processing a PDF file."""
     pdf_type: str
@@ -76,27 +92,38 @@ class PagesExtractionResult:
     is_complex: bool
     """True if any page has tables or multi-column layout."""
 
-def process_pdf(path: str, pages: Optional[list[int]] = None) -> PdfResult:
+def process_pdf(
+    path: str,
+    pages: Optional[list[int]] = None,
+    detection: Optional[DetectionConfig] = None,
+) -> PdfResult:
     """Process a PDF: detect type, extract text, convert to Markdown."""
     ...
 
-def process_pdf_bytes(data: bytes, pages: Optional[list[int]] = None) -> PdfResult:
+def process_pdf_bytes(
+    data: bytes,
+    pages: Optional[list[int]] = None,
+    detection: Optional[DetectionConfig] = None,
+) -> PdfResult:
     """Process a PDF from bytes in memory."""
     ...
 
-def detect_pdf(path: str) -> PdfResult:
+def detect_pdf(path: str, detection: Optional[DetectionConfig] = None) -> PdfResult:
     """Fast detection only — no text extraction."""
     ...
 
-def detect_pdf_bytes(data: bytes) -> PdfResult:
+def detect_pdf_bytes(data: bytes, detection: Optional[DetectionConfig] = None) -> PdfResult:
     """Fast detection from bytes."""
     ...
 
-def classify_pdf(path: str) -> PdfClassification:
+def classify_pdf(path: str, detection: Optional[DetectionConfig] = None) -> PdfClassification:
     """Lightweight classification — type, page count, and OCR pages (0-indexed)."""
     ...
 
-def classify_pdf_bytes(data: bytes) -> PdfClassification:
+def classify_pdf_bytes(
+    data: bytes,
+    detection: Optional[DetectionConfig] = None,
+) -> PdfClassification:
     """Lightweight classification from bytes."""
     ...
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,9 +389,17 @@ pub struct PdfClassification {
 /// Classify a PDF from a memory buffer without extracting text.
 /// Returns the PDF type and which pages need OCR (~10-50ms).
 pub fn classify_pdf_mem(buffer: &[u8]) -> Result<PdfClassification, PdfError> {
+    classify_pdf_mem_with_config(buffer, DetectionConfig::default())
+}
+
+/// Classify a PDF from a memory buffer with a custom detection configuration.
+pub fn classify_pdf_mem_with_config(
+    buffer: &[u8],
+    config: DetectionConfig,
+) -> Result<PdfClassification, PdfError> {
     validate_pdf_bytes(buffer)?;
     let (doc, page_count) = load_document_from_mem(buffer)?;
-    let detection = detector::detect_from_document(&doc, page_count, &DetectionConfig::default())?;
+    let detection = detector::detect_from_document(&doc, page_count, &config)?;
     Ok(PdfClassification {
         pdf_type: detection.pdf_type,
         page_count,

--- a/src/python.rs
+++ b/src/python.rs
@@ -40,13 +40,34 @@ impl PyDetectionConfig {
                 "the pages argument is only valid with strategy 'pages'",
             ));
         }
+        if !(0.0..=1.0).contains(&text_page_ratio_threshold) {
+            return Err(PyValueError::new_err(
+                "text_page_ratio_threshold must be between 0.0 and 1.0",
+            ));
+        }
         let strategy = match strategy {
-            "sample" => ScanStrategy::Sample(sample_pages),
+            "sample" => {
+                if sample_pages == 0 {
+                    return Err(PyValueError::new_err("sample_pages must be at least 1"));
+                }
+                ScanStrategy::Sample(sample_pages)
+            }
             "full" => ScanStrategy::Full,
             "early_exit" => ScanStrategy::EarlyExit,
-            "pages" => ScanStrategy::Pages(pages.ok_or_else(|| {
-                PyValueError::new_err("strategy 'pages' requires the pages argument")
-            })?),
+            "pages" => {
+                let pages = pages.ok_or_else(|| {
+                    PyValueError::new_err("strategy 'pages' requires the pages argument")
+                })?;
+                if pages.is_empty() {
+                    return Err(PyValueError::new_err("pages must not be empty"));
+                }
+                if pages.contains(&0) {
+                    return Err(PyValueError::new_err(
+                        "pages are 1-indexed; page 0 is invalid",
+                    ));
+                }
+                ScanStrategy::Pages(pages)
+            }
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "unknown strategy '{strategy}'; expected 'sample', 'full', 'early_exit', or 'pages'"

--- a/src/python.rs
+++ b/src/python.rs
@@ -4,8 +4,77 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::HashSet;
 
-use crate::detector::PdfType;
+use crate::detector::{DetectionConfig, PdfType, ScanStrategy};
 use crate::types::ItemType;
+
+// ---------------------------------------------------------------------------
+// Detection config wrapper
+// ---------------------------------------------------------------------------
+
+/// Configuration for PDF type detection.
+#[pyclass(name = "DetectionConfig")]
+#[derive(Clone)]
+pub struct PyDetectionConfig {
+    inner: DetectionConfig,
+}
+
+#[pymethods]
+impl PyDetectionConfig {
+    #[new]
+    #[pyo3(signature = (
+        strategy="sample",
+        sample_pages=8,
+        pages=None,
+        min_text_ops_per_page=3,
+        text_page_ratio_threshold=0.6,
+    ))]
+    fn new(
+        strategy: &str,
+        sample_pages: u32,
+        pages: Option<Vec<u32>>,
+        min_text_ops_per_page: u32,
+        text_page_ratio_threshold: f32,
+    ) -> PyResult<Self> {
+        if strategy != "pages" && pages.is_some() {
+            return Err(PyValueError::new_err(
+                "the pages argument is only valid with strategy 'pages'",
+            ));
+        }
+        let strategy = match strategy {
+            "sample" => ScanStrategy::Sample(sample_pages),
+            "full" => ScanStrategy::Full,
+            "early_exit" => ScanStrategy::EarlyExit,
+            "pages" => ScanStrategy::Pages(pages.ok_or_else(|| {
+                PyValueError::new_err("strategy 'pages' requires the pages argument")
+            })?),
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown strategy '{strategy}'; expected 'sample', 'full', 'early_exit', or 'pages'"
+                )))
+            }
+        };
+        Ok(Self {
+            inner: DetectionConfig {
+                strategy,
+                min_text_ops_per_page,
+                text_page_ratio_threshold,
+            },
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        let strategy = match &self.inner.strategy {
+            ScanStrategy::EarlyExit => "early_exit".to_string(),
+            ScanStrategy::Full => "full".to_string(),
+            ScanStrategy::Sample(n) => format!("sample({n})"),
+            ScanStrategy::Pages(pages) => format!("pages({pages:?})"),
+        };
+        format!(
+            "DetectionConfig(strategy={strategy}, min_text_ops_per_page={}, text_page_ratio_threshold={})",
+            self.inner.min_text_ops_per_page, self.inner.text_page_ratio_threshold
+        )
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Result wrapper
@@ -434,41 +503,62 @@ fn convert_region_results(results: Vec<crate::PageRegionResult>) -> Vec<PyPageRe
 // Public Python API
 // ---------------------------------------------------------------------------
 
-/// Process a PDF file: detect type, extract text, and convert to Markdown.
-#[pyfunction]
-#[pyo3(signature = (path, pages=None))]
-fn process_pdf(path: &str, pages: Option<Vec<u32>>) -> PyResult<PyPdfResult> {
-    let mut opts = crate::PdfOptions::new();
+fn build_options(
+    pages: Option<Vec<u32>>,
+    detection: Option<PyDetectionConfig>,
+    base: crate::PdfOptions,
+) -> crate::PdfOptions {
+    let mut opts = base;
     if let Some(p) = pages {
         opts = opts.pages(p);
     }
+    if let Some(d) = detection {
+        opts = opts.detection(d.inner);
+    }
+    opts
+}
+
+/// Process a PDF file: detect type, extract text, and convert to Markdown.
+#[pyfunction]
+#[pyo3(signature = (path, pages=None, detection=None))]
+fn process_pdf(
+    path: &str,
+    pages: Option<Vec<u32>>,
+    detection: Option<PyDetectionConfig>,
+) -> PyResult<PyPdfResult> {
+    let opts = build_options(pages, detection, crate::PdfOptions::new());
     let result = crate::process_pdf_with_options(path, opts).map_err(to_py_err)?;
     Ok(to_py_result(result))
 }
 
 /// Process a PDF from bytes in memory.
 #[pyfunction]
-#[pyo3(signature = (data, pages=None))]
-fn process_pdf_bytes(data: &[u8], pages: Option<Vec<u32>>) -> PyResult<PyPdfResult> {
-    let mut opts = crate::PdfOptions::new();
-    if let Some(p) = pages {
-        opts = opts.pages(p);
-    }
+#[pyo3(signature = (data, pages=None, detection=None))]
+fn process_pdf_bytes(
+    data: &[u8],
+    pages: Option<Vec<u32>>,
+    detection: Option<PyDetectionConfig>,
+) -> PyResult<PyPdfResult> {
+    let opts = build_options(pages, detection, crate::PdfOptions::new());
     let result = crate::process_pdf_mem_with_options(data, opts).map_err(to_py_err)?;
     Ok(to_py_result(result))
 }
 
 /// Fast detection only — no text extraction or markdown.
 #[pyfunction]
-fn detect_pdf(path: &str) -> PyResult<PyPdfResult> {
-    let result = crate::detect_pdf(path).map_err(to_py_err)?;
+#[pyo3(signature = (path, detection=None))]
+fn detect_pdf(path: &str, detection: Option<PyDetectionConfig>) -> PyResult<PyPdfResult> {
+    let opts = build_options(None, detection, crate::PdfOptions::detect_only());
+    let result = crate::process_pdf_with_options(path, opts).map_err(to_py_err)?;
     Ok(to_py_result(result))
 }
 
 /// Fast detection from bytes — no text extraction or markdown.
 #[pyfunction]
-fn detect_pdf_bytes(data: &[u8]) -> PyResult<PyPdfResult> {
-    let result = crate::detect_pdf_mem(data).map_err(to_py_err)?;
+#[pyo3(signature = (data, detection=None))]
+fn detect_pdf_bytes(data: &[u8], detection: Option<PyDetectionConfig>) -> PyResult<PyPdfResult> {
+    let opts = build_options(None, detection, crate::PdfOptions::detect_only());
+    let result = crate::process_pdf_mem_with_options(data, opts).map_err(to_py_err)?;
     Ok(to_py_result(result))
 }
 
@@ -476,16 +566,22 @@ fn detect_pdf_bytes(data: &[u8]) -> PyResult<PyPdfResult> {
 /// Faster than detect_pdf as it skips building the full PdfProcessResult.
 /// Pages in pages_needing_ocr are 0-indexed.
 #[pyfunction]
-fn classify_pdf(path: &str) -> PyResult<PyPdfClassification> {
+#[pyo3(signature = (path, detection=None))]
+fn classify_pdf(path: &str, detection: Option<PyDetectionConfig>) -> PyResult<PyPdfClassification> {
     let data = std::fs::read(path).map_err(|e| PyValueError::new_err(e.to_string()))?;
-    classify_pdf_bytes(&data)
+    classify_pdf_bytes(&data, detection)
 }
 
 /// Lightweight PDF classification from bytes.
 /// Pages in pages_needing_ocr are 0-indexed.
 #[pyfunction]
-fn classify_pdf_bytes(data: &[u8]) -> PyResult<PyPdfClassification> {
-    let result = crate::classify_pdf_mem(data).map_err(to_py_err)?;
+#[pyo3(signature = (data, detection=None))]
+fn classify_pdf_bytes(
+    data: &[u8],
+    detection: Option<PyDetectionConfig>,
+) -> PyResult<PyPdfClassification> {
+    let config = detection.map(|d| d.inner).unwrap_or_default();
+    let result = crate::classify_pdf_mem_with_config(data, config).map_err(to_py_err)?;
     Ok(PyPdfClassification {
         pdf_type: pdf_type_str(result.pdf_type),
         page_count: result.page_count,
@@ -616,6 +712,7 @@ fn extract_pages_markdown_bytes(
 /// Python module definition.
 #[pymodule]
 fn pdf_inspector(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyDetectionConfig>()?;
     m.add_class::<PyPdfResult>()?;
     m.add_class::<PyPageOcrReasons>()?;
     m.add_class::<PyPdfClassification>()?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1161,6 +1161,20 @@ startxref
 }
 
 #[test]
+fn test_classify_pdf_mem_with_config_full_scan() {
+    let pdf = make_minimal_text_pdf();
+
+    let config = DetectionConfig {
+        strategy: ScanStrategy::Full,
+        ..DetectionConfig::default()
+    };
+    let result = pdf_inspector::classify_pdf_mem_with_config(&pdf, config).unwrap();
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert_eq!(result.page_count, 1);
+    assert!(result.pages_needing_ocr.is_empty());
+}
+
+#[test]
 fn test_firecrawl_tagged_pdf_struct_tree() {
     use lopdf::Document;
     use pdf_inspector::structure_tree::{StructRole, StructTree};


### PR DESCRIPTION
The Rust API accepts a `DetectionConfig` through `PdfOptions::detection()`, but the Python bindings never exposed it, so Python callers are pinned to the default `Sample(8)` strategy. On long documents that means classification is decided from 8 sampled pages and `pages_needing_ocr` can only ever contain pages that happened to be sampled — even though the library itself documents `ScanStrategy::Full` as "best when you need accurate Mixed vs Scanned classification".

Changes:

- New `DetectionConfig` pyclass with `strategy` (`"sample"`, `"full"`, `"early_exit"`, `"pages"`), `sample_pages`, `pages`, `min_text_ops_per_page`, and `text_page_ratio_threshold`. Invalid combinations raise `ValueError`.
- Optional `detection=` keyword on `process_pdf(_bytes)`, `detect_pdf(_bytes)`, and `classify_pdf(_bytes)`.
- `classify_pdf_mem_with_config()` in the core crate; `classify_pdf_mem()` now delegates to it. This mirrors the existing `detect_pdf_type_mem` / `detect_pdf_type_mem_with_config` pair.
- Type stubs and `docs/python.md` updated; integration test for the new core function.

Fully backward compatible: the new argument is optional and omitting it keeps today's behavior.

```python
config = pdf_inspector.DetectionConfig(strategy="full")
result = pdf_inspector.detect_pdf("document.pdf", detection=config)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788252101&installation_model_id=11126&pr_number=203&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F203&signature=303bd4ad9eb6aa98aaf842a566598a210929ca1939b9febb27d864a24bc9fee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose detection configuration to Python. Callers can choose the scan strategy for better accuracy on long PDFs, with defaults unchanged and validation to prevent invalid configs.

- **New Features**
  - Added `DetectionConfig` pyclass with fields: `strategy`, `sample_pages`, `pages` (1-indexed), `min_text_ops_per_page`, `text_page_ratio_threshold`; validates degenerate values (e.g., `sample_pages >= 1`, `pages` required/non-empty for `"pages"` with no `0`, threshold 0.0–1.0).
  - New optional `detection=` on `process_pdf(_bytes)`, `detect_pdf(_bytes)`, and `classify_pdf(_bytes)`.
  - Updated docs and `pdf_inspector.pyi`.

- **Refactors**
  - Added `classify_pdf_mem_with_config()` in core; `classify_pdf_mem()` now delegates.
  - Added an integration test for full-scan classification.

<sup>Written for commit e2b2d4f20c890afbf8a606e6576e1b388305d2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

