### PR TITLE
fix: upgrade pyo3 0.25→0.29 (RUSTSEC-2026-0176, RUSTSEC-2026-0177)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 # Python bindings
-pyo3 = { version = "0.25", features = ["extension-module", "abi3-py38"], optional = true }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
 
 # Error handling
 thiserror = "2.0"


### PR DESCRIPTION
## Summary

`cargo audit` flags two advisories against `pyo3 0.25.1`, the version currently pinned in `Cargo.toml` under the optional `python` feature:

- [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) (memory-exposure): `BoundListIterator::nth`/`nth_back` and `BoundTupleIterator::nth`/`nth_back` computed the target index with unchecked `usize` arithmetic before bounds-checking, allowing out-of-bounds reads via integer overflow/underflow with a sufficiently large `n`.
- [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) (thread-safety): `PyCFunction::new_closure` required `Send` but not `Sync`, so the resulting Python callable could be invoked concurrently from multiple threads (free-threaded Python, or via `Python::detach`) without the compiler enforcing safety.

Both are fixed in `pyo3 0.29.0`.

## Reachability

Grepped `src/python.rs` for the affected APIs: this crate's bindings use only the standard `#[pyfunction]`/`#[pyclass]`/`#[pymethods]` macros, and never call `.nth()`/`.nth_back()` on a list/tuple iterator directly or `PyCFunction::new_closure`. Neither advisory's specific vulnerable function is invoked by this crate's own code today, so practical exploitability here is low. That said, `cargo audit` (and any downstream user running it against this crate) flags the dependency regardless of call-site reachability, and the fix is a version bump, not a rewrite — no reason to leave it unfixed while it's this cheap.

## Verification

- `maturin develop --release --features python` builds cleanly (8 pre-existing deprecation warnings about a future `FromPyObject`-derive-for-`Clone`-types change in a later pyo3 release, no errors)
- `pytest tests/test_python.py`: 63/64 pass. The one failure (`TestMultipleFixtures::test_process_all_fixtures[encrypted-secret123.pdf]`) is **confirmed pre-existing on unmodified pyo3 0.25.1** — the parametrized fixture test iterates every fixture in `tests/fixtures/` without excluding the deliberately-encrypted one, so it always raised `ValueError: PDF is encrypted` there, before and after this change. Unrelated to this PR; happy to fix separately if useful.
- Native `cargo test` (the `python` feature is off by default): 720 tests pass unchanged — this dependency is only linked when the feature is enabled.

## Testing

- `cargo build --release` (native, feature off) — unaffected, unchanged
- `maturin develop --release --features python` + `pytest tests/test_python.py` (table above)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788288734&installation_model_id=11126&pr_number=223&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F223&signature=d3abe9e60f7e958b5b716220541c396100ac3b614658cccee5bdb12f36b7c245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pyo3` from 0.25 to 0.29 to resolve `cargo audit` advisories RUSTSEC-2026-0176 and RUSTSEC-2026-0177, improving memory and thread safety for the optional `python` feature.

<sup>Written for commit f1a1ef58a861fcf473c824fe21b11a768fceaf5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

