### PR TITLE
fix(tounicode): skip subset GID remap for CIDFontType0 (CFF) descendants

### DIFF
--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -880,6 +880,22 @@ fn try_remap_subset_cmap(
         None => return (cmap, None),
     };
 
+    // Both repair paths below assume CIDs are glyph indices that a subsetter can
+    // renumber, which is only true for CIDFontType2 (TrueType). For CIDFontType0
+    // (CFF), CIDs are resolved through the CFF charset, so a valid CMap stays valid
+    // after subsetting and renumbering it corrupts otherwise-correct text.
+    // CIDToGIDMap is likewise CIDFontType2-only (PDF 32000-1:2008, 9.7.4.2), so this
+    // also ignores a CIDToGIDMap that a malformed producer attached to a CFF font.
+    let is_cid_font_type2 = cid_font_dict
+        .get(b"Subtype")
+        .ok()
+        .and_then(|o| o.as_name().ok())
+        .is_some_and(|n| n == b"CIDFontType2");
+    if !is_cid_font_type2 {
+        debug!("Subset remap skipped for obj={obj_num}: not a CIDFontType2 descendant");
+        return (cmap, None);
+    }
+
     // If there's an explicit CIDToGIDMap, build a repaired CMap using it.
     if let Some(cid_to_gid) = get_cid_to_gid_map(cid_font_dict, doc) {
         if let Some(repaired) = build_cmap_with_cid_to_gid_map(&cmap, &cid_to_gid) {
@@ -3093,6 +3109,7 @@ endbfrange
         // Build a CIDFont dict with Identity CIDToGIDMap and a W array that
         // covers CID 633 via `597 [widths...]`.
         let mut cid_font = lopdf::Dictionary::new();
+        cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType2".to_vec()));
         cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
         cid_font.set(
             "W",
@@ -3136,6 +3153,7 @@ endbfrange
 
         let mut doc = Document::new();
         let mut cid_font = lopdf::Dictionary::new();
+        cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType2".to_vec()));
         cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
         cid_font.set(
             "W",
@@ -3158,5 +3176,53 @@ endbfrange
             remapped.is_some(),
             "Remap must fire when CMap's CIDs are outside W array coverage"
         );
+    }
+
+    #[test]
+    fn test_try_remap_skipped_for_cid_font_type0() {
+        // Same W/CMap mismatch as the CIDFontType2 case above, but the descendant is
+        // CIDFontType0 (CFF). There CIDs are resolved through the CFF charset, so the
+        // ToUnicode CIDs stay valid after subsetting and must not be renumbered.
+        // Real-world case: Japanese Adobe-Japan1 PDFs (e.g. National Diet Library
+        // minutes) where remapping turned correct text into unrelated glyphs.
+        let cmap_content = r#"
+1 begincodespacerange
+<0000><FFFF>
+endcodespacerange
+1 beginbfrange
+<0200> <0220> <0410>
+endbfrange
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        let mut doc = Document::new();
+        let mut cid_font = lopdf::Dictionary::new();
+        cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType0".to_vec()));
+        // CIDToGIDMap is CIDFontType2-only, but a malformed producer can still emit
+        // it on a CFF font. It must not be used to rewrite the CMap either.
+        cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
+        cid_font.set(
+            "W",
+            lopdf::Object::Array(vec![
+                lopdf::Object::Integer(1),
+                lopdf::Object::Array(vec![lopdf::Object::Integer(500); 34]),
+            ]),
+        );
+        let cid_font_id = doc.add_object(cid_font);
+
+        let mut font_dict = lopdf::Dictionary::new();
+        font_dict.set("Encoding", lopdf::Object::Name(b"Identity-H".to_vec()));
+        font_dict.set(
+            "DescendantFonts",
+            lopdf::Object::Array(vec![lopdf::Object::Reference(cid_font_id)]),
+        );
+
+        let (primary, remapped) = try_remap_subset_cmap(cmap, &font_dict, &doc, 789);
+        assert!(
+            remapped.is_none(),
+            "Remap must be skipped for CIDFontType0 (CFF) descendants"
+        );
+        // The original CMap must still resolve its own CIDs.
+        assert_eq!(primary.lookup(0x0200), Some("\u{0410}".to_string()));
     }
 }

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -886,13 +886,16 @@ fn try_remap_subset_cmap(
     // after subsetting and renumbering it corrupts otherwise-correct text.
     // CIDToGIDMap is likewise CIDFontType2-only (PDF 32000-1:2008, 9.7.4.2), so this
     // also ignores a CIDToGIDMap that a malformed producer attached to a CFF font.
-    let is_cid_font_type2 = cid_font_dict
-        .get(b"Subtype")
-        .ok()
-        .and_then(|o| o.as_name().ok())
-        .is_some_and(|n| n == b"CIDFontType2");
-    if !is_cid_font_type2 {
-        debug!("Subset remap skipped for obj={obj_num}: not a CIDFontType2 descendant");
+    // /Subtype may be an indirect reference, so resolve it through the document.
+    // Only bail out when the descendant is *explicitly* something other than
+    // CIDFontType2: a missing or unresolvable /Subtype keeps the previous
+    // behaviour rather than silently disabling the repair.
+    let subtype = cid_font_dict.get(b"Subtype").ok().and_then(|o| match o {
+        Object::Reference(r) => doc.get_object(*r).ok().and_then(|o| o.as_name().ok()),
+        other => other.as_name().ok(),
+    });
+    if subtype.is_some_and(|name| name != b"CIDFontType2") {
+        debug!("Subset remap skipped for obj={obj_num}: descendant is not CIDFontType2");
         return (cmap, None);
     }
 
@@ -3109,7 +3112,6 @@ endbfrange
         // Build a CIDFont dict with Identity CIDToGIDMap and a W array that
         // covers CID 633 via `597 [widths...]`.
         let mut cid_font = lopdf::Dictionary::new();
-        cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType2".to_vec()));
         cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
         cid_font.set(
             "W",
@@ -3153,7 +3155,6 @@ endbfrange
 
         let mut doc = Document::new();
         let mut cid_font = lopdf::Dictionary::new();
-        cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType2".to_vec()));
         cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
         cid_font.set(
             "W",
@@ -3196,11 +3197,20 @@ endbfrange
         let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
 
         let mut doc = Document::new();
+
+        // CIDToGIDMap is CIDFontType2-only, but a malformed producer can still emit
+        // one on a CFF font. Use a real stream (not /Identity, which is treated as
+        // "no map") so this also fails if the guard is moved back below the
+        // CIDToGIDMap branch: cid 1 -> gid 0x0200, which the CMap resolves.
+        let mut cid_to_gid = vec![0u8; 68];
+        cid_to_gid[2] = 0x02;
+        cid_to_gid[3] = 0x00;
+        let cid_to_gid_id =
+            doc.add_object(lopdf::Stream::new(lopdf::Dictionary::new(), cid_to_gid));
+
         let mut cid_font = lopdf::Dictionary::new();
         cid_font.set("Subtype", lopdf::Object::Name(b"CIDFontType0".to_vec()));
-        // CIDToGIDMap is CIDFontType2-only, but a malformed producer can still emit
-        // it on a CFF font. It must not be used to rewrite the CMap either.
-        cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
+        cid_font.set("CIDToGIDMap", lopdf::Object::Reference(cid_to_gid_id));
         cid_font.set(
             "W",
             lopdf::Object::Array(vec![
@@ -3220,9 +3230,54 @@ endbfrange
         let (primary, remapped) = try_remap_subset_cmap(cmap, &font_dict, &doc, 789);
         assert!(
             remapped.is_none(),
-            "Remap must be skipped for CIDFontType0 (CFF) descendants"
+            "Remap must be skipped for CIDFontType0 (CFF) descendants, including a \
+             CIDToGIDMap a malformed producer attached to one"
         );
         // The original CMap must still resolve its own CIDs.
         assert_eq!(primary.lookup(0x0200), Some("\u{0410}".to_string()));
+    }
+
+    #[test]
+    fn test_try_remap_resolves_indirect_subtype() {
+        // /Subtype may be stored as an indirect reference. A genuine CIDFontType2
+        // font must still get the repair, so the guard has to dereference it rather
+        // than treat the unresolved value as "not CIDFontType2".
+        let cmap_content = r#"
+1 begincodespacerange
+<0000><FFFF>
+endcodespacerange
+1 beginbfrange
+<0200> <0220> <0410>
+endbfrange
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        let mut doc = Document::new();
+        let subtype_id = doc.add_object(lopdf::Object::Name(b"CIDFontType2".to_vec()));
+
+        let mut cid_font = lopdf::Dictionary::new();
+        cid_font.set("Subtype", lopdf::Object::Reference(subtype_id));
+        cid_font.set("CIDToGIDMap", lopdf::Object::Name(b"Identity".to_vec()));
+        cid_font.set(
+            "W",
+            lopdf::Object::Array(vec![
+                lopdf::Object::Integer(0),
+                lopdf::Object::Array(vec![lopdf::Object::Integer(500); 34]),
+            ]),
+        );
+        let cid_font_id = doc.add_object(cid_font);
+
+        let mut font_dict = lopdf::Dictionary::new();
+        font_dict.set("Encoding", lopdf::Object::Name(b"Identity-H".to_vec()));
+        font_dict.set(
+            "DescendantFonts",
+            lopdf::Object::Array(vec![lopdf::Object::Reference(cid_font_id)]),
+        );
+
+        let (_primary, remapped) = try_remap_subset_cmap(cmap, &font_dict, &doc, 790);
+        assert!(
+            remapped.is_some(),
+            "An indirect /Subtype naming CIDFontType2 must still reach the remap"
+        );
     }
 }


### PR DESCRIPTION
Fixes #208.

## What

`try_remap_subset_cmap`'s sequential-GID repair assumes CIDs are glyph indices a subsetter can renumber. That holds for `CIDFontType2` (TrueType) but not for `CIDFontType0` (CFF), where CIDs are resolved through the CFF charset — so a valid ToUnicode CMap stays valid after subsetting, and renumbering it corrupts otherwise-correct text.

For CFF fonts the corrupting path was unavoidable: `CIDToGIDMap` is CIDFontType2-only (PDF 32000-1:2008, 9.7.4.2), so the branch that repairs the CMap correctly can never be taken, and any CFF font whose `/W` array starts at a low CID fell through into `remap_to_sequential`.

This guards both repair paths on a CIDFontType2 descendant, placed **before** the `CIDToGIDMap` branch so a `CIDToGIDMap` wrongly attached to a CFF font by a malformed producer is ignored as well.

## Verification

On the National Diet Library proceedings PDF from #208 (sha256 `f0a36713…`):

| | before | after |
|---|---|---|
| U+FFFD | 1233 / 69099 chars (1.78%) | **0 / 68331** |
| repeated-glyph runs | present | gone |
| character 3-gram recall vs. hand-written ground truth | 0.354 | **0.605** |

The recall figure is a character-level 3-gram recall (whitespace and markdown punctuation stripped) against a manual transcription of the document's opening pages. Word-token metrics are not meaningful for Japanese, which has no inter-word spaces.

The PDF behind #118 (`text_simple__att10k.pdf`, sha256 `8b9aecf1…`, CIDFontType2 descendants) extracts **byte-identically** before and after — 3033 chars both ways.

`cargo fmt --check`, `cargo clippy -- -D warnings` and `cargo test` all pass (861 tests: 717 unit + 141 integration + 2 + 1 doc).

## Test changes

Two existing tests build descendant font dicts without a `/Subtype`, so they would stop exercising their intended path once the guard is added. Both set `CIDToGIDMap`, which is CIDFontType2-only, so `Subtype = CIDFontType2` is what the fixtures were already describing:

- `test_try_remap_fires_for_true_subset_mismatch` — would otherwise return early and never reach the remap it asserts on (fails loudly)
- `test_try_remap_skipped_when_w_covers_cmap` — would otherwise still pass, but for the wrong reason, no longer checking the W-coverage logic at all (a silent false positive)

Added `test_try_remap_skipped_for_cid_font_type0`, covering a plain CFF descendant and one carrying a spurious `CIDToGIDMap`.

## Scope note

This narrows an existing heuristic to the font type it was written for; it does not make that heuristic more precise. Separately: `/W` describes glyph *widths*, and a CID absent from `/W` legitimately falls back to `/DW`, so "`/W` starts low and does not cover the CMap's max CID" is suggestive of subset renumbering rather than proof of it — a compliant CIDFontType2 font with a sparse `/W` plus `/DW` could still trip it. That is pre-existing behaviour and orthogonal to this fix; happy to open a separate issue if you consider it worth tightening.

## Not verified

`pdf-evals` is not publicly accessible, so I could not run the 187-PDF snapshot suite or `bench.py score` that `AGENTS.md` asks for. Everything else in the checklist passes locally. Would appreciate a maintainer running that suite before merge.

## Remaining gap (not addressed here)

After the fix the Diet document still scores below pdf.js on character 3-gram recall (0.605 vs 0.780). The residual is a reading-order/layout question in this document class (mixed vertical/horizontal minutes), not an encoding one — the glyphs themselves now decode correctly. Happy to file that separately.

## Alternative considered

Reading the embedded CFF charset to resolve CID→GID properly would be the fuller fix, but it changes considerably more than a guard. Restricting the existing heuristic to the font type it was written for is the minimal correct change. Let me know if you would prefer the charset route and I will rework it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788259527&installation_model_id=11126&pr_number=209&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F209&signature=46aa3f560b670a34323912236bd39832af9f2e3330909be8953f55cd3b946bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip subset GID remapping for `CIDFontType0` (CFF) descendants to avoid corrupting valid ToUnicode mappings. Resolve indirect `/Subtype` and only skip when the descendant is explicitly not `CIDFontType2`; any `CIDToGIDMap` on CFF is ignored.

- **Bug Fixes**
  - Guard both repair paths on `CIDFontType2`, resolving indirect `/Subtype`; missing/unresolvable `/Subtype` keeps prior behavior.
  - Place the guard before the `CIDToGIDMap` branch; ignore `CIDToGIDMap` on CFF.
  - Results: NDL proceedings PDF now has 0 U+FFFD and higher 3-gram recall (0.605 vs 0.354); a `CIDFontType2` sample extracts byte-identically.
  - Tests: reverted earlier fixture edits; CFF regression uses a real `CIDToGIDMap` stream; added an indirect `/Subtype` test.

<sup>Written for commit eeb696f017695b7a5e07530ad71492be1bbdf5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

