### PR TITLE
Improve Arabic RTL text extraction

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -4,7 +4,9 @@
 //! matrix, and emits `TextItem`s and `PdfRect`s.
 
 use crate::text_utils::{
-    decode_text_string, effective_font_size, expand_ligatures, is_bold_font, is_italic_font,
+    decode_text_string, effective_font_size, expand_ligatures,
+    expand_ligatures_in_reversed_char_clusters, expand_ligatures_in_reversed_chars,
+    expand_ligatures_preserving_order, is_bold_font, is_italic_font,
 };
 use crate::tounicode::FontCMaps;
 use crate::types::{ItemType, PageExtraction, PdfLine, PdfRect, TextItem};
@@ -15,8 +17,8 @@ use std::collections::HashMap;
 
 use super::fonts::{
     build_font_encodings, build_font_widths, compute_string_width_ts, descriptor_style_flags,
-    extract_text_from_operand, get_font_file2_obj_num, get_operand_bytes, CMapDecisionCache,
-    FontStyleCache,
+    extract_text_clusters_from_operand, extract_text_from_operand, get_font_file2_obj_num,
+    get_operand_bytes, CMapDecisionCache, FontStyleCache,
 };
 use super::underline::UnderlineLine;
 use super::xobjects::{extract_form_xobject_text, get_page_xobjects, XObjectType};
@@ -294,6 +296,7 @@ pub(crate) fn extract_page_text_items(
     struct MarkedContentEntry {
         actual_text: Option<String>,
         mcid: Option<i64>,
+        reversed_chars: bool,
     }
     let mut marked_content_stack: Vec<MarkedContentEntry> = Vec::new();
     let mut suppress_glyph_extraction = false;
@@ -306,6 +309,18 @@ pub(crate) fn extract_page_text_items(
     /// Get the innermost MCID from the marked content stack.
     fn current_mcid(stack: &[MarkedContentEntry]) -> Option<i64> {
         stack.iter().rev().find_map(|e| e.mcid)
+    }
+
+    fn current_reversed_chars(stack: &[MarkedContentEntry]) -> bool {
+        stack.iter().any(|e| e.reversed_chars)
+    }
+
+    fn expand_content_text(text: &str, stack: &[MarkedContentEntry]) -> String {
+        if current_reversed_chars(stack) {
+            expand_ligatures_in_reversed_chars(text)
+        } else {
+            expand_ligatures(text)
+        }
     }
 
     for op in &content.operations {
@@ -488,18 +503,36 @@ pub(crate) fn extract_page_text_items(
                         }
                         continue;
                     }
-                    if let Some(text) = extract_text_from_operand(
-                        &op.operands[0],
-                        &current_font,
-                        font_base_names.get(&current_font).map(|s| s.as_str()),
-                        font_cmaps,
-                        &font_tounicode_refs,
-                        &inline_cmaps,
-                        &font_encodings,
-                        &encoding_cache,
-                        &mut cmap_decisions,
-                        &font_widths,
-                    ) {
+                    let text = if current_reversed_chars(&marked_content_stack) {
+                        extract_text_clusters_from_operand(
+                            &op.operands[0],
+                            &current_font,
+                            font_base_names.get(&current_font).map(|s| s.as_str()),
+                            font_cmaps,
+                            &font_tounicode_refs,
+                            &inline_cmaps,
+                            &font_encodings,
+                            &encoding_cache,
+                            &mut cmap_decisions,
+                            &font_widths,
+                        )
+                        .map(|clusters| expand_ligatures_in_reversed_char_clusters(&clusters))
+                    } else {
+                        extract_text_from_operand(
+                            &op.operands[0],
+                            &current_font,
+                            font_base_names.get(&current_font).map(|s| s.as_str()),
+                            font_cmaps,
+                            &font_tounicode_refs,
+                            &inline_cmaps,
+                            &font_encodings,
+                            &encoding_cache,
+                            &mut cmap_decisions,
+                            &font_widths,
+                        )
+                        .map(|text| expand_ligatures(&text))
+                    };
+                    if let Some(text) = text {
                         let combined =
                             multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
                         let rendered_size = effective_font_size(current_font_size, &combined);
@@ -528,7 +561,7 @@ pub(crate) fn extract_page_text_items(
                                 .copied()
                                 .unwrap_or((false, false));
                             items.push(TextItem {
-                                text: expand_ligatures(&text),
+                                text,
                                 x,
                                 y,
                                 width,
@@ -574,6 +607,8 @@ pub(crate) fn extract_page_text_items(
                         // (text, start_width_ts, end_width_ts)
                         let mut sub_items: Vec<(String, f32, f32)> = Vec::new();
                         let mut current_text = String::new();
+                        let reversed_chars = current_reversed_chars(&marked_content_stack);
+                        let mut current_clusters: Vec<String> = Vec::new();
                         let mut sub_start_width_ts: f32 = 0.0;
                         let mut total_width_ts: f32 = 0.0;
                         for element in array {
@@ -581,26 +616,45 @@ pub(crate) fn extract_page_text_items(
                                 Object::Integer(n) => {
                                     let n_val = *n as f32;
                                     let displacement = -n_val / 1000.0 * current_font_size;
-                                    if !is_invisible
-                                        && n_val < -column_gap_threshold
-                                        && !current_text.is_empty()
+                                    let has_current = if reversed_chars {
+                                        !current_clusters.is_empty()
+                                    } else {
+                                        !current_text.is_empty()
+                                    };
+                                    if !is_invisible && n_val < -column_gap_threshold && has_current
                                     {
                                         // Column gap: flush current segment
-                                        sub_items.push((
-                                            std::mem::take(&mut current_text),
-                                            sub_start_width_ts,
-                                            total_width_ts,
-                                        ));
+                                        let text = if reversed_chars {
+                                            let text = expand_ligatures_in_reversed_char_clusters(
+                                                &current_clusters,
+                                            );
+                                            current_clusters.clear();
+                                            text
+                                        } else {
+                                            std::mem::take(&mut current_text)
+                                        };
+                                        sub_items.push((text, sub_start_width_ts, total_width_ts));
                                         total_width_ts += displacement;
                                         sub_start_width_ts = total_width_ts;
                                     } else {
                                         total_width_ts += displacement;
+                                        let ends_with_space = if reversed_chars {
+                                            current_clusters
+                                                .last()
+                                                .is_some_and(|cluster| cluster.ends_with(' '))
+                                        } else {
+                                            current_text.ends_with(' ')
+                                        };
                                         if !is_invisible
                                             && n_val < -space_threshold
-                                            && !current_text.is_empty()
-                                            && !current_text.ends_with(' ')
+                                            && has_current
+                                            && !ends_with_space
                                         {
-                                            current_text.push(' ');
+                                            if reversed_chars {
+                                                current_clusters.push(" ".to_string());
+                                            } else {
+                                                current_text.push(' ');
+                                            }
                                         }
                                     }
                                     continue;
@@ -608,25 +662,44 @@ pub(crate) fn extract_page_text_items(
                                 Object::Real(n) => {
                                     let n_val = *n;
                                     let displacement = -n_val / 1000.0 * current_font_size;
-                                    if !is_invisible
-                                        && n_val < -column_gap_threshold
-                                        && !current_text.is_empty()
+                                    let has_current = if reversed_chars {
+                                        !current_clusters.is_empty()
+                                    } else {
+                                        !current_text.is_empty()
+                                    };
+                                    if !is_invisible && n_val < -column_gap_threshold && has_current
                                     {
-                                        sub_items.push((
-                                            std::mem::take(&mut current_text),
-                                            sub_start_width_ts,
-                                            total_width_ts,
-                                        ));
+                                        let text = if reversed_chars {
+                                            let text = expand_ligatures_in_reversed_char_clusters(
+                                                &current_clusters,
+                                            );
+                                            current_clusters.clear();
+                                            text
+                                        } else {
+                                            std::mem::take(&mut current_text)
+                                        };
+                                        sub_items.push((text, sub_start_width_ts, total_width_ts));
                                         total_width_ts += displacement;
                                         sub_start_width_ts = total_width_ts;
                                     } else {
                                         total_width_ts += displacement;
+                                        let ends_with_space = if reversed_chars {
+                                            current_clusters
+                                                .last()
+                                                .is_some_and(|cluster| cluster.ends_with(' '))
+                                        } else {
+                                            current_text.ends_with(' ')
+                                        };
                                         if !is_invisible
                                             && n_val < -space_threshold
-                                            && !current_text.is_empty()
-                                            && !current_text.ends_with(' ')
+                                            && has_current
+                                            && !ends_with_space
                                         {
-                                            current_text.push(' ');
+                                            if reversed_chars {
+                                                current_clusters.push(" ".to_string());
+                                            } else {
+                                                current_text.push(' ');
+                                            }
                                         }
                                     }
                                     continue;
@@ -645,7 +718,22 @@ pub(crate) fn extract_page_text_items(
                                 }
                             }
                             if !is_invisible {
-                                if let Some(text) = extract_text_from_operand(
+                                if reversed_chars {
+                                    if let Some(clusters) = extract_text_clusters_from_operand(
+                                        element,
+                                        &current_font,
+                                        font_base_names.get(&current_font).map(|s| s.as_str()),
+                                        font_cmaps,
+                                        &font_tounicode_refs,
+                                        &inline_cmaps,
+                                        &font_encodings,
+                                        &encoding_cache,
+                                        &mut cmap_decisions,
+                                        &font_widths,
+                                    ) {
+                                        current_clusters.extend(clusters);
+                                    }
+                                } else if let Some(text) = extract_text_from_operand(
                                     element,
                                     &current_font,
                                     font_base_names.get(&current_font).map(|s| s.as_str()),
@@ -662,8 +750,15 @@ pub(crate) fn extract_page_text_items(
                             }
                         }
                         // Flush remaining text
-                        if !is_invisible && !current_text.trim().is_empty() {
-                            sub_items.push((current_text, sub_start_width_ts, total_width_ts));
+                        if !is_invisible {
+                            let text = if reversed_chars {
+                                expand_ligatures_in_reversed_char_clusters(&current_clusters)
+                            } else {
+                                current_text
+                            };
+                            if !text.trim().is_empty() {
+                                sub_items.push((text, sub_start_width_ts, total_width_ts));
+                            }
                         }
                         // Emit one TextItem per sub-item
                         if !sub_items.is_empty() {
@@ -701,7 +796,11 @@ pub(crate) fn extract_page_text_items(
                                     0.0
                                 };
                                 items.push(TextItem {
-                                    text: expand_ligatures(text),
+                                    text: if reversed_chars {
+                                        text.clone()
+                                    } else {
+                                        expand_content_text(text, &marked_content_stack)
+                                    },
                                     x,
                                     y,
                                     width,
@@ -760,18 +859,36 @@ pub(crate) fn extract_page_text_items(
                     || suppress_glyph_extraction
                     || op.operands.is_empty())
                 {
-                    if let Some(text) = extract_text_from_operand(
-                        &op.operands[0],
-                        &current_font,
-                        font_base_names.get(&current_font).map(|s| s.as_str()),
-                        font_cmaps,
-                        &font_tounicode_refs,
-                        &inline_cmaps,
-                        &font_encodings,
-                        &encoding_cache,
-                        &mut cmap_decisions,
-                        &font_widths,
-                    ) {
+                    let text = if current_reversed_chars(&marked_content_stack) {
+                        extract_text_clusters_from_operand(
+                            &op.operands[0],
+                            &current_font,
+                            font_base_names.get(&current_font).map(|s| s.as_str()),
+                            font_cmaps,
+                            &font_tounicode_refs,
+                            &inline_cmaps,
+                            &font_encodings,
+                            &encoding_cache,
+                            &mut cmap_decisions,
+                            &font_widths,
+                        )
+                        .map(|clusters| expand_ligatures_in_reversed_char_clusters(&clusters))
+                    } else {
+                        extract_text_from_operand(
+                            &op.operands[0],
+                            &current_font,
+                            font_base_names.get(&current_font).map(|s| s.as_str()),
+                            font_cmaps,
+                            &font_tounicode_refs,
+                            &inline_cmaps,
+                            &font_encodings,
+                            &encoding_cache,
+                            &mut cmap_decisions,
+                            &font_widths,
+                        )
+                        .map(|text| expand_ligatures(&text))
+                    };
+                    if let Some(text) = text {
                         if !text.trim().is_empty() {
                             let combined =
                                 multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
@@ -797,7 +914,7 @@ pub(crate) fn extract_page_text_items(
                                 .copied()
                                 .unwrap_or((false, false));
                             items.push(TextItem {
-                                text: expand_ligatures(&text),
+                                text,
                                 x,
                                 y,
                                 width,
@@ -877,15 +994,26 @@ pub(crate) fn extract_page_text_items(
             }
             "BMC" => {
                 // Begin Marked Content (no properties)
+                let reversed_chars = op
+                    .operands
+                    .first()
+                    .and_then(|object| object.as_name().ok())
+                    .is_some_and(|name| name == b"ReversedChars");
                 marked_content_stack.push(MarkedContentEntry {
                     actual_text: None,
                     mcid: None,
+                    reversed_chars,
                 });
             }
             "BDC" => {
                 // Begin Marked Content with properties — extract ActualText and MCID
                 let mut actual_text: Option<String> = None;
                 let mut mcid: Option<i64> = None;
+                let reversed_chars = op
+                    .operands
+                    .first()
+                    .and_then(|object| object.as_name().ok())
+                    .is_some_and(|name| name == b"ReversedChars");
                 if op.operands.len() >= 2 {
                     let dict = match &op.operands[1] {
                         Object::Dictionary(d) => Some(d.clone()),
@@ -911,7 +1039,11 @@ pub(crate) fn extract_page_text_items(
                     actual_text_glyph_tm = None; // reset — will be captured at first Tj/TJ
                     actual_text_glyph_rise = None;
                 }
-                marked_content_stack.push(MarkedContentEntry { actual_text, mcid });
+                marked_content_stack.push(MarkedContentEntry {
+                    actual_text,
+                    mcid,
+                    reversed_chars,
+                });
             }
             "EMC" => {
                 // End Marked Content — emit ActualText item with correct width
@@ -948,7 +1080,7 @@ pub(crate) fn extract_page_text_items(
                                     .copied()
                                     .unwrap_or((false, false));
                                 items.push(TextItem {
-                                    text: expand_ligatures(&at),
+                                    text: expand_ligatures_preserving_order(&at),
                                     x,
                                     y,
                                     width,

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -1225,6 +1225,178 @@ pub(crate) fn extract_text_from_operand(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn extract_text_clusters_from_operand(
+    obj: &Object,
+    current_font: &str,
+    base_font_name: Option<&str>,
+    font_cmaps: &FontCMaps,
+    font_tounicode_refs: &std::collections::HashMap<String, u32>,
+    inline_cmaps: &std::collections::HashMap<String, crate::tounicode::CMapEntry>,
+    font_encodings: &PageFontEncodings,
+    encoding_cache: &HashMap<String, Encoding<'_>>,
+    cmap_decisions: &mut CMapDecisionCache,
+    font_widths: &PageFontWidths,
+) -> Option<Vec<String>> {
+    let is_type0_cid_font = font_widths
+        .get(current_font)
+        .is_some_and(|info| info.is_cid);
+    let use_cp1252_fallback =
+        should_use_cp1252_single_byte_fallback(base_font_name, is_type0_cid_font);
+
+    if let Object::String(bytes, _) = obj {
+        let mut decode_with_entry = |entry: &crate::tounicode::CMapEntry| -> Option<Vec<String>> {
+            if entry.primary.code_byte_length == 1 {
+                let encoding_map = font_encodings.get(current_font);
+                let decoded: Vec<String> = bytes
+                    .iter()
+                    .filter_map(|&b| {
+                        let code = b as u16;
+                        if let Some(s) = entry.primary.lookup(code) {
+                            if !s.contains('\u{FFFD}') {
+                                return Some(s);
+                            }
+                        }
+                        if let Some(fb) = entry.fallback.as_ref().and_then(|c| c.lookup(code)) {
+                            if !fb.contains('\u{FFFD}') {
+                                return Some(fb);
+                            }
+                        }
+                        if let Some(map) = encoding_map {
+                            if let Some(&ch) = map.get(&b) {
+                                return Some(ch.to_string());
+                            }
+                        }
+                        if b >= 0x20 {
+                            return Some(
+                                decode_single_byte_fallback_char(b, use_cp1252_fallback)
+                                    .to_string(),
+                            );
+                        }
+                        None
+                    })
+                    .collect();
+                if !decoded.is_empty() {
+                    return Some(decoded);
+                }
+                return None;
+            }
+
+            if bytes.len() % 2 == 1 {
+                let lookups = entry.primary.lookup_bytes(bytes);
+                let decoded: Vec<String> = lookups
+                    .iter()
+                    .filter_map(|&(_b, ref cmap_result)| cmap_result.clone())
+                    .collect();
+                if !decoded.is_empty() {
+                    return Some(decoded);
+                }
+            }
+
+            let primary_clusters = entry.primary.decode_cid_clusters(bytes);
+            let decoded_primary = primary_clusters.concat();
+            if let Some(remapped) = entry.remapped.as_ref() {
+                let remap_clusters = remapped.decode_cid_clusters(bytes);
+                let decoded_remap = remap_clusters.concat();
+                let fallback_clusters = entry
+                    .fallback
+                    .as_ref()
+                    .map(|c| c.decode_cid_clusters(bytes));
+                let decoded_fallback = fallback_clusters.as_ref().map(|clusters| clusters.concat());
+
+                if let Some(choice) = cmap_decisions
+                    .get_choice(font_tounicode_refs.get(current_font).copied().unwrap_or(0))
+                {
+                    let decoded = match choice {
+                        CMapChoice::Primary => primary_clusters.clone(),
+                        CMapChoice::Remapped => remap_clusters.clone(),
+                    };
+                    if !decoded.is_empty() {
+                        return Some(decoded);
+                    }
+                }
+
+                let choice = cmap_decisions.consider(
+                    font_tounicode_refs.get(current_font).copied().unwrap_or(0),
+                    &decoded_primary,
+                    &decoded_remap,
+                    bytes.len(),
+                );
+                let mut decoded = match choice {
+                    Some(CMapChoice::Primary) => primary_clusters,
+                    Some(CMapChoice::Remapped) => remap_clusters,
+                    None => {
+                        if score_text(&decoded_remap) > score_text(&decoded_primary) {
+                            remap_clusters
+                        } else {
+                            primary_clusters
+                        }
+                    }
+                };
+                if let (Some(fb_clusters), Some(fb)) = (fallback_clusters, decoded_fallback) {
+                    let decoded_text = decoded.concat();
+                    let decoded_len = decoded_text.chars().count();
+                    let expected = bytes.len() / 2;
+                    let prefer_fallback = (!fb.is_empty() && decoded_text.is_empty())
+                        || (!fb.is_empty() && expected > 0 && decoded_len * 2 < expected);
+                    if prefer_fallback || score_text(&fb) > score_text(&decoded_text) + 3 {
+                        decoded = fb_clusters;
+                    }
+                }
+                if !decoded.is_empty() {
+                    return Some(decoded);
+                }
+            } else if !primary_clusters.is_empty() {
+                if let Some(fb_clusters) = entry
+                    .fallback
+                    .as_ref()
+                    .map(|c| c.decode_cid_clusters(bytes))
+                {
+                    let fb = fb_clusters.concat();
+                    let decoded_len = decoded_primary.chars().count();
+                    let expected = bytes.len() / 2;
+                    let prefer_fallback = (!fb.is_empty() && decoded_primary.is_empty())
+                        || (!fb.is_empty() && expected > 0 && decoded_len * 2 < expected);
+                    if prefer_fallback || score_text(&fb) > score_text(&decoded_primary) + 3 {
+                        return Some(fb_clusters);
+                    }
+                }
+                return Some(primary_clusters);
+            }
+
+            None
+        };
+
+        if let Some(entry) = inline_cmaps.get(current_font) {
+            if let Some(decoded) = decode_with_entry(entry) {
+                return Some(decoded);
+            }
+        }
+
+        if let Some(&obj_num) = font_tounicode_refs.get(current_font) {
+            if let Some(entry) = font_cmaps.get_by_obj(obj_num) {
+                if let Some(decoded) = decode_with_entry(entry) {
+                    return Some(decoded);
+                }
+            }
+        }
+    }
+
+    extract_text_from_operand(
+        obj,
+        current_font,
+        base_font_name,
+        font_cmaps,
+        font_tounicode_refs,
+        inline_cmaps,
+        font_encodings,
+        encoding_cache,
+        cmap_decisions,
+        font_widths,
+    )
+    .map(|text| vec![text])
+}
+
 /// Fix a known producer bug in "TeXCMMathsSymbols" subset fonts (IntechOpen
 /// and sibling academic pipelines): the Computer Modern symbol glyphs are
 /// misnamed after Latin lookalikes (equal → /onequarter, plus → /thorn, …)

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -265,6 +265,7 @@ fn extract_positioned_text_impl(
         if has_gid_fonts {
             gid_encoded_pages.insert(*page_num);
         }
+        crate::text_utils::normalize_visual_order_arabic_items(&mut items);
         let threshold = crate::text_utils::fix_letterspaced_items(&mut items);
         if threshold > 0.10 {
             page_thresholds.insert(*page_num, threshold);

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -34,17 +34,54 @@ pub(crate) fn is_rtl_char(c: char) -> bool {
         | '\u{07C0}'..='\u{07FF}' // NKo
         | '\u{0800}'..='\u{083F}' // Samaritan
         | '\u{0840}'..='\u{085F}' // Mandaic
+        | '\u{0870}'..='\u{089F}' // Arabic Extended-B
         | '\u{08A0}'..='\u{08FF}' // Arabic Extended-A
+        | '\u{10E60}'..='\u{10E7F}' // Rumi Numeral Symbols
+        | '\u{10EC0}'..='\u{10EFF}' // Arabic Extended-C
+        | '\u{1EC70}'..='\u{1ECBF}' // Indic Siyaq Numbers
+        | '\u{1ED00}'..='\u{1ED4F}' // Ottoman Siyaq Numbers
+        | '\u{1EE00}'..='\u{1EEFF}' // Arabic Mathematical Alphabetic Symbols
         | '\u{FB1D}'..='\u{FB4F}' // Hebrew Presentation Forms
         | '\u{FB50}'..='\u{FDFF}' // Arabic Presentation Forms-A
-        | '\u{FE70}'..='\u{FEFF}' // Arabic Presentation Forms-B
+        | '\u{FE70}'..='\u{FEFE}' // Arabic Presentation Forms-B
     )
 }
 
 fn is_arabic_presentation_form(c: char) -> bool {
-    // U+FEFF is BOM/ZWNJ, not an Arabic presentation form despite falling
-    // in the Presentation Forms-B codepoint range.
+    // U+FEFF is BOM / zero-width no-break, not an Arabic presentation form
+    // despite falling in the Presentation Forms-B codepoint range.
     matches!(c, '\u{FB50}'..='\u{FDFF}' | '\u{FE70}'..='\u{FEFE}')
+}
+
+fn is_arabic_combining_mark(c: char) -> bool {
+    matches!(c,
+        '\u{0610}'..='\u{061A}'
+        | '\u{064B}'..='\u{065F}'
+        | '\u{0670}'
+        | '\u{06D6}'..='\u{06ED}'
+        | '\u{0898}'..='\u{089F}'
+        | '\u{08CA}'..='\u{08FF}'
+    )
+}
+
+fn is_arabic_script_char(c: char) -> bool {
+    matches!(c,
+        '\u{0600}'..='\u{06FF}' // Arabic
+        | '\u{0750}'..='\u{077F}' // Arabic Supplement
+        | '\u{0870}'..='\u{089F}' // Arabic Extended-B
+        | '\u{08A0}'..='\u{08FF}' // Arabic Extended-A
+        | '\u{10E60}'..='\u{10E7F}' // Rumi Numeral Symbols
+        | '\u{10EC0}'..='\u{10EFF}' // Arabic Extended-C
+        | '\u{1EC70}'..='\u{1ECBF}' // Indic Siyaq Numbers
+        | '\u{1ED00}'..='\u{1ED4F}' // Ottoman Siyaq Numbers
+        | '\u{1EE00}'..='\u{1EEFF}' // Arabic Mathematical Alphabetic Symbols
+        | '\u{FB50}'..='\u{FDFF}' // Arabic Presentation Forms-A
+        | '\u{FE70}'..='\u{FEFE}' // Arabic Presentation Forms-B
+    )
+}
+
+fn is_arabic_token_char(c: char) -> bool {
+    is_arabic_script_char(c) && (c.is_alphabetic() || is_arabic_combining_mark(c))
 }
 
 pub(crate) fn is_rtl_text<I, S>(texts: I) -> bool
@@ -136,7 +173,7 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
     let had_presentation_forms = text.chars().any(is_arabic_presentation_form);
 
     // Apply NFKC normalization only when Arabic presentation forms are present.
-    // This converts forms (U+FB50-FDFF, U+FE70-FEFF) back to base Arabic
+    // This converts forms (U+FB50-FDFF, U+FE70-FEFE) back to base Arabic
     // (U+0600-06FF). We avoid broad NFKC on all non-ASCII text because it
     // would convert NBSP (U+00A0) to regular space, breaking downstream logic.
     // Latin ligatures are already handled by the explicit match arms below.
@@ -174,8 +211,9 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
 
     // If the original text had Arabic presentation forms, the characters are in
     // visual (LTR screen) order. After NFKC normalization, reverse to restore
-    // logical reading order.
-    if had_presentation_forms {
+    // logical reading order. Strong base-Arabic visual-order spans are handled
+    // here; short clue-less runs are handled later with page context.
+    if had_presentation_forms || looks_like_visual_order_base_arabic(&result) {
         result = reverse_visual_arabic(&result);
     }
 
@@ -188,29 +226,27 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
 /// Mixed content (embedded numbers or Latin words) splits into LTR and non-LTR
 /// runs: run order is reversed, and only non-LTR runs are reversed internally.
 fn reverse_visual_arabic(text: &str) -> String {
-    // Check if there are any LTR runs (ASCII letters or digits)
-    let has_ltr = text.chars().any(|c| c.is_ascii_alphanumeric());
+    // Check if there are any LTR runs (Latin letters or digits). Arabic-Indic
+    // digits are weak bidi characters but their internal order should stay LTR.
+    let has_ltr = text.chars().any(is_visual_ltr_base_char);
 
     if !has_ltr {
-        // Pure RTL: simple reversal
-        return text.chars().rev().collect();
+        return reverse_rtl_run(text);
     }
 
-    // Mixed content: split into runs of LTR (ASCII alphanumeric + adjacent
+    // Mixed content: split into runs of LTR (Latin/numeric + adjacent
     // punctuation like '.', ',', '/', '-') vs non-LTR (Arabic + spaces + other).
     let chars: Vec<char> = text.chars().collect();
     let mut runs: Vec<(bool, String)> = Vec::new(); // (is_ltr, content)
 
     let mut i = 0;
     while i < chars.len() {
-        let is_ltr = chars[i].is_ascii_alphanumeric()
-            || (chars[i].is_ascii_punctuation() && is_adjacent_to_ascii_alnum(&chars, i));
+        let is_ltr = is_visual_ltr_run_char(&chars, i);
 
         let mut run = String::new();
         while i < chars.len() {
             let c = chars[i];
-            let c_is_ltr = c.is_ascii_alphanumeric()
-                || (c.is_ascii_punctuation() && is_adjacent_to_ascii_alnum(&chars, i));
+            let c_is_ltr = is_visual_ltr_run_char(&chars, i);
             if c_is_ltr != is_ltr {
                 break;
             }
@@ -227,16 +263,266 @@ fn reverse_visual_arabic(text: &str) -> String {
         if *is_ltr {
             result.push_str(content);
         } else {
-            result.extend(content.chars().rev());
+            result.push_str(&reverse_rtl_run(content));
         }
     }
     result
 }
 
-/// Check if the character at `idx` is adjacent to an ASCII alphanumeric character.
-fn is_adjacent_to_ascii_alnum(chars: &[char], idx: usize) -> bool {
-    (idx > 0 && chars[idx - 1].is_ascii_alphanumeric())
-        || (idx + 1 < chars.len() && chars[idx + 1].is_ascii_alphanumeric())
+fn reverse_rtl_run(text: &str) -> String {
+    let mut clusters: Vec<String> = Vec::new();
+    for c in text.chars() {
+        if is_arabic_combining_mark(c) {
+            if let Some(last) = clusters.last_mut() {
+                last.push(c);
+            } else {
+                clusters.push(c.to_string());
+            }
+        } else {
+            clusters.push(c.to_string());
+        }
+    }
+    clusters.reverse();
+    clusters.concat()
+}
+
+fn is_visual_ltr_base_char(c: char) -> bool {
+    c.is_numeric()
+        || c.is_ascii_alphabetic()
+        || (c.is_alphabetic() && !is_rtl_char(c) && !is_cjk_char(c))
+}
+
+fn is_visual_ltr_punctuation(c: char) -> bool {
+    c.is_ascii_punctuation() || matches!(c, '\u{066B}' | '\u{066C}')
+}
+
+fn is_visual_ltr_run_char(chars: &[char], idx: usize) -> bool {
+    is_visual_ltr_base_char(chars[idx])
+        || (is_visual_ltr_punctuation(chars[idx]) && is_adjacent_to_ltr_base(chars, idx))
+}
+
+fn is_adjacent_to_ltr_base(chars: &[char], idx: usize) -> bool {
+    (idx > 0 && is_visual_ltr_base_char(chars[idx - 1]))
+        || (idx + 1 < chars.len() && is_visual_ltr_base_char(chars[idx + 1]))
+}
+
+fn is_no_space_before_punctuation(c: char) -> bool {
+    matches!(
+        c,
+        '.' | ','
+            | ';'
+            | '!'
+            | '?'
+            | ')'
+            | ']'
+            | '}'
+            | '\''
+            | '%'
+            | '\u{060C}' // Arabic comma
+            | '\u{061B}' // Arabic semicolon
+            | '\u{061F}' // Arabic question mark
+            | '\u{066A}' // Arabic percent sign
+            | '\u{066B}' // Arabic decimal separator
+            | '\u{066C}' // Arabic thousands separator
+            | '\u{06D4}' // Arabic full stop
+    )
+}
+
+pub(crate) fn normalize_visual_order_arabic_items(items: &mut [TextItem]) {
+    if !page_looks_like_visual_order_base_arabic(items) {
+        return;
+    }
+
+    for item in items.iter_mut() {
+        if !matches!(item.item_type, crate::types::ItemType::Text) {
+            continue;
+        }
+        if should_reverse_base_arabic_item_on_visual_page(&item.text) {
+            item.text = reverse_visual_arabic(&item.text);
+        }
+    }
+}
+
+fn page_looks_like_visual_order_base_arabic(items: &[TextItem]) -> bool {
+    let mut visual_score = 0u32;
+    let mut logical_score = 0u32;
+    let mut arabic_items = 0u32;
+
+    for item in items {
+        if !matches!(item.item_type, crate::types::ItemType::Text) {
+            continue;
+        }
+        let arabic_alpha = item
+            .text
+            .chars()
+            .filter(|&c| is_arabic_token_char(c))
+            .count();
+        if arabic_alpha < 2 || !is_rtl_text(std::iter::once(item.text.as_str())) {
+            continue;
+        }
+        arabic_items += 1;
+        let (visual, logical) = visual_logical_arabic_scores(&item.text);
+        visual_score += visual;
+        logical_score += logical;
+    }
+
+    arabic_items >= 3 && visual_score >= 6 && visual_score > logical_score
+}
+
+fn should_reverse_base_arabic_item_on_visual_page(text: &str) -> bool {
+    let arabic_alpha = text.chars().filter(|&c| is_arabic_token_char(c)).count();
+    if arabic_alpha < 2 || !is_rtl_text(std::iter::once(text)) {
+        return false;
+    }
+
+    let (visual_score, logical_score) = visual_logical_arabic_scores(text);
+    logical_score == 0 || visual_score > logical_score
+}
+
+fn looks_like_visual_order_base_arabic(text: &str) -> bool {
+    let arabic_alpha = text.chars().filter(|&c| is_arabic_token_char(c)).count();
+    if arabic_alpha < 4 || !is_rtl_text(std::iter::once(text)) {
+        return false;
+    }
+    let (visual_score, logical_score) = visual_logical_arabic_scores(text);
+    visual_score >= 2 && visual_score > logical_score
+}
+
+fn visual_logical_arabic_scores(text: &str) -> (u32, u32) {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for c in text.chars() {
+        if is_arabic_token_char(c) {
+            current.push(c);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    visual_logical_arabic_token_scores(tokens)
+}
+
+fn visual_logical_arabic_token_scores(tokens: Vec<String>) -> (u32, u32) {
+    let mut visual_score = 0;
+    let mut logical_score = 0;
+    for token in tokens {
+        let normalized = strip_arabic_combining_marks(&token);
+        let len = normalized.chars().count();
+        if len >= 4 {
+            if has_logical_arabic_article_prefix(&normalized) {
+                logical_score += 2;
+            }
+            if has_visual_arabic_article_suffix(&normalized) {
+                visual_score += 2;
+            }
+        }
+        if is_common_logical_arabic_token(&normalized) {
+            logical_score += 3;
+        }
+        if is_common_visual_arabic_token(&normalized) {
+            visual_score += 3;
+        }
+    }
+    (visual_score, logical_score)
+}
+
+fn has_logical_arabic_article_prefix(token: &str) -> bool {
+    [
+        "ال", "الأ", "الإ", "وال", "فالأ", "بال", "بالأ", "كال", "كالأ", "لل",
+    ]
+    .iter()
+    .any(|prefix| token.starts_with(prefix) && token.chars().count() > prefix.chars().count())
+}
+
+fn has_visual_arabic_article_suffix(token: &str) -> bool {
+    ["لا", "لأا", "لإا", "لاو", "لأاف", "لاب", "لأاب", "لاك", "لأاك"]
+        .iter()
+        .any(|suffix| token.ends_with(suffix) && token.chars().count() > suffix.chars().count())
+}
+
+fn strip_arabic_combining_marks(text: &str) -> String {
+    text.chars()
+        .filter(|&c| !is_arabic_combining_mark(c))
+        .collect()
+}
+
+fn is_common_logical_arabic_token(token: &str) -> bool {
+    matches!(
+        token,
+        "في" | "من"
+            | "على"
+            | "إلى"
+            | "الى"
+            | "عن"
+            | "أن"
+            | "إن"
+            | "هو"
+            | "هي"
+            | "هذا"
+            | "ذلك"
+            | "الذي"
+            | "التي"
+            | "بسم"
+            | "الله"
+            | "الرحمن"
+            | "الرحيم"
+            | "الحمد"
+            | "الكتاب"
+            | "الفقه"
+            | "أصول"
+            | "اصول"
+            | "الأنوار"
+            | "الانوار"
+            | "المنار"
+            | "متن"
+    )
+}
+
+fn is_common_visual_arabic_token(token: &str) -> bool {
+    matches!(
+        token,
+        "يف" | "نم"
+            | "ىلع"
+            | "ىلإ"
+            | "ىلا"
+            | "نع"
+            | "نأ"
+            | "نإ"
+            | "وه"
+            | "يه"
+            | "اذه"
+            | "كلذ"
+            | "يذلا"
+            | "يتلا"
+            | "مسب"
+            | "للها"
+            | "هللا"
+            | "نمحرلا"
+            | "ميحرلا"
+            | "دمحلا"
+            | "باتكلا"
+            | "هقفلا"
+            | "لوصأ"
+            | "لوصا"
+            | "راونألا"
+            | "راونلأا"
+            | "راونالا"
+            | "رانملا"
+            | "نتم"
+            | "تايوتحملا"
+            | "ةلماشلا"
+            | "ةبتكملا"
+            | "فلؤملا"
+            | "ردصملا"
+            | "لولاا"
+            | "لوألا"
+            | "نياثلا"
+            | "ثلاثلا"
+            | "عبارلا"
+            | "عاونأ"
+    )
 }
 
 /// Decode a PDF text string (ActualText, etc.) that may be UTF-16BE (BOM \xFE\xFF)
@@ -558,7 +844,7 @@ pub(crate) fn should_join_items(
     // Always join if current starts with punctuation that typically follows without space
     // e.g., "www" + ".com" → "www.com", not "www .com"
     if let Some(c) = curr_first {
-        if matches!(c, '.' | ',' | ';' | '!' | '?' | ')' | ']' | '}' | '\'') {
+        if is_no_space_before_punctuation(c) {
             return true;
         }
     }
@@ -846,6 +1132,39 @@ mod tests {
     }
 
     #[test]
+    fn no_reversal_for_logical_base_arabic_common_words() {
+        let input = "بسم الله الرحمن الرحيم";
+        let result = expand_ligatures(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn reverse_visual_order_base_arabic_common_words() {
+        let mut items = vec![
+            make_text_item("يفسنلا تاكربلا وبأ", 300.0, 120.0, 12.0),
+            make_text_item("هوجو", 250.0, 30.0, 12.0),
+            make_text_item("ةنسلاو", 200.0, 40.0, 12.0),
+        ];
+        normalize_visual_order_arabic_items(&mut items);
+        assert_eq!(items[0].text, "أبو البركات النسفي");
+        assert_eq!(items[1].text, "وجوه");
+        assert_eq!(items[2].text, "والسنة");
+    }
+
+    #[test]
+    fn reverse_visual_order_base_arabic_with_arabic_indic_digits() {
+        let mut items = vec![
+            make_text_item("٢٠٢١-٠٣-١٧ :ينمزلا عباطلا", 300.0, 180.0, 12.0),
+            make_text_item("راونألا رانم", 300.0, 90.0, 12.0),
+            make_text_item("ةلماشلا ةبتكملا", 300.0, 90.0, 12.0),
+        ];
+        normalize_visual_order_arabic_items(&mut items);
+        assert_eq!(items[0].text, "الطابع الزمني: ٢٠٢١-٠٣-١٧");
+        assert_eq!(items[1].text, "منار الأنوار");
+        assert_eq!(items[2].text, "المكتبة الشاملة");
+    }
+
+    #[test]
     fn latin_text_unaffected() {
         assert_eq!(expand_ligatures("Hello World"), "Hello World");
     }
@@ -870,6 +1189,20 @@ mod tests {
     }
 
     #[test]
+    fn reverse_visual_arabic_keeps_arabic_indic_digits() {
+        let input = "\u{0623}\u{0661}\u{0662}\u{0663}\u{0628}";
+        let result = reverse_visual_arabic(input);
+        assert_eq!(result, "\u{0628}\u{0661}\u{0662}\u{0663}\u{0623}");
+    }
+
+    #[test]
+    fn reverse_visual_arabic_preserves_diacritic_clusters() {
+        let input = "\u{0628}\u{064E}\u{0627}";
+        let result = reverse_visual_arabic(input);
+        assert_eq!(result, "\u{0627}\u{0628}\u{064E}");
+    }
+
+    #[test]
     fn arabic_presentation_form_detection() {
         // Presentation Forms-A range
         assert!(is_arabic_presentation_form('\u{FB50}'));
@@ -882,6 +1215,26 @@ mod tests {
         assert!(!is_arabic_presentation_form('\u{0645}'));
         // Latin
         assert!(!is_arabic_presentation_form('A'));
+    }
+
+    #[test]
+    fn rtl_detection_covers_modern_arabic_blocks() {
+        assert!(is_rtl_char('\u{0870}')); // Arabic Extended-B
+        assert!(is_rtl_char('\u{10EC0}')); // Arabic Extended-C
+        assert!(is_rtl_char('\u{1EE00}')); // Arabic Mathematical Alphabetic Symbols
+        assert!(!is_rtl_char('\u{FEFF}')); // BOM, not Arabic text
+    }
+
+    #[test]
+    fn joins_before_arabic_punctuation() {
+        let word = make_text_item(
+            "\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}",
+            100.0,
+            40.0,
+            12.0,
+        );
+        let comma = make_text_item("\u{060C}", 143.0, 3.0, 12.0);
+        assert!(should_join_items(&word, &comma, 0.10));
     }
 
     /// Helper to create a single-char TextItem at a given x position with width.

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -84,6 +84,13 @@ fn is_arabic_token_char(c: char) -> bool {
     is_arabic_script_char(c) && (c.is_alphabetic() || is_arabic_combining_mark(c))
 }
 
+fn is_arabic_alef(c: char) -> bool {
+    matches!(
+        c,
+        '\u{0622}' | '\u{0623}' | '\u{0625}' | '\u{0627}' | '\u{0671}'
+    )
+}
+
 pub(crate) fn is_rtl_text<I, S>(texts: I) -> bool
 where
     I: Iterator<Item = S>,
@@ -150,12 +157,71 @@ pub fn is_italic_font(font_name: &str) -> bool {
         || lower.contains("kursiv") // German for italic
 }
 
+#[derive(Clone, Copy)]
+enum VisualOrderMode {
+    Auto,
+    Preserve,
+    ReversedChars,
+}
+
 /// Expand Unicode ligature characters to their component characters.
 /// This makes extracted text more searchable and semantically correct.
 /// Also applies NFKC normalization (converts Arabic presentation forms to base
 /// characters, decomposes Latin ligatures, etc.) and reverses visual-order
 /// Arabic text back to logical order when presentation forms are detected.
 pub(crate) fn expand_ligatures(text: &str) -> String {
+    expand_ligatures_impl(text, VisualOrderMode::Auto)
+}
+
+/// Normalize ligatures/control characters without changing character order.
+///
+/// PDF `/ActualText` entries are replacement text supplied by the producer;
+/// inside browser-generated `/ReversedChars` spans these replacements are
+/// already logical glyph clusters and must not be reversed independently.
+pub(crate) fn expand_ligatures_preserving_order(text: &str) -> String {
+    expand_ligatures_impl(text, VisualOrderMode::Preserve)
+}
+
+/// Normalize text emitted inside a PDF `/ReversedChars` marked-content span.
+///
+/// In Chrome/Edge generated RTL PDFs, many raw glyph chunks are visual-order
+/// fragments. Chunks containing spaces need local reversal so word separators
+/// move to the logical side before line-level RTL item ordering runs.
+pub(crate) fn expand_ligatures_in_reversed_chars(text: &str) -> String {
+    expand_ligatures_impl(text, VisualOrderMode::ReversedChars)
+}
+
+pub(crate) fn expand_ligatures_in_reversed_char_clusters(clusters: &[String]) -> String {
+    if clusters.is_empty() {
+        return String::new();
+    }
+
+    let clusters: Vec<String> = clusters
+        .iter()
+        .map(|cluster| expand_ligatures_preserving_order(cluster))
+        .collect();
+
+    if clusters.len() == 1 {
+        return clusters.concat();
+    }
+
+    let has_rtl = clusters
+        .iter()
+        .flat_map(|cluster| cluster.chars())
+        .any(is_rtl_char);
+    let has_ltr_alpha = clusters
+        .iter()
+        .flat_map(|cluster| cluster.chars())
+        .any(|c| c.is_alphabetic() && !is_rtl_char(c) && !is_cjk_char(c));
+
+    if !has_rtl && has_ltr_alpha {
+        return clusters.concat();
+    }
+
+    reverse_visual_clusters(&clusters)
+}
+
+fn expand_ligatures_impl(text: &str, visual_order_mode: VisualOrderMode) -> String {
     // Strip null bytes and other control characters (except newline/tab)
     let text = if text
         .bytes()
@@ -213,11 +279,41 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
     // visual (LTR screen) order. After NFKC normalization, reverse to restore
     // logical reading order. Strong base-Arabic visual-order spans are handled
     // here; short clue-less runs are handled later with page context.
-    if had_presentation_forms || looks_like_visual_order_base_arabic(&result) {
+    let should_reverse = match visual_order_mode {
+        VisualOrderMode::Auto => {
+            had_presentation_forms || looks_like_visual_order_base_arabic(&result)
+        }
+        VisualOrderMode::Preserve => false,
+        VisualOrderMode::ReversedChars => {
+            had_presentation_forms
+                || looks_like_visual_order_base_arabic(&result)
+                || reversed_chars_fragment_needs_reversal(&result)
+        }
+    };
+
+    if should_reverse {
         result = reverse_visual_arabic(&result);
     }
 
     result
+}
+
+fn reversed_chars_fragment_needs_reversal(text: &str) -> bool {
+    if !text.chars().any(char::is_whitespace) {
+        return false;
+    }
+    if text.trim().is_empty() {
+        return false;
+    }
+
+    let has_rtl = text.chars().any(is_rtl_char);
+    let has_ltr_alpha = text
+        .chars()
+        .any(|c| c.is_alphabetic() && !is_rtl_char(c) && !is_cjk_char(c));
+
+    // Keep embedded LTR phrases such as "Open AI" in their own order, but
+    // still flip separators around Arabic, numbers, and punctuation fragments.
+    has_rtl || !has_ltr_alpha
 }
 
 /// Reverse visual-order Arabic text to logical order.
@@ -304,6 +400,57 @@ fn is_visual_ltr_run_char(chars: &[char], idx: usize) -> bool {
 fn is_adjacent_to_ltr_base(chars: &[char], idx: usize) -> bool {
     (idx > 0 && is_visual_ltr_base_char(chars[idx - 1]))
         || (idx + 1 < chars.len() && is_visual_ltr_base_char(chars[idx + 1]))
+}
+
+fn reverse_visual_clusters(clusters: &[String]) -> String {
+    let has_ltr = clusters.iter().any(|cluster| {
+        cluster
+            .chars()
+            .any(|c| is_visual_ltr_base_char(c) || is_visual_ltr_punctuation(c))
+    });
+
+    if !has_ltr {
+        return clusters.iter().rev().cloned().collect::<Vec<_>>().concat();
+    }
+
+    let mut runs: Vec<(bool, Vec<&String>)> = Vec::new();
+    let mut i = 0;
+    while i < clusters.len() {
+        let is_ltr = is_visual_ltr_cluster(clusters, i);
+        let mut run = Vec::new();
+        while i < clusters.len() && is_visual_ltr_cluster(clusters, i) == is_ltr {
+            run.push(&clusters[i]);
+            i += 1;
+        }
+        runs.push((is_ltr, run));
+    }
+
+    runs.reverse();
+    let mut result = String::new();
+    for (is_ltr, run) in runs {
+        if is_ltr {
+            for cluster in run {
+                result.push_str(cluster);
+            }
+        } else {
+            for cluster in run.into_iter().rev() {
+                result.push_str(cluster);
+            }
+        }
+    }
+    result
+}
+
+fn is_visual_ltr_cluster(clusters: &[String], idx: usize) -> bool {
+    let cluster = &clusters[idx];
+    cluster.chars().any(is_visual_ltr_base_char)
+        || (cluster.chars().any(is_visual_ltr_punctuation)
+            && is_cluster_adjacent_to_ltr_base(clusters, idx))
+}
+
+fn is_cluster_adjacent_to_ltr_base(clusters: &[String], idx: usize) -> bool {
+    (idx > 0 && clusters[idx - 1].chars().any(is_visual_ltr_base_char))
+        || (idx + 1 < clusters.len() && clusters[idx + 1].chars().any(is_visual_ltr_base_char))
 }
 
 fn is_no_space_before_punctuation(c: char) -> bool {
@@ -899,6 +1046,31 @@ pub(crate) fn should_join_items(
             return false;
         }
 
+        // Browser-generated RTL text often alternates one-glyph ActualText
+        // spans with short raw glyph fragments. Their measured widths can be
+        // zero or slightly negative, so the generic single/multi thresholds
+        // sometimes create spaces inside Arabic words ("ع ليكم", "عر بية").
+        if let (Some(p), Some(c)) = (prev_last_char, curr_first_char) {
+            let prev_chars = prev_item.text.trim().chars().count();
+            let curr_chars = curr_item.text.trim().chars().count();
+            if is_rtl_char(p) && is_rtl_char(c) {
+                let curr_width = curr_item.width.abs();
+                let rtl_gap = if prev_item.x > curr_item.x {
+                    prev_item.x - (curr_item.x + curr_width)
+                } else {
+                    curr_item.x - (prev_item.x + prev_item.width.abs())
+                };
+                if rtl_gap > -font_size * 0.15 && rtl_gap < font_size * 0.35 {
+                    if (is_arabic_alef(p) && c == '\u{0644}') || c == '\u{0629}' {
+                        return true;
+                    }
+                    if prev_chars == 1 && (2..=3).contains(&curr_chars) {
+                        return true;
+                    }
+                }
+            }
+        }
+
         // Numeric continuity: digits, commas, periods, and percent signs that
         // are positioned close together are almost always a single number.
         // e.g., "34,20" + "8" → "34,208", "+13." + "0" + "%" → "+13.0%"
@@ -1203,6 +1375,49 @@ mod tests {
     }
 
     #[test]
+    fn reversed_chars_fragments_move_visual_spaces_to_logical_side() {
+        assert_eq!(expand_ligatures_in_reversed_chars(" م"), "م ");
+        assert_eq!(expand_ligatures_in_reversed_chars("رو م"), "م ور");
+        assert_eq!(expand_ligatures_in_reversed_chars(" ."), ". ");
+    }
+
+    #[test]
+    fn reversed_chars_clusters_reverse_glyph_order_not_cluster_text() {
+        let two_glyphs = vec!["ر".to_string(), "د".to_string()];
+        assert_eq!(
+            expand_ligatures_in_reversed_char_clusters(&two_glyphs),
+            "در"
+        );
+
+        let one_cluster = vec!["بي".to_string()];
+        assert_eq!(
+            expand_ligatures_in_reversed_char_clusters(&one_cluster),
+            "بي"
+        );
+    }
+
+    #[test]
+    fn reversed_chars_clusters_move_spaces_without_reversing_digits() {
+        let clusters = vec![" ".to_string(), "م".to_string(), "و".to_string()];
+        assert_eq!(expand_ligatures_in_reversed_char_clusters(&clusters), "وم ");
+
+        let numeric = vec![" ".to_string(), "25".to_string()];
+        assert_eq!(expand_ligatures_in_reversed_char_clusters(&numeric), "25 ");
+    }
+
+    #[test]
+    fn reversed_chars_preserves_ltr_phrases_but_moves_numeric_separators() {
+        assert_eq!(expand_ligatures_in_reversed_chars("Open AI"), "Open AI");
+        assert_eq!(expand_ligatures_in_reversed_chars(" 25"), "25 ");
+    }
+
+    #[test]
+    fn actual_text_preserving_order_keeps_arabic_ligature_expansions() {
+        assert_eq!(expand_ligatures_preserving_order("لا"), "لا");
+        assert_eq!(expand_ligatures_preserving_order("الله"), "الله");
+    }
+
+    #[test]
     fn arabic_presentation_form_detection() {
         // Presentation Forms-A range
         assert!(is_arabic_presentation_form('\u{FB50}'));
@@ -1235,6 +1450,25 @@ mod tests {
         );
         let comma = make_text_item("\u{060C}", 143.0, 3.0, 12.0);
         assert!(should_join_items(&word, &comma, 0.10));
+    }
+
+    #[test]
+    fn joins_short_rtl_fragments_without_collapsing_long_word_boundaries() {
+        let ain = make_text_item("ع", 511.70, 7.09, 13.5);
+        let lam_yeh = make_text_item("لي", 508.90, 0.0, 13.5);
+        assert!(should_join_items(&ain, &lam_yeh, 0.10));
+
+        let ta_marbuta = make_text_item("ة", 334.28, 5.06, 13.5);
+        let next_word = make_text_item("بالل", 327.25, -5.89, 13.5);
+        assert!(!should_join_items(&ta_marbuta, &next_word, 0.10));
+
+        let alef = make_text_item("ا", 518.26, 6.53, 13.5);
+        let lam = make_text_item("ل", 515.46, 2.79, 13.5);
+        assert!(should_join_items(&alef, &lam, 0.10));
+
+        let final_lam = make_text_item("ل", 405.0, 2.79, 13.5);
+        let final_ta_marbuta = make_text_item("ة", 401.0, 5.06, 13.5);
+        assert!(should_join_items(&final_lam, &final_ta_marbuta, 0.10));
     }
 
     /// Helper to create a single-char TextItem at a given x position with width.

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -449,7 +449,16 @@ impl ToUnicodeCMap {
 
     /// Decode a byte slice to a Unicode string, respecting the CMap's code byte width
     pub fn decode_cids(&self, bytes: &[u8]) -> String {
-        let mut result = String::new();
+        self.decode_cid_clusters(bytes).concat()
+    }
+
+    /// Decode a byte slice to Unicode clusters, one output string per source code.
+    ///
+    /// A single glyph code may map to multiple Unicode scalar values. Keeping
+    /// those mappings as clusters lets RTL visual-order correction reverse
+    /// glyph order without transposing multi-character glyph expansions.
+    pub fn decode_cid_clusters(&self, bytes: &[u8]) -> Vec<String> {
+        let mut result = Vec::new();
         let mut unmapped_count = 0usize;
 
         if self.code_byte_length == 1 {
@@ -457,12 +466,12 @@ impl ToUnicodeCMap {
             for &b in bytes {
                 let code = b as u16;
                 match self.lookup(code) {
-                    Some(s) if !s.contains('\u{FFFD}') => result.push_str(&s),
+                    Some(s) if !s.contains('\u{FFFD}') => result.push(s),
                     _ => {
                         // For single-byte unmapped codes, try as Latin-1
                         // (the byte IS the character code in most legacy encodings)
                         if b >= 0x20 {
-                            result.push(b as char);
+                            result.push((b as char).to_string());
                         }
                         unmapped_count += 1;
                     }
@@ -474,7 +483,7 @@ impl ToUnicodeCMap {
                 if chunk.len() == 2 {
                     let cid = u16::from_be_bytes([chunk[0], chunk[1]]);
                     match self.lookup(cid) {
-                        Some(s) if !s.contains('\u{FFFD}') => result.push_str(&s),
+                        Some(s) if !s.contains('\u{FFFD}') => result.push(s),
                         _ => {
                             if self.cid_passthrough {
                                 // Last-resort: treat CID as Unicode codepoint.
@@ -482,7 +491,7 @@ impl ToUnicodeCMap {
                                 // used Unicode values as CIDs but stripped the cmap.
                                 if let Some(ch) = char::from_u32(cid as u32) {
                                     if !ch.is_control() || ch == '\t' || ch == '\n' {
-                                        result.push(ch);
+                                        result.push(ch.to_string());
                                     } else {
                                         unmapped_count += 1;
                                     }
@@ -508,7 +517,7 @@ impl ToUnicodeCMap {
             bytes.len() / 2
         };
         if total > 0 && unmapped_count > total / 2 {
-            return String::new();
+            return Vec::new();
         }
 
         result


### PR DESCRIPTION
## Summary

- Expand Arabic/RTL Unicode coverage, including newer Arabic blocks and Arabic mathematical symbols.
- Normalize Arabic presentation-form text back to logical order while preserving combining marks and Arabic-Indic digit runs.
- Add conservative visual-order normalization for base Arabic text items.
- Join Arabic punctuation without adding an unwanted space.

## Notes

This improves Arabic support for native-text PDFs. It does not add an OCR engine. Scanned or image-backed Arabic PDFs are still routed through the existing `pages_needing_ocr` flow so callers can use an external OCR pipeline.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cargo build --release`
- Manually tested Arabic PDFs in `temp/`; clean native-text Arabic improved, scanned PDFs still correctly require OCR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254178&installation_model_id=11126&pr_number=207&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F207&signature=3427fb240b7223c819307ed1d9893aee7cb3e0ad36c4ebe1dce564e62b1b76ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Arabic RTL text extraction with cluster-aware reversal and support for browser `/ReversedChars` spans, producing correct logical order without breaking ligature expansions or digits. Native-text PDFs improve; scanned PDFs still go through the existing OCR path.

- **New Features**
  - Detect `/ReversedChars` marked-content spans and reverse visual-order glyph clusters to logical order; preserve multi‑char glyph mappings, diacritics, and keep Arabic‑Indic digits LTR.
  - Add cluster-aware CMap decoding for `Tj/TJ`, and expand ligatures while preserving order for `/ActualText`.
  - Page-level heuristic `normalize_visual_order_arabic_items` flips base‑Arabic visual‑order lines early (before letter‑spacing fixes).
  - Expand RTL ranges (Arabic Extended‑B/C, Arabic Mathematical symbols, Siyaq numbers, Rumi numerals); exclude U+FEFF from presentation forms.
  - Improve spacing: join before Arabic punctuation and reduce spurious spaces inside Arabic words in browser PDFs; tests cover `/ReversedChars`, digits, diacritics, and punctuation joins.

<sup>Written for commit 4cd0b35a74f80a742d7a2cdfdd6eefca21bcd78f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

