### PR TITLE
fix(extractor): weigh U+FFFD by evidence in the per-page gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use text_quality::{
     analyze_text_quality, detect_encoding_issues, is_cid_garbage, is_garbage_text,
-    region_items_have_decoding_issue,
+    markdown_encoding_issues_with_evidence, region_items_have_decoding_issue,
 };
 use tounicode::FontCMaps;
 
@@ -540,8 +540,15 @@ pub fn extract_pages_markdown_mem(
             )
         };
 
+        // `analyze_text_quality` has already weighed this page's replacement
+        // characters against the density policy — `has_text_quality_issue`
+        // carries that verdict. Re-testing the markdown with the strict
+        // `detect_encoding_issues` would overturn it on a single unmappable
+        // glyph and blank the page below, so the markdown pass uses the same
+        // evidence policy (issue #202).
         let has_decoding_issue = has_text_quality_issue
-            || (!md.is_empty() && (is_cid_garbage(&md) || detect_encoding_issues(&md)));
+            || (!md.is_empty()
+                && (is_cid_garbage(&md) || markdown_encoding_issues_with_evidence(&md)));
         if has_decoding_issue {
             add_ocr_reason(
                 &mut ocr_reasons_by_page,
@@ -5836,6 +5843,88 @@ mod tests {
         // Under threshold of 10 total dollars — should not trigger
         let text = "a$b c$d e$f";
         assert!(!detect_encoding_issues(text));
+    }
+
+    /// Body prose used to build realistic page-sized markdown in the
+    /// evidence-gate tests below. 57 chars, 46 of them non-whitespace.
+    const EVIDENCE_TEST_BODY: &str = "Samples are kept in the cold room and logged on arrival. ";
+
+    /// Issue #202: one unmappable glyph must not invalidate a whole page.
+    ///
+    /// This is the case `test_text_quality_allows_isolated_replacement_character`
+    /// already protects at the item level, asserted here on the markdown the
+    /// per-page gate actually inspects. The strict entry point deliberately
+    /// still fires — the divergence is the point of the fix.
+    #[test]
+    fn test_markdown_evidence_allows_isolated_replacement_char() {
+        let md = format!(
+            "\u{FFFD} -18 C. Check the seal before use.\n\n{}",
+            EVIDENCE_TEST_BODY.repeat(12)
+        );
+
+        assert!(detect_encoding_issues(&md));
+        assert!(!markdown_encoding_issues_with_evidence(&md));
+    }
+
+    /// Three scattered symbol glyphs on a ~700-char page sit far below the
+    /// 250 bps density floor, so `replacement_spans >= 3` alone must not
+    /// route the page to OCR.
+    #[test]
+    fn test_markdown_evidence_allows_scattered_replacement_chars() {
+        let chunk = EVIDENCE_TEST_BODY.repeat(5);
+        let md = format!("{chunk}\u{FFFD}{chunk}\u{FFFD}{chunk}\u{FFFD}");
+
+        assert_eq!(md.matches('\u{FFFD}').count(), 3);
+        assert!(!markdown_encoding_issues_with_evidence(&md));
+    }
+
+    /// A genuinely broken text layer still routes to OCR: 12 replacement
+    /// characters at >= 500 bps trips `enough_bad_text`. Kept above the
+    /// 80-char floor so this exercises the density rule, not the
+    /// short-page rule.
+    #[test]
+    fn test_markdown_evidence_flags_dense_replacement_chars() {
+        let md = format!(
+            "{}{}",
+            "\u{FFFD}".repeat(12),
+            "Broken glyph run in the table header cells and totals row. ".repeat(2)
+        );
+
+        assert!(md.chars().filter(|c| !c.is_whitespace()).count() > 80);
+        assert!(markdown_encoding_issues_with_evidence(&md));
+    }
+
+    /// On a page that is nothing but a short broken fragment, a run of two
+    /// is already enough evidence (`chars <= 80` branch).
+    #[test]
+    fn test_markdown_evidence_flags_short_page_replacement_run() {
+        assert!(markdown_encoding_issues_with_evidence(
+            "Fig \u{FFFD}\u{FFFD} 3"
+        ));
+    }
+
+    /// Only the U+FFFD heuristic is weighed by evidence. Dollar-as-space
+    /// stays strict.
+    #[test]
+    fn test_markdown_evidence_still_flags_dollar_as_space() {
+        let garbled = "Last$advanced$Book$Programm$3th$Workshop$on$Chest$Wall$Deformities$and$More";
+        assert!(markdown_encoding_issues_with_evidence(garbled));
+    }
+
+    #[test]
+    fn test_markdown_evidence_allows_clean_text() {
+        assert!(!markdown_encoding_issues_with_evidence(
+            "Normal markdown text with no issues."
+        ));
+    }
+
+    /// Regression guard for the other three `detect_encoding_issues` call
+    /// sites (region text, table candidates, document-level flag), which
+    /// keep the strict single-character policy.
+    #[test]
+    fn test_detect_encoding_issues_stays_strict_on_single_fffd() {
+        let md = format!("{}\u{FFFD}", EVIDENCE_TEST_BODY.repeat(12));
+        assert!(detect_encoding_issues(&md));
     }
 
     /// Real garbled output from ParseBench `text_simple__att10k.pdf`: a broken

--- a/src/text_quality.rs
+++ b/src/text_quality.rs
@@ -375,6 +375,63 @@ fn has_replacement_text_run(text: &str) -> bool {
     longest_run >= 2 || replacement >= 3
 }
 
+/// Rebuild [`PageTextQualityEvidence`] from assembled markdown so the
+/// page-level policy can be applied to it.
+///
+/// [`analyze_text_quality`] sees one [`TextItem`] at a time, so it needs
+/// [`has_replacement_text_run`] to decide a span is worth counting at all. By
+/// the time markdown exists the spans are concatenated: a run straddling two
+/// items is visible here and nowhere else, which is why the per-page gate
+/// still inspects markdown after the item analyzer has run.
+///
+/// Field-for-field this mirrors the accumulation in [`analyze_text_quality`],
+/// counting each contiguous U+FFFD run as one span the way that loop counts
+/// one span per issue-bearing item. Markdown also carries syntax characters
+/// (`#`, `|`, `*`) that item text does not, so `chars` runs slightly high and
+/// the density floor is marginally more permissive than the item-level path.
+fn markdown_replacement_evidence(markdown: &str) -> PageTextQualityEvidence {
+    let (replacement_chars, longest_replacement_run) = replacement_text_stats(markdown);
+
+    PageTextQualityEvidence {
+        chars: markdown.chars().filter(|ch| !ch.is_whitespace()).count(),
+        replacement_chars,
+        replacement_spans: markdown
+            .split(|ch| ch != '\u{FFFD}')
+            .filter(|run| !run.is_empty())
+            .count(),
+        longest_replacement_run,
+        // Not read by `page_replacement_evidence_needs_ocr`; the markdown
+        // gate runs the cipher check separately below.
+        ..Default::default()
+    }
+}
+
+/// Markdown-level encoding check for the per-page extraction gate.
+///
+/// Same three heuristics as [`detect_encoding_issues`], except U+FFFD is
+/// weighed by [`page_replacement_evidence_needs_ocr`] instead of tripping on a
+/// single character. A lone unmappable glyph — a `≤`, a diameter sign, a
+/// ballot box drawn from a subset symbol font with no ToUnicode CMap — is
+/// common on otherwise healthy office pages, and blanking the page over it
+/// discarded text that decoded perfectly (issue #202).
+///
+/// [`detect_encoding_issues`] keeps the strict policy for callers that only
+/// set a flag or reject one table candidate, where a false positive costs no
+/// content.
+pub(crate) fn markdown_encoding_issues_with_evidence(markdown: &str) -> bool {
+    if page_replacement_evidence_needs_ocr(&markdown_replacement_evidence(markdown)) {
+        return true;
+    }
+
+    if has_dollar_as_space_pattern(markdown) {
+        return true;
+    }
+
+    let mut stats = CipherGarbleStats::default();
+    stats.add_text(markdown);
+    stats.looks_garbled()
+}
+
 fn has_private_use_text_run(text: &str) -> bool {
     let mut total = 0usize;
     let mut private_use = 0usize;

--- a/tests/fixtures/isolated_replacement_char.pdf
+++ b/tests/fixtures/isolated_replacement_char.pdf
@@ -1,0 +1,79 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 851 >>
+stream
+BT
+/F1 11 Tf
+14 TL
+56 760 Td
+(Section 4 - Storage and handling) Tj
+T*
+() Tj
+T*
+(Samples are kept in the cold room and logged on arrival. The retention) Tj
+T*
+(period is twelve months from the date of receipt unless the method) Tj
+T*
+(states otherwise. Containers must be labelled with the sample number,) Tj
+T*
+(the date, and the name of the person who took the sample.) Tj
+T*
+() Tj
+T*
+(Stock solutions are stable for twelve months when stored at) Tj
+T*
+/F2 11 Tf
+<00A3> Tj
+/F1 11 Tf
+( -18 C. Check the seal before use and discard any container) Tj
+T*
+(whose label is no longer legible. Record the check in the logbook.) Tj
+T*
+() Tj
+T*
+(Filters are supplied in two sizes. Use the larger one for turbid) Tj
+T*
+(samples and the smaller one for everything else. Rinse the funnel) Tj
+T*
+(with deionised water between samples to avoid carry-over.) Tj
+T*
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type0 /BaseFont /AAAAAA+SymbolMT /Encoding /Identity-H /DescendantFonts [7 0 R] >>
+endobj
+7 0 obj
+<< /Type /Font /Subtype /CIDFontType2 /BaseFont /AAAAAA+SymbolMT /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 8 0 R /DW 1000 >>
+endobj
+8 0 obj
+<< /Type /FontDescriptor /FontName /AAAAAA+SymbolMT /Flags 4 /FontBBox [0 -220 1113 1005] /ItalicAngle 0 /Ascent 1005 /Descent -220 /CapHeight 662 /StemV 86 >>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000251 00000 n 
+0000001153 00000 n 
+0000001250 00000 n 
+0000001373 00000 n 
+0000001561 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+1736
+%%EOF

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2939,6 +2939,28 @@ fn test_extract_pages_markdown_out_of_range() {
     assert!(result.pages_needing_ocr.contains(&10000)); // 1-indexed
 }
 
+/// Issue #202: a page carrying one unmappable glyph must still return its
+/// text. The fixture is ~700 characters of Helvetica prose plus a single CID
+/// drawn from an Identity-H font with no ToUnicode CMap, which extracts as one
+/// U+FFFD — the shape a word processor emits when the body font lacks a glyph.
+///
+/// Before the fix this page came back as `markdown: ""` with
+/// `ocr_reason: "suspected_garbled_text"`, while `process_pdf` kept the same
+/// content on the same file.
+#[test]
+fn test_extract_pages_markdown_keeps_page_with_isolated_replacement_char() {
+    let buf = std::fs::read("tests/fixtures/isolated_replacement_char.pdf").unwrap();
+    let result = extract_pages_markdown_mem(&buf, Some(&[0])).unwrap();
+
+    let page = &result.pages[0];
+    assert_eq!(page.markdown.matches('\u{FFFD}').count(), 1);
+    assert!(page.markdown.contains("Section 4"));
+    assert!(page.markdown.contains("Rinse the funnel"));
+    assert!(!page.needs_ocr);
+    assert_eq!(page.ocr_reason, None);
+    assert!(result.pages_needing_ocr.is_empty());
+}
+
 #[test]
 fn test_extract_pages_markdown_empty_pages_list() {
     let buf = std::fs::read("tests/fixtures/nexo-price-en.pdf").unwrap();


### PR DESCRIPTION
Fixes #202.

## Problem

`extract_pages_markdown` returns `markdown: ""` for any page containing a single U+FFFD, discarding text that decoded correctly, and reports the page as `needs_ocr: true` with `ocr_reason: "suspected_garbled_text"`.

Reproduced on `main` @ a15ec2d with the reporter's 1,980-byte fixture — ~700 characters of Helvetica prose plus one CID from an Identity-H font with no ToUnicode CMap:

| Entry point | Before | After |
| --- | --- | --- |
| `extract_pages_markdown` | `md_len=0`, `needs_ocr=true`, `suspected_garbled_text` | `md_len=684`, `needs_ocr=false`, `None` |
| `process_pdf` | `md_len=684`, `pages_needing_ocr=[]` | unchanged |
| `extract_text_with_positions` | 665 chars, 1 U+FFFD | unchanged |

## Root cause

The reporter's diagnosis is correct. `analyze_text_quality` already handles this case deliberately: `has_replacement_text_run` (`text_quality.rs:373`) declines to count a lone replacement character as evidence at all, and `page_replacement_evidence_needs_ocr` applies density thresholds on top. `test_text_quality_allows_isolated_replacement_character` pins that behaviour.

The markdown is then built in full and discarded by a second check at `lib.rs:544` — `detect_encoding_issues`, whose first heuristic is `markdown.contains('\u{FFFD}')`. The calibrated decision is overturned by an uncalibrated one. The existing tests pass because they exercise `analyze_text_quality` directly rather than the composed path.

## Approach

This is the reporter's direction 1, scoped to the one call site that loses data.

`markdown_encoding_issues_with_evidence` rebuilds `PageTextQualityEvidence` from assembled markdown — non-whitespace `chars`, total `replacement_chars`, `longest_replacement_run`, and each contiguous U+FFFD run as one `replacement_span` — then runs the existing `page_replacement_evidence_needs_ocr` over it. Dollar-as-space and cipher-garble stay strict.

**No new thresholds.** Markdown becomes a second evidence source for the policy already tuned in this module, so the calibration stays in one place.

The markdown pass is kept rather than deleted because a replacement run straddling two adjacent `TextItem`s is visible only after concatenation — the item-level analyzer sees one span at a time and would miss it.

`detect_encoding_issues` is unchanged, so the three call sites where a false positive costs no content keep the strict policy:

| Call site | Effect of a lone U+FFFD |
| --- | --- |
| `lib.rs:544` `extract_pages_markdown` | **was blanking the page** — now evidence-weighed |
| `lib.rs:759` `extract_regions_text` | sets `needs_ocr`; region text still returned |
| `lib.rs:977` table candidate eval | rejects one candidate, falls through to next detector |
| `lib.rs:3754` `process_pdf` | sets `has_encoding_issues`; markdown preserved |

## Verification

- `cargo fmt`, `cargo clippy -- -D warnings` clean
- Full suite green: 723 unit + 142 integration
- **Fixture sweep:** ran `extract_pages_markdown` over every fixture in `tests/fixtures` (757 pages) with and without the patch. Exactly one line differs — the new fixture. Zero collateral change across the 756 pre-existing pages.
- The new integration test was confirmed to fail with the call site reverted, then pass with it applied

## Tests added

Six unit tests covering isolated / scattered / dense / short-page-run / dollar-as-space / clean markdown, plus a regression guard asserting `detect_encoding_issues` still fires on a lone U+FFFD so the other three call sites stay pinned. Integration test uses the reporter's generator output, committed as `tests/fixtures/isolated_replacement_char.pdf` (1,980 bytes, stdlib-generated, no third-party content).

## Notes and deliberate non-goals

- **`chars` runs slightly high.** Markdown carries syntax characters (`#`, `|`, `*`) that item text does not, making the density floor marginally more permissive than the item-level path. Flagged rather than compensated for with a fudge factor; happy to adjust if you'd prefer stripping syntax first.
- **Document-level flag untouched.** `process_pdf` still reports `has_encoding_issues: true` for this file. That's out of scope here since it loses no data, but say the word and I'll extend the same treatment to `lib.rs:3754`.
- **Contract unchanged.** `needs_ocr` pages still return `""`; this PR only stops a healthy page from being classified that way. The reporter's direction 2 would be a separate, breaking change.
- No `pdf-evals` snapshot run — I don't have that corpus locally. The fixture sweep above is the closest substitute I could produce.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788253326&installation_model_id=11126&pr_number=206&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F206&signature=a67d4ebcb8cc9d81b259fb92cb7d1ea9a513251ceca8083538a5238e0c7a51f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents blanking a page in `extract_pages_markdown` when it contains a single U+FFFD by weighing replacement characters with evidence. Preserves valid text and avoids false `needs_ocr` flags. Fixes #202.

- **Bug Fixes**
  - Use `markdown_encoding_issues_with_evidence` in the per-page gate to apply density-based checks instead of the strict single-character rule.
  - Keep strict checks for region text, table candidate evaluation, and the document-level `has_encoding_issues` flag.
  - Add unit and integration tests with a new fixture; fixture sweep shows no collateral changes.

<sup>Written for commit 540282b518797b6628f8d909c71dd9ca36bc9cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

