### PR TITLE
feat: Added UniFFI bindings to generate swift & kotlin code

### DIFF
--- a/.github/workflows/publish-xcframework.yml
+++ b/.github/workflows/publish-xcframework.yml
@@ -1,4 +1,4 @@
-name: Publish Xcframework
+name: Publish XCFramework
 
 on:
   push:
@@ -19,8 +19,8 @@ jobs:
       name: Build Apple slices
       runs-on: macos-latest
       env:
-
         TARGETS: "aarch64-apple-ios,aarch64-apple-ios-macabi,aarch64-apple-ios-sim,aarch64-apple-tvos,aarch64-apple-tvos-sim,aarch64-apple-visionos,aarch64-apple-visionos-sim,aarch64-apple-watchos,aarch64-apple-watchos-sim,x86_64-apple-ios,x86_64-apple-ios-macabi"
+
       steps:
           - uses: actions/checkout@v4
 
@@ -101,11 +101,13 @@ jobs:
               zip -r -y $FRAMEWORK_NAME.xcframework.zip $FRAMEWORK_NAME.xcframework
 
           - name: Compute checksum for Package.swift binaryTarget
-            run: swift package compute-checksum swift/$FRAMEWORK_NAME.xcframework.zip
+            run: echo $(swift package compute-checksum swift/$FRAMEWORK_NAME.xcframework.zip) > ${{ env.FRAMEWORK_NAME }}.xcframework.zip.checksum
 
           - name: Upload Apple build artifact
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
             with:
                 name: apple-build
-                path: swift/$FRAMEWORK_NAME.xcframework.zip
+                path: |
+                    swift/${{ env.FRAMEWORK_NAME }}.xcframework.zip
+                    swift/${{ env.FRAMEWORK_NAME }}.xcframework.zip.checksum
                 if-no-files-found: error

--- a/.github/workflows/publish-xcframework.yml
+++ b/.github/workflows/publish-xcframework.yml
@@ -1,0 +1,110 @@
+name: Publish WebAssembly package
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+  FRAMEWORK_NAME: pdf_inspector
+
+jobs:
+  apple-build:
+      name: Build Apple slices
+      runs-on: macos-latest
+      env:
+
+        TARGETS: "aarch64-apple-ios,aarch64-apple-ios-macabi,aarch64-apple-ios-sim,aarch64-apple-tvos,aarch64-apple-tvos-sim,aarch64-apple-visionos,aarch64-apple-visionos-sim,aarch64-apple-watchos,aarch64-apple-watchos-sim,x86_64-apple-ios,x86_64-apple-ios-macabi"
+      steps:
+          - uses: actions/checkout@v4
+
+          - name: Install Rust
+            uses: dtolnay/rust-toolchain@stable
+            with:
+              targets: ${{ env.TARGETS }}
+
+          - name: Build host dylib for bindgen
+            run: cargo build --release --features uniffi
+
+          - name: Generate Swift bindings
+            run: |
+              mkdir -p swift
+              cargo run --release --features uniffi --bin uniffi-bindgen -- generate \
+                --library "target/release/libpdf_inspector.dylib" \
+                --language swift \
+                --out-dir swift
+
+          - name: Build Apple Rust slices
+            run: |
+              RUST_TARGETS=()
+
+              # Split by comma and populate the array safely
+              IFS=',' read -ra ADDR <<< "$TARGETS"
+              for target in "${ADDR[@]}"; do
+                  RUST_TARGETS+=("--target" "$target")
+              done
+
+              # Run your build command
+              cargo build --release --features uniffi "${RUST_TARGETS[@]}"
+
+          - name: Stage headers (Rename & Move)
+            run: |
+              mkdir -p target/apple/headers
+              cp swift/pdf_inspectorFFI.h target/apple/headers/
+              cp swift/pdf_inspectorFFI.modulemap target/apple/headers/module.modulemap
+              rm -f swift/pdf_inspectorFFI.h swift/pdf_inspectorFFI.modulemap
+
+          # Most of our targets are all for separate architectures, however the iOS Simulator and Mac Catalyst have multiple targets
+          # for a single architecture. Combine those into a single slice here.
+          - name: Fatten multi-arch slices (iOS Simulator & Mac Catalyst)
+            run: |
+              mkdir -p target/apple/fat/ios-simulator target/apple/fat/ios-macabi
+              lipo -create \
+                "target/aarch64-apple-ios-sim/release/${LIB_NAME}.a" \
+                "target/x86_64-apple-ios/release/${LIB_NAME}.a" \
+                -output "target/apple/fat/ios-simulator/${LIB_NAME}.a"
+              lipo -create \
+                "target/aarch64-apple-ios-macabi/release/${LIB_NAME}.a" \
+                "target/x86_64-apple-ios-macabi/release/${LIB_NAME}.a" \
+                -output "target/apple/fat/ios-macabi/${LIB_NAME}.a"
+
+          - name: Assemble ${{ env.FRAMEWORK_NAME }}.xcframework
+            run: |
+              SLICES=(
+                "target/aarch64-apple-ios/release/${LIB_NAME}.a"
+                "target/apple/fat/ios-simulator/${LIB_NAME}.a"
+                "target/apple/fat/ios-macabi/${LIB_NAME}.a"
+                "target/aarch64-apple-tvos/release/${LIB_NAME}.a"
+                "target/aarch64-apple-tvos-sim/release/${LIB_NAME}.a"
+                "target/aarch64-apple-visionos/release/${LIB_NAME}.a"
+                "target/aarch64-apple-visionos-sim/release/${LIB_NAME}.a"
+                "target/aarch64-apple-watchos/release/${LIB_NAME}.a"
+                "target/aarch64-apple-watchos-sim/release/${LIB_NAME}.a"
+              )
+
+              XCFRAMEWORK_ARGS=()
+              for lib in "${SLICES[@]}"; do
+                  XCFRAMEWORK_ARGS+=("-library" "$lib" "-headers" "target/apple/headers")
+              done
+
+              xcodebuild -create-xcframework "${XCFRAMEWORK_ARGS[@]}" -output swift/$FRAMEWORK_NAME.xcframework
+
+          - name: Zip xcframework for distribution
+            run: |
+              cd swift
+              zip -r -y $FRAMEWORK_NAME.xcframework.zip $FRAMEWORK_NAME.xcframework
+
+          - name: Compute checksum for Package.swift binaryTarget
+            run: swift package compute-checksum swift/$FRAMEWORK_NAME.xcframework.zip
+
+          - name: Upload Apple build artifact
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+                name: apple-build
+                path: rust/target/apple-build/
+                if-no-files-found: error

--- a/.github/workflows/publish-xcframework.yml
+++ b/.github/workflows/publish-xcframework.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   FRAMEWORK_NAME: pdf_inspector
+  LIB_NAME: libpdf_inspector
 
 jobs:
   apple-build:
@@ -35,7 +36,7 @@ jobs:
             run: |
               mkdir -p swift
               cargo run --release --features uniffi --bin uniffi-bindgen -- generate \
-                --library "target/release/libpdf_inspector.dylib" \
+                --library "target/release/${LIB_NAME}.dylib" \
                 --language swift \
                 --out-dir swift
 
@@ -61,24 +62,24 @@ jobs:
 
           # Most of our targets are all for separate architectures, however the iOS Simulator and Mac Catalyst have multiple targets
           # for a single architecture. Combine those into a single slice here.
-          - name: Fatten multi-arch slices (iOS Simulator & Mac Catalyst)
+          - name: Create multi-arch slices (iOS Simulator & Mac Catalyst)
             run: |
-              mkdir -p target/apple/fat/ios-simulator target/apple/fat/ios-macabi
+              mkdir -p target/apple/multi/ios-simulator target/apple/multi/ios-macabi
               lipo -create \
                 "target/aarch64-apple-ios-sim/release/${LIB_NAME}.a" \
                 "target/x86_64-apple-ios/release/${LIB_NAME}.a" \
-                -output "target/apple/fat/ios-simulator/${LIB_NAME}.a"
+                -output "target/apple/multi/ios-simulator/${LIB_NAME}.a"
               lipo -create \
                 "target/aarch64-apple-ios-macabi/release/${LIB_NAME}.a" \
                 "target/x86_64-apple-ios-macabi/release/${LIB_NAME}.a" \
-                -output "target/apple/fat/ios-macabi/${LIB_NAME}.a"
+                -output "target/apple/multi/ios-macabi/${LIB_NAME}.a"
 
           - name: Assemble ${{ env.FRAMEWORK_NAME }}.xcframework
             run: |
               SLICES=(
                 "target/aarch64-apple-ios/release/${LIB_NAME}.a"
-                "target/apple/fat/ios-simulator/${LIB_NAME}.a"
-                "target/apple/fat/ios-macabi/${LIB_NAME}.a"
+                "target/apple/multi/ios-simulator/${LIB_NAME}.a"
+                "target/apple/multi/ios-macabi/${LIB_NAME}.a"
                 "target/aarch64-apple-tvos/release/${LIB_NAME}.a"
                 "target/aarch64-apple-tvos-sim/release/${LIB_NAME}.a"
                 "target/aarch64-apple-visionos/release/${LIB_NAME}.a"

--- a/.github/workflows/publish-xcframework.yml
+++ b/.github/workflows/publish-xcframework.yml
@@ -106,5 +106,5 @@ jobs:
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
             with:
                 name: apple-build
-                path: rust/target/apple-build/
+                path: swift/$FRAMEWORK_NAME.xcframework.zip
                 if-no-files-found: error

--- a/.github/workflows/publish-xcframework.yml
+++ b/.github/workflows/publish-xcframework.yml
@@ -1,4 +1,4 @@
-name: Publish WebAssembly package
+name: Publish Xcframework
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ crate-type = ["lib", "cdylib"]
 # Python bindings
 pyo3 = { version = "0.25", features = ["extension-module", "abi3-py38"], optional = true }
 
+# Swift Bindings
+uniffi = { version = "0.32.0", features = [ "cli" ], optional = true}
+
 # Error handling
 thiserror = "2.0"
 
@@ -56,12 +59,16 @@ env_logger = "0.11"
 lopdf = { version = "0.42.0", default-features = false, features = ["wasm_js"] }
 include_dir = "0.7"
 
+[build-dependencies]
+uniffi = { version = "0.32.0", features = [ "build" ] }
+
 [dev-dependencies]
 tempfile = "3.3"
 
 [features]
 default = []
 python = ["pyo3"]
+uniffi = ["dep:uniffi"]
 
 [[bin]]
 name = "pdf2md"
@@ -74,3 +81,8 @@ path = "src/bin/detect_pdf.rs"
 [[bin]]
 name = "dump_ops"
 path = "src/bin/dump_ops.rs"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "src/bin/uniffi_bindgen.rs"
+required-features = ["uniffi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 
 [lib]
 name = "pdf_inspector"
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 # Python bindings

--- a/src/bin/uniffi_bindgen.rs
+++ b/src/bin/uniffi_bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,190 @@
+//! UniFFI bindings for pdf-inspector.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiPdfType {
+    TextBased,
+    Scanned,
+    ImageBased,
+    Mixed,
+}
+
+impl From<crate::PdfType> for FfiPdfType {
+    fn from(t: crate::PdfType) -> Self {
+        match t {
+            crate::PdfType::TextBased => FfiPdfType::TextBased,
+            crate::PdfType::Scanned => FfiPdfType::Scanned,
+            crate::PdfType::ImageBased => FfiPdfType::ImageBased,
+            crate::PdfType::Mixed => FfiPdfType::Mixed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct FfiPageOcrReasons {
+    /// 1-indexed page number.
+    pub page: u32,
+    /// Machine-readable OCR reason identifiers.
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, uniffi::Record)]
+pub struct FfiLayoutComplexity {
+    /// True if any page has tables or multi-column text.
+    pub is_complex: bool,
+    /// 1-indexed pages where table borders were detected.
+    pub pages_with_tables: Vec<u32>,
+    /// 1-indexed pages where 2+ text columns were detected.
+    pub pages_with_columns: Vec<u32>,
+}
+
+impl From<crate::LayoutComplexity> for FfiLayoutComplexity {
+    fn from(l: crate::LayoutComplexity) -> Self {
+        FfiLayoutComplexity {
+            is_complex: l.is_complex,
+            pages_with_tables: l.pages_with_tables,
+            pages_with_columns: l.pages_with_columns,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiPdfResult {
+    /// The detected PDF type.
+    pub pdf_type: FfiPdfType,
+    /// Markdown output (None if detect-only or scanned PDF).
+    pub markdown: Option<String>,
+    /// Total number of pages.
+    pub page_count: u32,
+    /// Processing time in milliseconds.
+    pub processing_time_ms: u64,
+    /// 1-indexed page numbers that need OCR.
+    pub pages_needing_ocr: Vec<u32>,
+    /// Machine-readable OCR reasons by 1-indexed page.
+    pub ocr_reasons_by_page: Vec<FfiPageOcrReasons>,
+    /// Title from PDF metadata.
+    pub title: Option<String>,
+    /// Detection confidence (0.0-1.0).
+    pub confidence: f32,
+    /// Layout complexity analysis (tables, multi-column detection).
+    pub layout: FfiLayoutComplexity,
+    /// Whether encoding issues were detected.
+    pub has_encoding_issues: bool,
+}
+
+impl From<crate::PdfProcessResult> for FfiPdfResult {
+    fn from(r: crate::PdfProcessResult) -> Self {
+        FfiPdfResult {
+            pdf_type: r.pdf_type.into(),
+            markdown: r.markdown,
+            page_count: r.page_count,
+            processing_time_ms: r.processing_time_ms,
+            pages_needing_ocr: r.pages_needing_ocr,
+            ocr_reasons_by_page: r
+                .ocr_reasons_by_page
+                .into_iter()
+                .map(|reason| FfiPageOcrReasons {
+                    page: reason.page,
+                    reasons: reason.reasons,
+                })
+                .collect(),
+            title: r.title,
+            confidence: r.confidence,
+            layout: r.layout.into(),
+            has_encoding_issues: r.has_encoding_issues,
+        }
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FfiPdfClassification {
+    /// The detected PDF type.
+    pub pdf_type: FfiPdfType,
+    /// Total number of pages.
+    pub page_count: u32,
+    /// 0-indexed page numbers that need OCR.
+    pub pages_needing_ocr: Vec<u32>,
+    /// Detection confidence (0.0-1.0).
+    pub confidence: f32,
+}
+
+impl From<crate::PdfClassification> for FfiPdfClassification {
+    fn from(r: crate::PdfClassification) -> Self {
+        FfiPdfClassification {
+            pdf_type: r.pdf_type.into(),
+            page_count: r.page_count,
+            pages_needing_ocr: r.pages_needing_ocr,
+            confidence: r.confidence,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum FfiError {
+    #[error("{0}")]
+    Msg(String),
+}
+
+impl From<crate::PdfError> for FfiError {
+    fn from(e: crate::PdfError) -> Self {
+        FfiError::Msg(e.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+/// Process a PDF file: detect type, extract text, and convert to Markdown.
+#[uniffi::export]
+pub fn process_pdf(path: String) -> Result<FfiPdfResult, FfiError> {
+    let result = crate::process_pdf_with_options(path, crate::PdfOptions::new())?;
+    Ok(result.into())
+}
+
+/// Process a PDF from bytes in memory.
+#[uniffi::export]
+pub fn process_pdf_bytes(data: Vec<u8>) -> Result<FfiPdfResult, FfiError> {
+    let result = crate::process_pdf_mem_with_options(&data, crate::PdfOptions::new())?;
+    Ok(result.into())
+}
+
+/// Fast detection only — no text extraction or markdown.
+#[uniffi::export]
+pub fn detect_pdf(path: String) -> Result<FfiPdfResult, FfiError> {
+    let result = crate::detect_pdf(path)?;
+    Ok(result.into())
+}
+
+/// Fast detection from bytes — no text extraction or markdown.
+#[uniffi::export]
+pub fn detect_pdf_bytes(data: Vec<u8>) -> Result<FfiPdfResult, FfiError> {
+    let result = crate::detect_pdf_mem(&data)?;
+    Ok(result.into())
+}
+
+/// Lightweight PDF classification for routing decisions.
+#[uniffi::export]
+pub fn classify_pdf(path: String) -> Result<FfiPdfClassification, FfiError> {
+    let data = std::fs::read(&path).map_err(crate::PdfError::from)?;
+    classify_pdf_bytes(data)
+}
+
+/// Lightweight PDF classification from bytes.
+#[uniffi::export]
+pub fn classify_pdf_bytes(data: Vec<u8>) -> Result<FfiPdfClassification, FfiError> {
+    let result = crate::classify_pdf_mem(&data)?;
+    Ok(result.into())
+}
+
+/// Extract plain text from a PDF file.
+#[uniffi::export]
+pub fn extract_text(path: String) -> Result<String, FfiError> {
+    Ok(crate::extract_text(path)?)
+}
+
+/// Extract plain text from PDF bytes.
+#[uniffi::export]
+pub fn extract_text_bytes(data: Vec<u8>) -> Result<String, FfiError> {
+    Ok(crate::extractor::extract_text_mem(&data)?)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,12 @@
 #[cfg(feature = "python")]
 pub mod python;
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+#[cfg(feature = "uniffi")]
+pub mod ffi;
+
 pub mod adobe_korea1;
 pub mod detector;
 pub mod extractor;


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788385320&installation_model_id=11126&pr_number=239&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F239&signature=e4d5c620d680e68de02ab4a0907cc0893e3c719dfc8fec9381f053f2fbe81507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds UniFFI bindings to expose pdf-inspector APIs and generate Swift/Kotlin SDKs. Adds CI to build and publish a multi-arch Apple `pdf_inspector.xcframework` with headers and an SPM checksum.

- **New Features**
  - Introduced `uniffi` feature and `src/ffi.rs` exporting PDF processing, detection, classification, and text extraction APIs.
  - Added `staticlib` crate type and `uniffi-bindgen` binary for code generation.
  - New workflow builds Apple slices, runs `uniffi` to emit Swift headers, assembles `pdf_inspector.xcframework`, zips it, and uploads the artifact + checksum.

- **Migration**
  - To generate bindings locally: `cargo build --release --features uniffi` then `cargo run --release --features uniffi --bin uniffi-bindgen -- generate --library target/release/libpdf_inspector.dylib --language swift --out-dir swift`.
  - Consumers can add the zipped `pdf_inspector.xcframework` to SwiftPM using the uploaded checksum.
  - No changes for existing Rust users unless enabling the `uniffi` feature.

<sup>Written for commit 72b258e0ac1cdf3a8be2528326dab9407970f964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

