### PR TITLE
fix: upgrade lopdf 0.41→0.42 (RUSTSEC-2026-0187, high-severity stack-overflow DoS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,14 +46,14 @@ ttf-parser = "0.25"
 # Native builds keep lopdf's parallel parser and CLI logging. Browser WASM is
 # deliberately single-threaded so it works without cross-origin isolation.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-lopdf = { version = "0.41.0", features = ["rayon"] }
+lopdf = { version = "0.42", features = ["rayon"] }
 rayon = "1.10"
 env_logger = "0.11"
 
 # Browser builds use JavaScript randomness for encrypted PDFs and embed the
 # bundled CMaps because there is no filesystem at runtime.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-lopdf = { version = "0.41.0", default-features = false, features = ["wasm_js"] }
+lopdf = { version = "0.42", default-features = false, features = ["wasm_js"] }
 include_dir = "0.7"
 
 [dev-dependencies]

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -499,11 +499,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -556,6 +558,25 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "indexmap"
@@ -672,9 +693,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lopdf"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags",
@@ -833,6 +854,7 @@ name = "pdf-inspector"
 version = "0.1.7"
 dependencies = [
  "env_logger",
+ "include_dir",
  "log",
  "lopdf",
  "once_cell",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -605,9 +605,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags 2.13.1",


### PR DESCRIPTION
## Summary

`cargo audit` flags [RUSTSEC-2026-0187](https://rustsec.org/advisories/RUSTSEC-2026-0187) (CVSS 3.1: **7.5, high**) against `lopdf 0.41.0`, the version currently pinned in `Cargo.toml`.

`lopdf::Document::load*` parses nested PDF arrays/dictionaries with **unbounded recursion**. A ~21KB crafted PDF whose Catalog contains a deeply nested array (`/X [[[ … ]]]`, ~10,380 levels) exhausts the call stack and aborts the process with `SIGABRT`. This is a hard process crash, not a `panic!` — it cannot be caught with `catch_unwind`, and it happens inside `lopdf`'s own object parser, before any of this crate's own recursion-depth guards (`structure_tree`'s `MAX_DEPTH`, `extractor::xobjects`'s `MAX_FORM_XOBJECT_DEPTH`) get a chance to run.

Since this crate exists specifically to process PDFs from untrusted/uploaded sources, this is a directly relevant, verified DoS: one small malicious upload crashes whatever process is handling it.

## Why this needs an explicit bump

`Cargo.toml` pins `lopdf = "0.41.0"`, which under Cargo's default caret semver means `>=0.41.0, <0.42.0`. **`cargo update` alone cannot pick up the fix** — 0.42.0, where the advisory says this was patched, is outside that range and needs an explicit version bump.

## Fix

Bump `lopdf` to `"0.42"` in both the native and wasm32 dependency blocks.

## Verification

Built a PoC PDF matching the advisory's repro (Catalog `/X` value = `"[" * N + "]" * N`) at N = 10380 (the advisory's exact figure), 50000, and 100000:

| | `lopdf` 0.41.0 (before) | `lopdf` 0.42.0 (after) |
|---|---|---|
| `detect-pdf poc.pdf --json` | `exit=134` (SIGABRT) at all 3 depths — `thread 'main' has overflowed its stack, fatal runtime error: stack overflow, aborting` | `exit=0`, clean `"Object load error"` at all 3 depths |

`cargo test`: 720 tests pass unchanged on 0.42.0 — drop-in compatible, no API changes needed on this crate's side.

## Testing

- `cargo build --release`, `cargo test` (720 tests, 0 failures)
- Manual PoC reproduction before/after at 3 nesting depths (table above)
- `cargo audit` clean on this dependency after the bump (two separate, lower-priority advisories remain against `pyo3` 0.25.1, used only behind the `python` feature, and an unmaintained-crate warning on `ttf-parser` — happy to open follow-ups for those if useful, kept out of this PR to keep it a single, fast-to-review fix for the high-severity issue)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788286139&installation_model_id=11126&pr_number=222&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F222&signature=7ada58351a55f55ccf331b130382009d010bc1da3f794c0001e601d219a8a674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `lopdf` to `0.42` to fix RUSTSEC-2026-0187 (high-severity stack-overflow DoS) in nested PDF parsing. Prevents hard crashes on crafted PDFs in native, WASM, and Node builds.

- **Dependencies**
  - Bumped `lopdf` from `0.41.0` to `0.42` for native (`features: ["rayon"]`) and `wasm32` targets (`default-features = false`, `features: ["wasm_js"]`).
  - Updated checked-in lockfiles `wasm/Cargo.lock` and `napi/Cargo.lock` to resolve `lopdf 0.42.0` so bindings ship the fixed version.

<sup>Written for commit a602f5c5acf1bd9858f7b76760eb71aa98d6d934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

