### PR TITLE
perf: enable LTO and codegen-units=1 for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,14 @@ include_dir = "0.7"
 [dev-dependencies]
 tempfile = "3.3"
 
+# Matches the release profile already used in napi/ and wasm/: LTO and a
+# single codegen unit trade build time for a smaller, faster binary. Debug
+# builds are untouched, so the local dev loop isn't affected.
+[profile.release]
+lto = true
+codegen-units = 1
+strip = "debuginfo"
+
 [features]
 default = []
 python = ["pyo3"]


### PR DESCRIPTION
Fixes #95.

## Summary

`napi/` and `wasm/` already set `lto = true` in their own `[profile.release]` (`wasm/` also already had `codegen-units = 1`), but the root crate — used for the Rust library, the `pdf2md`/`detect-pdf` CLI binaries, and the Python wheel via `maturin` — had no `[profile.release]` section at all, so it built with Cargo's defaults (`lto = false`, `codegen-units = 16`).

## Change

Added the same profile the other two bindings already use:

```toml
[profile.release]
lto = true
codegen-units = 1
strip = "debuginfo"
```

`strip = "debuginfo"` wasn't explicitly requested in the issue but matches `napi/`'s existing profile, so debug builds stay untouched and all three release profiles are now consistent.

## Verification

| | Before | After |
|---|---|---|
| `pdf2md` binary size | 6,592,512 bytes | 5,448,176 bytes (~17% smaller) |
| `detect-pdf` binary size | 6,592,512 bytes | 5,448,176 bytes (~17% smaller) |

Full test suite (859 tests — lib, bins, doctests) passes unchanged in release mode. Release build time goes from ~11s to ~1m40s on this machine, as expected for LTO + a single codegen unit — this only affects `cargo build --release`, not the day-to-day debug-build dev loop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788289963&installation_model_id=11126&pr_number=224&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F224&signature=338a6dab0a39a900f79ee17520e2330912c638a360aea608214ba369b9af9844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable LTO and `codegen-units = 1` in the root `[profile.release]` to produce smaller, faster binaries, consistent with `napi/` and `wasm/`. Also sets `strip = "debuginfo"`; `pdf2md`/`detect-pdf` are ~17% smaller and release builds take longer, while debug builds are unchanged.

<sup>Written for commit 3b60055fed17ea3ec4bb029e9cb09969d8870aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

