### PR TITLE
feat(detector): expose image and template-image page counters on classification results

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -122,6 +122,10 @@ class PdfResult:                     # process_pdf / detect_pdf
 class PdfClassification:             # classify_pdf
     pdf_type: str
     page_count: int
+    pages_sampled: int
+    pages_with_text: int
+    pages_with_images: int
+    pages_with_template_images: int  # sampled pages that look like a scan (full-page template image)
     pages_needing_ocr: list[int]     # 0-indexed
     confidence: float
 

--- a/napi/README.md
+++ b/napi/README.md
@@ -89,6 +89,10 @@ for (const region of result[0].regions) {
 interface PdfClassification {
   pdfType: string          // "TextBased" | "Scanned" | "Mixed" | "ImageBased"
   pageCount: number
+  pagesSampled: number      // pages sampled for detection
+  pagesWithText: number     // sampled pages with extractable text
+  pagesWithImages: number   // sampled pages containing images
+  pagesWithTemplateImages: number // sampled pages that look like a scan
   pagesNeedingOcr: number[] // 0-indexed page numbers
   confidence: number        // 0.0 - 1.0
 }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -62,6 +62,15 @@ pub struct PageOcrReasons {
 pub struct PdfClassification {
     pub pdf_type: PdfType,
     pub page_count: u32,
+    /// Number of pages sampled for detection.
+    pub pages_sampled: u32,
+    /// Number of sampled pages with extractable text.
+    pub pages_with_text: u32,
+    /// Number of sampled pages containing images.
+    pub pages_with_images: u32,
+    /// Number of sampled pages that look like a scan (single full-page
+    /// template image with little real text).
+    pub pages_with_template_images: u32,
     /// 0-indexed page numbers that need OCR.
     pub pages_needing_ocr: Vec<u32>,
     pub confidence: f64,
@@ -153,9 +162,7 @@ fn to_napi_result(r: pdf_inspector::PdfProcessResult) -> PdfResult {
     }
 }
 
-fn to_napi_page_ocr_reasons(
-    reasons: Vec<pdf_inspector::PageOcrReasons>,
-) -> Vec<PageOcrReasons> {
+fn to_napi_page_ocr_reasons(reasons: Vec<pdf_inspector::PageOcrReasons>) -> Vec<PageOcrReasons> {
     reasons
         .into_iter()
         .map(|reason| PageOcrReasons {
@@ -244,6 +251,10 @@ pub fn classify_pdf(buffer: Buffer) -> Result<PdfClassification> {
         Ok(PdfClassification {
             pdf_type: convert_pdf_type(result.pdf_type),
             page_count: result.page_count,
+            pages_sampled: result.pages_sampled,
+            pages_with_text: result.pages_with_text,
+            pages_with_images: result.pages_with_images,
+            pages_with_template_images: result.pages_with_template_images,
             pages_needing_ocr: result.pages_needing_ocr,
             confidence: result.confidence as f64,
         })

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -22,6 +22,15 @@ class PdfClassification:
     pdf_type: str
     """'text_based', 'scanned', 'image_based', or 'mixed'."""
     page_count: int
+    pages_sampled: int
+    """Number of pages sampled for detection."""
+    pages_with_text: int
+    """Number of sampled pages with extractable text."""
+    pages_with_images: int
+    """Number of sampled pages containing images."""
+    pages_with_template_images: int
+    """Number of sampled pages that look like a scan (single full-page
+    template image with little real text)."""
     pages_needing_ocr: list[int]
     """0-indexed page numbers that need OCR."""
     confidence: float

--- a/src/bin/detect_pdf.rs
+++ b/src/bin/detect_pdf.rs
@@ -223,11 +223,13 @@ fn run_detect_only(pdf_path: &str, json_output: bool, start: Instant) {
                     .collect();
                 let ocr_reasons = format_detector_ocr_reasons(&result.ocr_reasons_by_page);
                 println!(
-                    r#"{{"pdf_type":"{}","page_count":{},"pages_sampled":{},"pages_with_text":{},"confidence":{:.2},"title":{},"ocr_recommended":{},"pages_needing_ocr":[{}],"ocr_reasons_by_page":[{}],"detection_time_ms":{}}}"#,
+                    r#"{{"pdf_type":"{}","page_count":{},"pages_sampled":{},"pages_with_text":{},"pages_with_images":{},"pages_with_template_images":{},"confidence":{:.2},"title":{},"ocr_recommended":{},"pages_needing_ocr":[{}],"ocr_reasons_by_page":[{}],"detection_time_ms":{}}}"#,
                     pdf_type_str(&result.pdf_type),
                     result.page_count,
                     result.pages_sampled,
                     result.pages_with_text,
+                    result.pages_with_images,
+                    result.pages_with_template_images,
                     result.confidence,
                     result
                         .title
@@ -258,6 +260,11 @@ fn run_detect_only(pdf_path: &str, json_output: bool, start: Instant) {
                 println!("Page count: {}", result.page_count);
                 println!("Pages sampled: {}", result.pages_sampled);
                 println!("Pages with text: {}", result.pages_with_text);
+                println!("Pages with images: {}", result.pages_with_images);
+                println!(
+                    "Pages with template images: {}",
+                    result.pages_with_template_images
+                );
                 println!(
                     "OCR recommended: {}",
                     if result.ocr_recommended { "YES" } else { "NO" }

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -50,6 +50,11 @@ pub struct PdfTypeResult {
     pub pages_sampled: u32,
     /// Number of pages with text operators found
     pub pages_with_text: u32,
+    /// Number of sampled pages containing images
+    pub pages_with_images: u32,
+    /// Number of sampled pages that look like a scan (single full-page
+    /// template image with little real text)
+    pub pages_with_template_images: u32,
     /// Confidence score (0.0 - 1.0)
     pub confidence: f32,
     /// Title from metadata (if available)
@@ -469,6 +474,8 @@ pub(crate) fn detect_from_document(
         page_count,
         pages_sampled,
         pages_with_text,
+        pages_with_images,
+        pages_with_template_images,
         confidence,
         title,
         ocr_recommended,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,15 @@ pub struct PdfClassification {
     pub pdf_type: PdfType,
     /// Total page count.
     pub page_count: u32,
+    /// Number of pages sampled for detection.
+    pub pages_sampled: u32,
+    /// Number of sampled pages with extractable text.
+    pub pages_with_text: u32,
+    /// Number of sampled pages containing images.
+    pub pages_with_images: u32,
+    /// Number of sampled pages that look like a scan (single full-page
+    /// template image with little real text).
+    pub pages_with_template_images: u32,
     /// 0-indexed page numbers that need OCR (scanned/image pages).
     pub pages_needing_ocr: Vec<u32>,
     /// Detection confidence score (0.0–1.0).
@@ -395,6 +404,10 @@ pub fn classify_pdf_mem(buffer: &[u8]) -> Result<PdfClassification, PdfError> {
     Ok(PdfClassification {
         pdf_type: detection.pdf_type,
         page_count,
+        pages_sampled: detection.pages_sampled,
+        pages_with_text: detection.pages_with_text,
+        pages_with_images: detection.pages_with_images,
+        pages_with_template_images: detection.pages_with_template_images,
         // Convert from 1-indexed to 0-indexed for caller convenience
         pages_needing_ocr: detection.pages_needing_ocr.iter().map(|&p| p - 1).collect(),
         confidence: detection.confidence,

--- a/src/python.rs
+++ b/src/python.rs
@@ -99,6 +99,19 @@ pub struct PyPdfClassification {
     /// Total number of pages.
     #[pyo3(get)]
     pub page_count: u32,
+    /// Number of pages sampled for detection.
+    #[pyo3(get)]
+    pub pages_sampled: u32,
+    /// Number of sampled pages with extractable text.
+    #[pyo3(get)]
+    pub pages_with_text: u32,
+    /// Number of sampled pages containing images.
+    #[pyo3(get)]
+    pub pages_with_images: u32,
+    /// Number of sampled pages that look like a scan (single full-page
+    /// template image with little real text).
+    #[pyo3(get)]
+    pub pages_with_template_images: u32,
     /// 0-indexed page numbers that need OCR.
     #[pyo3(get)]
     pub pages_needing_ocr: Vec<u32>,
@@ -489,6 +502,10 @@ fn classify_pdf_bytes(data: &[u8]) -> PyResult<PyPdfClassification> {
     Ok(PyPdfClassification {
         pdf_type: pdf_type_str(result.pdf_type),
         page_count: result.page_count,
+        pages_sampled: result.pages_sampled,
+        pages_with_text: result.pages_with_text,
+        pages_with_images: result.pages_with_images,
+        pages_with_template_images: result.pages_with_template_images,
         pages_needing_ocr: result.pages_needing_ocr,
         confidence: result.confidence,
     })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1177,6 +1177,87 @@ fn test_detection_counters_on_text_pdf() {
     assert_eq!(classification.pages_with_template_images, 0);
 }
 
+/// A single page whose only content is a full-page 1000×1000 image — the
+/// shape of a scanned document. The declared dimensions exceed the 500K-pixel
+/// template threshold; the stream itself stays one byte.
+fn make_full_page_image_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    let content = "q 612 0 0 792 0 0 cm /Im0 Do Q";
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        4,
+        &format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content.len(),
+            content
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        "<< /Type /XObject /Subtype /Image /Width 1000 /Height 1000 \
+         /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\nstream\nx\nendstream",
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn test_detection_counters_on_scanned_pdf() {
+    let pdf = make_full_page_image_pdf();
+
+    let classification = pdf_inspector::classify_pdf_mem(&pdf).unwrap();
+    assert_eq!(classification.pdf_type, PdfType::Scanned);
+    assert_eq!(classification.pages_sampled, 1);
+    assert_eq!(classification.pages_with_text, 0);
+    assert_eq!(classification.pages_with_images, 1);
+    assert_eq!(classification.pages_with_template_images, 1);
+}
+
 #[test]
 fn test_firecrawl_tagged_pdf_struct_tree() {
     use lopdf::Document;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1101,6 +1101,8 @@ fn test_pages_needing_ocr_field_accessible() {
         page_count: 1,
         pages_sampled: 1,
         pages_with_text: 1,
+        pages_with_images: 0,
+        pages_with_template_images: 0,
         confidence: 1.0,
         title: None,
         ocr_recommended: false,
@@ -1158,6 +1160,21 @@ startxref
             result.pages_needing_ocr
         );
     }
+}
+
+#[test]
+fn test_detection_counters_on_text_pdf() {
+    let pdf = make_minimal_text_pdf();
+
+    let detection = pdf_inspector::detect_pdf_type_mem(&pdf).unwrap();
+    assert_eq!(detection.pages_with_images, 0);
+    assert_eq!(detection.pages_with_template_images, 0);
+
+    let classification = pdf_inspector::classify_pdf_mem(&pdf).unwrap();
+    assert_eq!(classification.pages_sampled, 1);
+    assert_eq!(classification.pages_with_text, 1);
+    assert_eq!(classification.pages_with_images, 0);
+    assert_eq!(classification.pages_with_template_images, 0);
 }
 
 #[test]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(pdf_type, "TextBased");
         assert!(get_count("pagesSampled") >= 1.0);
         assert!(get_count("pagesWithText") >= 1.0);
-        assert!(get_count("pagesWithImages") >= 0.0);
+        assert_eq!(get_count("pagesWithImages"), 0.0);
         assert_eq!(get_count("pagesWithTemplateImages"), 0.0);
         assert!(!text.is_empty());
     }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -54,6 +54,14 @@ export interface PdfProcessResult {
 export interface PdfClassification {
   pdfType: PdfType;
   pageCount: number;
+  /** Number of pages sampled for detection. */
+  pagesSampled: number;
+  /** Number of sampled pages with extractable text. */
+  pagesWithText: number;
+  /** Number of sampled pages containing images. */
+  pagesWithImages: number;
+  /** Number of sampled pages that look like a scan (single full-page template image with little real text). */
+  pagesWithTemplateImages: number;
   /** 0-indexed page numbers, matching the native Node.js API. */
   pagesNeedingOcr: number[];
   confidence: number;
@@ -158,6 +166,10 @@ impl From<PdfProcessResult> for WasmPdfProcessResult {
 struct WasmPdfClassification {
     pdf_type: &'static str,
     page_count: u32,
+    pages_sampled: u32,
+    pages_with_text: u32,
+    pages_with_images: u32,
+    pages_with_template_images: u32,
     pages_needing_ocr: Vec<u32>,
     confidence: f64,
 }
@@ -259,6 +271,10 @@ pub fn classify_pdf(data: &[u8]) -> Result<JsValue, JsValue> {
     serialize(&WasmPdfClassification {
         pdf_type: pdf_type_name(result.pdf_type),
         page_count: result.page_count,
+        pages_sampled: result.pages_sampled,
+        pages_with_text: result.pages_with_text,
+        pages_with_images: result.pages_with_images,
+        pages_with_template_images: result.pages_with_template_images,
         pages_needing_ocr: result.pages_needing_ocr,
         confidence: result.confidence as f64,
     })

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -421,9 +421,19 @@ mod tests {
             .expect("pdfType")
             .as_string()
             .expect("pdfType string");
+        let get_count = |key: &str| {
+            Reflect::get(&classification, &JsValue::from_str(key))
+                .expect(key)
+                .as_f64()
+                .expect("count number")
+        };
         let text = extract_text(TEXT_PDF).expect("extract text");
 
         assert_eq!(pdf_type, "TextBased");
+        assert!(get_count("pagesSampled") >= 1.0);
+        assert!(get_count("pagesWithText") >= 1.0);
+        assert!(get_count("pagesWithImages") >= 0.0);
+        assert_eq!(get_count("pagesWithTemplateImages"), 0.0);
         assert!(!text.is_empty());
     }
 


### PR DESCRIPTION
The detector counts `pages_with_images` and `pages_with_template_images` while classifying, but discards both — callers only see the final `pdf_type` and `ocr_recommended`. Pipelines that route between local extraction and OCR can't calibrate their own policy against the signals the classifier actually used.

Changes:

- `PdfTypeResult` gains `pages_with_images` and `pages_with_template_images`.
- `PdfClassification` gains those two plus the existing `pages_sampled` / `pages_with_text`, and the new fields are mirrored in the Python, Node, and wasm classification results (the Node and wasm shapes are documented as sharing one surface, so all three stay in sync).
- `detect-pdf --json` includes the counters.

Deliberately not included:

- `text_ratio` — it is exactly `pages_with_text / pages_sampled`, both now exposed.
- `PdfProcessResult` — it already omits detector internals (`pages_sampled`, `pages_with_text`), so the counters stay off it too.

Adding fields to these structs is source-breaking for anyone constructing them literally; reading code is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788252108&installation_model_id=11126&pr_number=204&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F204&signature=c5af202db65101d3a44061bffa71ac3557cce86fd853c915ce21951e4896d355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose image counters in PDF classification so pipelines can calibrate OCR routing with the same signals the detector uses. Also include these counters in `detect-pdf --json` and sync Python, Node (`napi`), and `wasm` APIs.

- **New Features**
  - Add `pages_with_images` and `pages_with_template_images` to `PdfTypeResult` and `PdfClassification`.
  - Add `pages_sampled` and `pages_with_text` to `PdfClassification`.
  - Update Python typings, Node `napi` interface, and `wasm` interface and docs to include the new fields.
  - `detect-pdf --json` now outputs the counters; CLI text output prints them.
  - Tests cover counters on text and scanned PDFs; `wasm` tests assert 0 image counts for text PDFs.

- **Migration**
  - Struct additions are source-breaking for code that constructs these types; code that reads them is unaffected.
  - `PdfProcessResult` remains unchanged (detector internals are not exposed there).
  - If you parse `detect-pdf --json`, expect the new keys.

<sup>Written for commit 60b897353ef26f6c198ba0745e286abaf551b088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

