### PR TITLE
fix(markdown): preserve redline edits in prose

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1090,7 +1090,12 @@ pub fn extract_tables_in_regions_mem(
                     candidates.push(candidate);
                 }
             }
-            let detected = tables::detect_tables(&matched, base_font_size, false);
+            let detected = tables::detect_tables_with_page_width(
+                &matched,
+                base_font_size,
+                false,
+                items.map_or(1.0, |items| tables::content_width(items)),
+            );
             if let Some(candidate) = detected
                 .iter()
                 .find_map(|t| evaluate(TableCandidateSource::Heuristic, t))
@@ -5652,6 +5657,7 @@ fn compute_layout_complexity(
 
         // Check for side-by-side layout
         let owned_items: Vec<types::TextItem> = page_items.iter().map(|i| (*i).clone()).collect();
+        let page_content_width = tables::content_width(&owned_items);
         let bands = markdown::split_side_by_side(&owned_items);
 
         let band_ranges: Vec<(f32, f32)> = if bands.is_empty() {
@@ -5702,7 +5708,12 @@ fn compute_layout_complexity(
                 break;
             }
             // Heuristic fallback for borderless tables
-            let heuristic_tables = tables::detect_tables(&band_items, base_size, false);
+            let heuristic_tables = tables::detect_tables_with_page_width(
+                &band_items,
+                base_size,
+                false,
+                page_content_width,
+            );
             if has_data_table(&heuristic_tables) {
                 found_table = true;
                 break;

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1035,8 +1035,8 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     context: MarkdownDocumentContext<'_>,
 ) -> String {
     use crate::tables::{
-        detect_tables, detect_tables_from_lines, detect_tables_from_rects,
-        detect_tables_from_struct_tree, try_build_rect_guided_table,
+        content_width, detect_tables_from_lines, detect_tables_from_rects,
+        detect_tables_from_struct_tree, detect_tables_with_page_width, try_build_rect_guided_table,
     };
     use crate::types::ItemType;
 
@@ -1144,6 +1144,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     for page in pages {
         let group = page_groups.get(&page).unwrap();
         let page_items: Vec<TextItem> = group.iter().map(|(_, item)| (*item).clone()).collect();
+        let page_content_width = content_width(&page_items);
 
         // Chart-bar regions: bar charts drawn as filled rects read as cell
         // rects or aligned text and get gridded into phantom tables. Their
@@ -1428,7 +1429,12 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                     // table can share the prose anchors. Reject only candidates
                     // whose cells prove they are parallel prose fragments.
                     let reject_parallel_prose = chart_prose_columns && !was_split;
-                    let tables = detect_tables(subset_items, base_size, false);
+                    let tables = detect_tables_with_page_width(
+                        subset_items,
+                        base_size,
+                        false,
+                        page_content_width,
+                    );
                     for table in tables {
                         if reject_parallel_prose && is_parallel_prose_table(&table) {
                             log::debug!(
@@ -1609,7 +1615,12 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
             // and reject chart-page prose candidates individually below.
             let skip_body_font =
                 merged_retry_skips_body_font(detected_columns, !chart_regions.is_empty());
-            let heuristic_tables = detect_tables(&chart_free, base_size, skip_body_font);
+            let heuristic_tables = detect_tables_with_page_width(
+                &chart_free,
+                base_size,
+                skip_body_font,
+                page_content_width,
+            );
             for table in &heuristic_tables {
                 if !chart_regions.is_empty() && is_parallel_prose_table(table) {
                     log::debug!(

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -86,7 +86,9 @@ fn merge_adjacent_items_preserving(
                 let decoration_changes = next_item.is_underline != first_item.is_underline
                     || next_item.is_strikeout != first_item.is_strikeout;
                 if decoration_changes
-                    && (preserved_indices.contains(&first_idx)
+                    && (indices
+                        .iter()
+                        .any(|index| preserved_indices.contains(index))
                         || preserved_indices.contains(&next_idx))
                 {
                     break;
@@ -1981,6 +1983,24 @@ mod tests {
         assert_eq!(index_map, vec![vec![0], vec![1]]);
         assert!(merged[0].is_strikeout);
         assert!(merged[1].is_underline);
+    }
+
+    #[test]
+    fn merge_adjacent_items_keeps_boundary_after_preserved_fragment() {
+        let mut prefix = body_item("prefix", 20.0, 700.0, false);
+        prefix.is_underline = true;
+        let mut replacement = body_item("replacement", 111.0, 700.0, false);
+        replacement.is_underline = true;
+        let deleted = body_item("deleted", 202.0, 700.0, true);
+        let preserved_indices = std::collections::HashSet::from([1]);
+
+        let (merged, index_map) =
+            merge_adjacent_items_preserving(&[prefix, replacement, deleted], &preserved_indices);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(index_map, vec![vec![0, 1], vec![2]]);
+        assert!(merged[0].is_underline);
+        assert!(merged[1].is_strikeout);
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -159,10 +159,9 @@ fn expand_consolidated_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<usize>) 
     (expanded, index_map)
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct RedlineEditRegion {
-    x_min: f32,
-    x_max: f32,
+    x_ranges: Vec<(f32, f32)>,
     y_min: f32,
     y_max: f32,
     spans_page_width: bool,
@@ -199,20 +198,20 @@ fn redline_edit_regions(items: &[TextItem], page_width: f32) -> Vec<RedlineEditR
     const Y_PADDING: f32 = 36.0;
     const X_PADDING: f32 = 12.0;
     const PAGE_WIDTH_RATIO: f32 = 0.35;
+    const MAX_HORIZONTAL_GAP_RATIO: f32 = 0.20;
 
     let mut strikeouts: Vec<&TextItem> = items.iter().filter(|item| item.is_strikeout).collect();
     strikeouts.sort_by(|a, b| a.y.total_cmp(&b.y));
 
-    let mut rows: Vec<(f32, f32, f32)> = Vec::new();
+    let mut rows: Vec<(f32, Vec<(f32, f32)>)> = Vec::new();
     for item in strikeouts {
-        if let Some((_, x_min, x_max)) = rows
+        if let Some((_, x_ranges)) = rows
             .last_mut()
-            .filter(|(y, _, _)| (item.y - *y).abs() <= ROW_DEDUP_TOLERANCE)
+            .filter(|(y, _)| (item.y - *y).abs() <= ROW_DEDUP_TOLERANCE)
         {
-            *x_min = x_min.min(item.x);
-            *x_max = x_max.max(item.x + item.width);
+            x_ranges.push((item.x, item.x + item.width));
         } else {
-            rows.push((item.y, item.x, item.x + item.width));
+            rows.push((item.y, vec![(item.x, item.x + item.width)]));
         }
     }
 
@@ -224,23 +223,40 @@ fn redline_edit_regions(items: &[TextItem], page_width: f32) -> Vec<RedlineEditR
             end += 1;
         }
         if end - start >= 2 {
-            let x_min = rows[start..end]
+            let mut x_ranges: Vec<(f32, f32)> = rows[start..end]
                 .iter()
-                .map(|(_, x_min, _)| *x_min)
-                .fold(f32::INFINITY, f32::min);
-            let x_max = rows[start..end]
+                .flat_map(|(_, x_ranges)| x_ranges.iter().copied())
+                .collect();
+            x_ranges.sort_by(|a, b| a.0.total_cmp(&b.0));
+            let mut merged_ranges: Vec<(f32, f32)> = Vec::new();
+            for (x_min, x_max) in x_ranges {
+                // Modest inline gaps can separate fragments of one flowing
+                // edit; column-scale gaps must remain distinct spatial masks.
+                if let Some((_, merged_max)) = merged_ranges.last_mut().filter(|(_, merged_max)| {
+                    x_min - *merged_max <= page_width * MAX_HORIZONTAL_GAP_RATIO
+                }) {
+                    *merged_max = merged_max.max(x_max);
+                } else {
+                    merged_ranges.push((x_min, x_max));
+                }
+            }
+            let covered_width: f32 = merged_ranges
                 .iter()
-                .map(|(_, _, x_max)| *x_max)
-                .fold(f32::NEG_INFINITY, f32::max);
+                .map(|(x_min, x_max)| x_max - x_min)
+                .sum();
+            for (x_min, x_max) in &mut merged_ranges {
+                *x_min -= X_PADDING;
+                *x_max += X_PADDING;
+            }
             // Redlines spread across much of the text width are flowing prose,
             // so their whole Y-band is ambiguous. Compact edits can be scoped
-            // horizontally without hiding a neighboring table.
+            // to their actual horizontal spans without hiding content between
+            // unrelated edits in separate columns.
             regions.push(RedlineEditRegion {
-                x_min: x_min - X_PADDING,
-                x_max: x_max + X_PADDING,
+                x_ranges: merged_ranges,
                 y_min: rows[start].0 - Y_PADDING,
                 y_max: rows[end - 1].0 + Y_PADDING,
-                spans_page_width: x_max - x_min >= page_width * PAGE_WIDTH_RATIO,
+                spans_page_width: covered_width >= page_width * PAGE_WIDTH_RATIO,
             });
         }
         start = end;
@@ -259,6 +275,16 @@ fn redline_edit_regions(items: &[TextItem], page_width: f32) -> Vec<RedlineEditR
         }
     }
     regions
+}
+
+fn overlaps_redline_x(item: &TextItem, region: &RedlineEditRegion) -> bool {
+    let range_index = region
+        .x_ranges
+        .partition_point(|(_, x_max)| *x_max < item.x);
+    region
+        .x_ranges
+        .get(range_index)
+        .is_some_and(|(x_min, _)| item.x + item.width >= *x_min)
 }
 
 fn has_distinct_rows(
@@ -371,7 +397,7 @@ fn is_heuristic_table_evidence(
         return false;
     }
 
-    let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
+    let overlaps_x = overlaps_redline_x(item, region);
     !overlaps_x || is_revised_table_cell(item, columns)
 }
 
@@ -397,8 +423,7 @@ fn revised_table_cell_indices(
             let region_index = redline_region_at_y(redline_regions, item.y)?;
             let region = &redline_regions[region_index];
             (item.is_underline
-                && item.x + item.width >= region.x_min
-                && item.x <= region.x_max
+                && overlaps_redline_x(item, region)
                 && is_revised_table_cell(item, &underlined_table_columns[region_index]))
             .then_some(item_index)
         })
@@ -2083,6 +2108,31 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "redline rows must suppress decorations, not nearby live table cells"
+        );
+    }
+
+    #[test]
+    fn separate_strikeout_columns_do_not_suppress_content_between_them() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 160.0, y, false));
+            items.push(body_item("row value", 280.0, y, false));
+        }
+        for (row, y) in [700.0, 684.0, 668.0, 652.0].into_iter().enumerate() {
+            let x = if row % 2 == 0 { 50.0 } else { 420.0 };
+            let mut deletion = body_item("old", x, y, true);
+            deletion.width = 30.0;
+            items.push(deletion);
+        }
+
+        let regions = redline_edit_regions(&items, content_width(&items));
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].x_ranges.len(), 2);
+        assert!(!regions[0].spans_page_width);
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "separate edit columns must not create a suppression bridge across the page"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -259,8 +259,36 @@ fn redline_edit_regions(items: &[TextItem], page_width: f32) -> Vec<RedlineEditR
     regions
 }
 
-/// Repeated underlined items at the same X position are table-shaped evidence
-/// in a compact redline region, where they commonly represent revised cells.
+fn has_distinct_rows(
+    items: &[&TextItem],
+    underlined_only: bool,
+    required: usize,
+    tolerance: f32,
+) -> bool {
+    debug_assert!(required <= 3);
+    let mut rows = [0.0; 3];
+    let mut row_count = 0;
+    for item in items {
+        if underlined_only && !item.is_underline {
+            continue;
+        }
+        if rows[..row_count]
+            .iter()
+            .all(|row| (item.y - row).abs() > tolerance)
+        {
+            rows[row_count] = item.y;
+            row_count += 1;
+            if row_count == required {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Aligned live items seeded by underline evidence form revised table columns.
+/// Compact edits accept one replacement backed by surrounding live rows; wide
+/// prose-like edits require replacements on at least two distinct rows.
 fn underlined_table_columns(
     items: &[TextItem],
     redline_regions: &[RedlineEditRegion],
@@ -268,77 +296,49 @@ fn underlined_table_columns(
     const X_ALIGNMENT_TOLERANCE: f32 = 4.0;
     const ROW_DEDUP_TOLERANCE: f32 = 8.0;
 
-    // Sort underlines once by Y. Because redline regions are non-overlapping,
-    // the cursor assigns each underline to at most one region.
-    let mut underlined: Vec<&TextItem> = items.iter().filter(|item| item.is_underline).collect();
-    underlined.sort_by(|a, b| a.y.total_cmp(&b.y));
+    // Sort once globally by X, then partition candidates into their unique Y
+    // regions. Each regional vector remains X-sorted without another sort.
+    let mut live_items: Vec<&TextItem> = items.iter().filter(|item| !item.is_strikeout).collect();
+    live_items.sort_by(|a, b| a.x.total_cmp(&b.x));
+    let mut candidates_by_region: Vec<Vec<&TextItem>> = vec![Vec::new(); redline_regions.len()];
+    for item in live_items {
+        if let Some(region_index) = redline_region_at_y(redline_regions, item.y) {
+            candidates_by_region[region_index].push(item);
+        }
+    }
 
     let mut columns_by_region = Vec::with_capacity(redline_regions.len());
-    let mut underline_start = 0;
-    for region in redline_regions {
-        if region.spans_page_width {
-            columns_by_region.push(Vec::new());
-            continue;
-        }
-        while underline_start < underlined.len() && underlined[underline_start].y < region.y_min {
-            underline_start += 1;
-        }
-        let mut underline_end = underline_start;
-        while underline_end < underlined.len() && underlined[underline_end].y <= region.y_max {
-            underline_end += 1;
-        }
-
-        let mut candidates = underlined[underline_start..underline_end].to_vec();
-        candidates.sort_by(|a, b| a.x.total_cmp(&b.x));
-
+    for (region, candidates) in redline_regions.iter().zip(candidates_by_region) {
         let mut columns: Vec<UnderlinedTableColumn> = Vec::new();
-        let mut left = 0;
-        let mut min_y_indices = std::collections::VecDeque::new();
-        let mut max_y_indices = std::collections::VecDeque::new();
-        for (index, item) in candidates.iter().enumerate() {
-            while left < index && item.x - candidates[left].x > X_ALIGNMENT_TOLERANCE {
-                if min_y_indices.front() == Some(&left) {
-                    min_y_indices.pop_front();
-                }
-                if max_y_indices.front() == Some(&left) {
-                    max_y_indices.pop_front();
-                }
-                left += 1;
+        let mut start = 0;
+        while start < candidates.len() {
+            let mut end = start + 1;
+            while end < candidates.len()
+                && candidates[end].x - candidates[start].x <= X_ALIGNMENT_TOLERANCE
+            {
+                end += 1;
             }
-
-            let has_aligned_peer = min_y_indices
-                .front()
-                .is_some_and(|&peer| (item.y - candidates[peer].y).abs() > ROW_DEDUP_TOLERANCE)
-                || max_y_indices
-                    .front()
-                    .is_some_and(|&peer| (item.y - candidates[peer].y).abs() > ROW_DEDUP_TOLERANCE);
-            if has_aligned_peer {
-                let x_min = item.x - X_ALIGNMENT_TOLERANCE;
-                let x_max = item.x + X_ALIGNMENT_TOLERANCE;
+            let aligned_items = &candidates[start..end];
+            let enough_live_rows = has_distinct_rows(aligned_items, false, 3, ROW_DEDUP_TOLERANCE);
+            let required_underlined_rows = if region.spans_page_width { 2 } else { 1 };
+            let enough_underlined_rows = has_distinct_rows(
+                aligned_items,
+                true,
+                required_underlined_rows,
+                ROW_DEDUP_TOLERANCE,
+            );
+            if enough_live_rows && enough_underlined_rows {
+                let x_min = candidates[start].x - X_ALIGNMENT_TOLERANCE;
+                let x_max = candidates[end - 1].x + X_ALIGNMENT_TOLERANCE;
                 if let Some(column) = columns.last_mut().filter(|column| column.x_max >= x_min) {
                     column.x_max = column.x_max.max(x_max);
                 } else {
                     columns.push(UnderlinedTableColumn { x_min, x_max });
                 }
             }
-
-            while min_y_indices
-                .back()
-                .is_some_and(|&peer| candidates[peer].y >= item.y)
-            {
-                min_y_indices.pop_back();
-            }
-            min_y_indices.push_back(index);
-            while max_y_indices
-                .back()
-                .is_some_and(|&peer| candidates[peer].y <= item.y)
-            {
-                max_y_indices.pop_back();
-            }
-            max_y_indices.push_back(index);
+            start = end;
         }
         columns_by_region.push(columns);
-        underline_start = underline_end;
     }
     columns_by_region
 }
@@ -364,21 +364,19 @@ fn is_heuristic_table_evidence(
         return true;
     };
     let region = &redline_regions[region_index];
-    if region.spans_page_width {
+    let columns = &underlined_table_columns[region_index];
+    if region.spans_page_width && columns.is_empty() {
         return false;
     }
 
     let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
-    !overlaps_x || is_revised_table_cell(item, &underlined_table_columns[region_index])
+    !overlaps_x || is_revised_table_cell(item, columns)
 }
 
 fn is_revised_table_cell(
     item: &TextItem,
     underlined_table_columns: &[UnderlinedTableColumn],
 ) -> bool {
-    if !item.is_underline {
-        return false;
-    }
     let column_index = underlined_table_columns.partition_point(|column| column.x_max < item.x);
     underlined_table_columns
         .get(column_index)
@@ -396,7 +394,7 @@ fn revised_table_cell_indices(
         .filter_map(|(item_index, item)| {
             let region_index = redline_region_at_y(redline_regions, item.y)?;
             let region = &redline_regions[region_index];
-            (!region.spans_page_width
+            (item.is_underline
                 && item.x + item.width >= region.x_min
                 && item.x <= region.x_max
                 && is_revised_table_cell(item, &underlined_table_columns[region_index]))
@@ -425,6 +423,10 @@ pub(crate) fn detect_tables_with_page_width(
     // inherit only the first fragment's decoration flags.
     let redline_regions = redline_edit_regions(items, page_width);
     let underlined_table_columns = underlined_table_columns(items, &redline_regions);
+    let source_evidence: Vec<bool> = items
+        .iter()
+        .map(|item| is_heuristic_table_evidence(item, &redline_regions, &underlined_table_columns))
+        .collect();
     let revised_table_cells =
         revised_table_cell_indices(items, &redline_regions, &underlined_table_columns);
 
@@ -433,6 +435,14 @@ pub(crate) fn detect_tables_with_page_width(
 
     // Step 2: Expand consolidated financial items (e.g. "$ 1,234 $ 5,678" → sub-items)
     let (expanded_items, expand_map) = expand_consolidated_items(&merged_items);
+    let expanded_evidence: Vec<bool> = expand_map
+        .iter()
+        .map(|&merged_index| {
+            merge_map[merged_index]
+                .iter()
+                .all(|&source_index| source_evidence[source_index])
+        })
+        .collect();
     let items = &expanded_items[..]; // shadow parameter — all detection uses processed items
 
     let mut tables = Vec::new();
@@ -444,8 +454,8 @@ pub(crate) fn detect_tables_with_page_width(
     let table_candidates: Vec<(usize, &TextItem)> = items
         .iter()
         .enumerate()
-        .filter(|(_, item)| {
-            is_heuristic_table_evidence(item, &redline_regions, &underlined_table_columns)
+        .filter(|(index, item)| {
+            expanded_evidence[*index]
                 && item.font_size <= table_font_threshold
                 && item.font_size >= 6.0
         })
@@ -497,11 +507,7 @@ pub(crate) fn detect_tables_with_page_width(
             .enumerate()
             .filter(|(idx, item)| {
                 !claimed_indices.contains(idx)
-                    && is_heuristic_table_evidence(
-                        item,
-                        &redline_regions,
-                        &underlined_table_columns,
-                    )
+                    && expanded_evidence[*idx]
                     && item.font_size >= body_font_low
                     && item.font_size <= body_font_high
                     && item.font_size >= 6.0
@@ -2115,6 +2121,66 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "aligned replacement cells must preserve a partially revised table"
+        );
+    }
+
+    #[test]
+    fn single_replacement_uses_aligned_live_table_rows() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let mut value = body_item("row value", 220.0, y, false);
+            value.is_underline = row == 0;
+            items.push(value);
+        }
+        for y in [700.0, 652.0, 604.0] {
+            items.push(body_item("old value", 220.0, y, true));
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "one replacement cell must retain its aligned live table column"
+        );
+    }
+
+    #[test]
+    fn wide_revised_table_keeps_repeated_replacement_evidence() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let mut value = body_item("row value", 220.0, y, false);
+            value.is_underline = row < 2;
+            items.push(value);
+            let strikeout_x = if row % 2 == 0 { 220.0 } else { 400.0 };
+            items.push(body_item("old value", strikeout_x, y, true));
+        }
+
+        assert!(redline_edit_regions(&items, content_width(&items))[0].spans_page_width);
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "wide edits must keep a table column with repeated replacements"
+        );
+    }
+
+    #[test]
+    fn revised_financial_columns_survive_item_expansion() {
+        let mut items = Vec::new();
+        for row in 0..4 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            items.push(body_item("old value", 180.0, y, true));
+            let mut values = body_item("$ 100 $ 200 $ 300", 180.0, y, false);
+            values.width = 300.0;
+            values.is_underline = true;
+            items.push(values);
+        }
+
+        let tables = detect_tables(&items, 12.0, false);
+        assert!(
+            tables.iter().any(|table| table.columns.len() >= 4),
+            "all expanded financial columns must inherit their source evidence"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -18,7 +18,15 @@ use super::{Table, TableDetectionMode};
 ///
 /// Returns `(merged_items, index_map)` where `index_map[merged_idx]` contains
 /// the original item indices that were merged into that item.
+#[cfg(test)]
 pub(crate) fn merge_adjacent_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<Vec<usize>>) {
+    merge_adjacent_items_preserving(items, &std::collections::HashSet::new())
+}
+
+fn merge_adjacent_items_preserving(
+    items: &[TextItem],
+    preserved_indices: &std::collections::HashSet<usize>,
+) -> (Vec<TextItem>, Vec<Vec<usize>>) {
     if items.is_empty() {
         return (vec![], vec![]);
     }
@@ -68,6 +76,18 @@ pub(crate) fn merge_adjacent_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<Ve
 
                 // Must be similar font size (within 20%)
                 if (next_item.font_size - first_item.font_size).abs() > first_item.font_size * 0.20
+                {
+                    break;
+                }
+
+                // Proven replacement cells must retain their own decoration.
+                // Otherwise an adjacent old/new pair inherits only the first
+                // fragment's flags and can lose the live table evidence.
+                let decoration_changes = next_item.is_underline != first_item.is_underline
+                    || next_item.is_strikeout != first_item.is_strikeout;
+                if decoration_changes
+                    && (preserved_indices.contains(&first_idx)
+                        || preserved_indices.contains(&next_idx))
                 {
                     break;
                 }
@@ -234,28 +254,68 @@ fn underlined_table_columns(
     const X_ALIGNMENT_TOLERANCE: f32 = 4.0;
     const ROW_DEDUP_TOLERANCE: f32 = 8.0;
 
-    let mut columns = Vec::new();
+    let mut columns: Vec<UnderlinedTableColumn> = Vec::new();
     for (region_index, region) in redline_regions.iter().enumerate() {
         if region.spans_page_width {
             continue;
         }
-        let candidates: Vec<&TextItem> = items
+        let mut candidates: Vec<&TextItem> = items
             .iter()
             .filter(|item| item.is_underline && item.y >= region.y_min && item.y <= region.y_max)
             .collect();
+        candidates.sort_by(|a, b| a.x.total_cmp(&b.x));
 
-        for item in &candidates {
-            let has_aligned_peer = candidates.iter().any(|other| {
-                (item.x - other.x).abs() <= X_ALIGNMENT_TOLERANCE
-                    && (item.y - other.y).abs() > ROW_DEDUP_TOLERANCE
-            });
-            if has_aligned_peer {
-                columns.push(UnderlinedTableColumn {
-                    region_index,
-                    x_min: item.x - X_ALIGNMENT_TOLERANCE,
-                    x_max: item.x + X_ALIGNMENT_TOLERANCE,
-                });
+        let mut left = 0;
+        let mut min_y_indices = std::collections::VecDeque::new();
+        let mut max_y_indices = std::collections::VecDeque::new();
+        for (index, item) in candidates.iter().enumerate() {
+            while left < index && item.x - candidates[left].x > X_ALIGNMENT_TOLERANCE {
+                if min_y_indices.front() == Some(&left) {
+                    min_y_indices.pop_front();
+                }
+                if max_y_indices.front() == Some(&left) {
+                    max_y_indices.pop_front();
+                }
+                left += 1;
             }
+
+            let has_aligned_peer = min_y_indices
+                .front()
+                .is_some_and(|&peer| (item.y - candidates[peer].y).abs() > ROW_DEDUP_TOLERANCE)
+                || max_y_indices
+                    .front()
+                    .is_some_and(|&peer| (item.y - candidates[peer].y).abs() > ROW_DEDUP_TOLERANCE);
+            if has_aligned_peer {
+                let x_min = item.x - X_ALIGNMENT_TOLERANCE;
+                let x_max = item.x + X_ALIGNMENT_TOLERANCE;
+                if let Some(column) = columns
+                    .last_mut()
+                    .filter(|column| column.region_index == region_index && column.x_max >= x_min)
+                {
+                    column.x_max = column.x_max.max(x_max);
+                } else {
+                    columns.push(UnderlinedTableColumn {
+                        region_index,
+                        x_min,
+                        x_max,
+                    });
+                }
+            }
+
+            while min_y_indices
+                .back()
+                .is_some_and(|&peer| candidates[peer].y >= item.y)
+            {
+                min_y_indices.pop_back();
+            }
+            min_y_indices.push_back(index);
+            while max_y_indices
+                .back()
+                .is_some_and(|&peer| candidates[peer].y <= item.y)
+            {
+                max_y_indices.pop_back();
+            }
+            max_y_indices.push_back(index);
         }
     }
     columns
@@ -279,20 +339,48 @@ fn is_heuristic_table_evidence(
         }
 
         let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
-        if overlaps_x {
-            let is_revised_table_cell = item.is_underline
-                && underlined_table_columns.iter().any(|column| {
-                    column.region_index == region_index
-                        && item.x >= column.x_min
-                        && item.x <= column.x_max
-                });
-            if !is_revised_table_cell {
-                return false;
-            }
+        if overlaps_x && !is_revised_table_cell(item, region_index, underlined_table_columns) {
+            return false;
         }
     }
 
     true
+}
+
+fn is_revised_table_cell(
+    item: &TextItem,
+    region_index: usize,
+    underlined_table_columns: &[UnderlinedTableColumn],
+) -> bool {
+    item.is_underline
+        && underlined_table_columns.iter().any(|column| {
+            column.region_index == region_index && item.x >= column.x_min && item.x <= column.x_max
+        })
+}
+
+fn revised_table_cell_indices(
+    items: &[TextItem],
+    redline_regions: &[RedlineEditRegion],
+    underlined_table_columns: &[UnderlinedTableColumn],
+) -> std::collections::HashSet<usize> {
+    items
+        .iter()
+        .enumerate()
+        .filter_map(|(item_index, item)| {
+            redline_regions
+                .iter()
+                .enumerate()
+                .any(|(region_index, region)| {
+                    !region.spans_page_width
+                        && item.y >= region.y_min
+                        && item.y <= region.y_max
+                        && item.x + item.width >= region.x_min
+                        && item.x <= region.x_max
+                        && is_revised_table_cell(item, region_index, underlined_table_columns)
+                })
+                .then_some(item_index)
+        })
+        .collect()
 }
 
 /// Detect tables in a set of text items from a single page
@@ -304,9 +392,11 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
     // inherit only the first fragment's decoration flags.
     let redline_regions = redline_edit_regions(items);
     let underlined_table_columns = underlined_table_columns(items, &redline_regions);
+    let revised_table_cells =
+        revised_table_cell_indices(items, &redline_regions, &underlined_table_columns);
 
     // Step 1: Merge adjacent single-char items into words (handles per-character PDFs)
-    let (merged_items, merge_map) = merge_adjacent_items(items);
+    let (merged_items, merge_map) = merge_adjacent_items_preserving(items, &revised_table_cells);
 
     // Step 2: Expand consolidated financial items (e.g. "$ 1,234 $ 5,678" → sub-items)
     let (expanded_items, expand_map) = expand_consolidated_items(&merged_items);
@@ -1839,6 +1929,22 @@ mod tests {
     }
 
     #[test]
+    fn merge_adjacent_items_preserves_redline_boundaries() {
+        let old = body_item("old value", 220.0, 700.0, true);
+        let mut replacement = body_item("new value", 312.0, 700.0, false);
+        replacement.is_underline = true;
+        let preserved_indices = std::collections::HashSet::from([1]);
+
+        let (merged, index_map) =
+            merge_adjacent_items_preserving(&[old, replacement], &preserved_indices);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(index_map, vec![vec![0], vec![1]]);
+        assert!(merged[0].is_strikeout);
+        assert!(merged[1].is_underline);
+    }
+
+    #[test]
     fn body_font_redline_deletions_do_not_create_a_table() {
         let mut items = Vec::new();
         for row in 0..8 {
@@ -1976,6 +2082,24 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "aligned replacement cells must preserve a partially revised table"
+        );
+    }
+
+    #[test]
+    fn adjacent_revised_fragments_preserve_live_table_cells() {
+        let mut items = Vec::new();
+        for row in 0..4 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            items.push(body_item("old value", 220.0, y, true));
+            let mut replacement = body_item("new value", 312.0, y, false);
+            replacement.is_underline = true;
+            items.push(replacement);
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "adjacent old/new fragments must retain the live revised cells"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -137,47 +137,162 @@ fn expand_consolidated_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<usize>) 
     (expanded, index_map)
 }
 
-/// Y-bands where multiple strikeout rows indicate a redline edit block.
+#[derive(Clone, Copy)]
+struct RedlineEditRegion {
+    x_min: f32,
+    x_max: f32,
+    y_min: f32,
+    y_max: f32,
+    spans_page_width: bool,
+}
+
+#[derive(Clone, Copy)]
+struct UnderlinedTableColumn {
+    region_index: usize,
+    x_min: f32,
+    x_max: f32,
+}
+
+/// Spatial regions where multiple strikeout rows indicate a redline edit block.
 ///
 /// A lone deletion can occur inside or beside a real table, so it must not
 /// globally suppress underlined table cells. Closely spaced strikeout rows are
 /// different: together with nearby underlines they form the overlapping
 /// old/new text layers used by legislative redlines, and those decorations
 /// must not become heuristic column evidence.
-fn redline_edit_bands(items: &[TextItem]) -> Vec<(f32, f32)> {
+fn redline_edit_regions(items: &[TextItem]) -> Vec<RedlineEditRegion> {
     const ROW_DEDUP_TOLERANCE: f32 = 8.0;
     const MAX_CLUSTER_GAP: f32 = 64.0;
-    const BAND_PADDING: f32 = 36.0;
+    const Y_PADDING: f32 = 36.0;
+    const X_PADDING: f32 = 12.0;
+    const PAGE_WIDTH_RATIO: f32 = 0.35;
 
-    let mut rows: Vec<f32> = items
+    let page_x_min = items
         .iter()
-        .filter(|item| item.is_strikeout)
-        .map(|item| item.y)
-        .collect();
-    rows.sort_by(|a, b| a.total_cmp(b));
-    rows.dedup_by(|a, b| (*a - *b).abs() <= ROW_DEDUP_TOLERANCE);
+        .map(|item| item.x)
+        .fold(f32::INFINITY, f32::min);
+    let page_x_max = items
+        .iter()
+        .map(|item| item.x + item.width)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let page_width = (page_x_max - page_x_min).max(1.0);
 
-    let mut bands = Vec::new();
+    let mut strikeouts: Vec<&TextItem> = items.iter().filter(|item| item.is_strikeout).collect();
+    strikeouts.sort_by(|a, b| a.y.total_cmp(&b.y));
+
+    let mut rows: Vec<(f32, f32, f32)> = Vec::new();
+    for item in strikeouts {
+        if let Some((_, x_min, x_max)) = rows
+            .last_mut()
+            .filter(|(y, _, _)| (item.y - *y).abs() <= ROW_DEDUP_TOLERANCE)
+        {
+            *x_min = x_min.min(item.x);
+            *x_max = x_max.max(item.x + item.width);
+        } else {
+            rows.push((item.y, item.x, item.x + item.width));
+        }
+    }
+
+    let mut regions = Vec::new();
     let mut start = 0;
     while start < rows.len() {
         let mut end = start + 1;
-        while end < rows.len() && rows[end] - rows[end - 1] <= MAX_CLUSTER_GAP {
+        while end < rows.len() && rows[end].0 - rows[end - 1].0 <= MAX_CLUSTER_GAP {
             end += 1;
         }
         if end - start >= 2 {
-            bands.push((rows[start] - BAND_PADDING, rows[end - 1] + BAND_PADDING));
+            let x_min = rows[start..end]
+                .iter()
+                .map(|(_, x_min, _)| *x_min)
+                .fold(f32::INFINITY, f32::min);
+            let x_max = rows[start..end]
+                .iter()
+                .map(|(_, _, x_max)| *x_max)
+                .fold(f32::NEG_INFINITY, f32::max);
+            // Redlines spread across much of the text width are flowing prose,
+            // so their whole Y-band is ambiguous. Compact edits can be scoped
+            // horizontally without hiding a neighboring table.
+            regions.push(RedlineEditRegion {
+                x_min: x_min - X_PADDING,
+                x_max: x_max + X_PADDING,
+                y_min: rows[start].0 - Y_PADDING,
+                y_max: rows[end - 1].0 + Y_PADDING,
+                spans_page_width: x_max - x_min >= page_width * PAGE_WIDTH_RATIO,
+            });
         }
         start = end;
     }
-    bands
+    regions
 }
 
-fn is_heuristic_table_evidence(item: &TextItem, redline_bands: &[(f32, f32)]) -> bool {
-    !(item.is_strikeout
-        || item.is_underline
-            && redline_bands
-                .iter()
-                .any(|(y_min, y_max)| item.y >= *y_min && item.y <= *y_max))
+/// Repeated underlined items at the same X position are table-shaped evidence
+/// in a compact redline region, where they commonly represent revised cells.
+fn underlined_table_columns(
+    items: &[TextItem],
+    redline_regions: &[RedlineEditRegion],
+) -> Vec<UnderlinedTableColumn> {
+    const X_ALIGNMENT_TOLERANCE: f32 = 4.0;
+    const ROW_DEDUP_TOLERANCE: f32 = 8.0;
+
+    let mut columns = Vec::new();
+    for (region_index, region) in redline_regions.iter().enumerate() {
+        if region.spans_page_width {
+            continue;
+        }
+        let candidates: Vec<&TextItem> = items
+            .iter()
+            .filter(|item| item.is_underline && item.y >= region.y_min && item.y <= region.y_max)
+            .collect();
+
+        for item in &candidates {
+            let has_aligned_peer = candidates.iter().any(|other| {
+                (item.x - other.x).abs() <= X_ALIGNMENT_TOLERANCE
+                    && (item.y - other.y).abs() > ROW_DEDUP_TOLERANCE
+            });
+            if has_aligned_peer {
+                columns.push(UnderlinedTableColumn {
+                    region_index,
+                    x_min: item.x - X_ALIGNMENT_TOLERANCE,
+                    x_max: item.x + X_ALIGNMENT_TOLERANCE,
+                });
+            }
+        }
+    }
+    columns
+}
+
+fn is_heuristic_table_evidence(
+    item: &TextItem,
+    redline_regions: &[RedlineEditRegion],
+    underlined_table_columns: &[UnderlinedTableColumn],
+) -> bool {
+    if item.is_strikeout {
+        return false;
+    }
+
+    for (region_index, region) in redline_regions.iter().enumerate() {
+        if item.y < region.y_min || item.y > region.y_max {
+            continue;
+        }
+        if region.spans_page_width {
+            return false;
+        }
+
+        let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
+        if overlaps_x {
+            let is_revised_table_cell = item.is_underline
+                && underlined_table_columns.iter().any(|column| {
+                    column.region_index == region_index
+                        && item.x >= column.x_min
+                        && item.x <= column.x_max
+                });
+            if !is_revised_table_cell {
+                return false;
+            }
+        }
+    }
+
+    true
 }
 
 /// Detect tables in a set of text items from a single page
@@ -187,7 +302,8 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
     }
     // Compute these before consolidation: adjacent old/new text can merge and
     // inherit only the first fragment's decoration flags.
-    let redline_bands = redline_edit_bands(items);
+    let redline_regions = redline_edit_regions(items);
+    let underlined_table_columns = underlined_table_columns(items, &redline_regions);
 
     // Step 1: Merge adjacent single-char items into words (handles per-character PDFs)
     let (merged_items, merge_map) = merge_adjacent_items(items);
@@ -206,7 +322,7 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
         .iter()
         .enumerate()
         .filter(|(_, item)| {
-            is_heuristic_table_evidence(item, &redline_bands)
+            is_heuristic_table_evidence(item, &redline_regions, &underlined_table_columns)
                 && item.font_size <= table_font_threshold
                 && item.font_size >= 6.0
         })
@@ -258,7 +374,11 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
             .enumerate()
             .filter(|(idx, item)| {
                 !claimed_indices.contains(idx)
-                    && is_heuristic_table_evidence(item, &redline_bands)
+                    && is_heuristic_table_evidence(
+                        item,
+                        &redline_regions,
+                        &underlined_table_columns,
+                    )
                     && item.font_size >= body_font_low
                     && item.font_size <= body_font_high
                     && item.font_size >= 6.0
@@ -1798,6 +1918,64 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "redline rows must suppress decorations, not nearby live table cells"
+        );
+    }
+
+    #[test]
+    fn wide_redline_rows_do_not_turn_fragmented_prose_into_a_table() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("line number", 50.0, y, false));
+            items.push(body_item("live prose fragment", 160.0, y, false));
+            let strikeout_x = if row % 2 == 0 { 280.0 } else { 430.0 };
+            items.push(body_item("deleted prose", strikeout_x, y, true));
+        }
+
+        assert!(
+            detect_tables(&items, 12.0, false).is_empty(),
+            "full-width redline prose must not retain table-shaped fragments"
+        );
+    }
+
+    #[test]
+    fn nearby_redline_rows_do_not_remove_separate_underlined_table_evidence() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let mut value = body_item("row value", 220.0, y, false);
+            value.is_underline = true;
+            items.push(value);
+        }
+        for y in [700.0, 652.0, 604.0] {
+            items.push(body_item("deleted prose", 400.0, y, true));
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "redline rows must not suppress a horizontally separate underlined table"
+        );
+    }
+
+    #[test]
+    fn multiple_revised_rows_do_not_remove_underlined_table_column() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let replacement_x = 220.0 + (row % 2) as f32 * 2.0;
+            let mut value = body_item("new value", replacement_x, y, false);
+            value.is_underline = true;
+            items.push(value);
+        }
+        for y in [700.0, 652.0, 604.0] {
+            items.push(body_item("old value", 220.0, y, true));
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "aligned replacement cells must preserve a partially revised table"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -137,11 +137,56 @@ fn expand_consolidated_items(items: &[TextItem]) -> (Vec<TextItem>, Vec<usize>) 
     (expanded, index_map)
 }
 
+/// Y-bands where multiple strikeout rows indicate a redline edit block.
+///
+/// A lone deletion can occur inside or beside a real table, so it must not
+/// globally suppress underlined table cells. Closely spaced strikeout rows are
+/// different: together with nearby underlines they form the overlapping
+/// old/new text layers used by legislative redlines, and those decorations
+/// must not become heuristic column evidence.
+fn redline_edit_bands(items: &[TextItem]) -> Vec<(f32, f32)> {
+    const ROW_DEDUP_TOLERANCE: f32 = 8.0;
+    const MAX_CLUSTER_GAP: f32 = 64.0;
+    const BAND_PADDING: f32 = 36.0;
+
+    let mut rows: Vec<f32> = items
+        .iter()
+        .filter(|item| item.is_strikeout)
+        .map(|item| item.y)
+        .collect();
+    rows.sort_by(|a, b| a.total_cmp(b));
+    rows.dedup_by(|a, b| (*a - *b).abs() <= ROW_DEDUP_TOLERANCE);
+
+    let mut bands = Vec::new();
+    let mut start = 0;
+    while start < rows.len() {
+        let mut end = start + 1;
+        while end < rows.len() && rows[end] - rows[end - 1] <= MAX_CLUSTER_GAP {
+            end += 1;
+        }
+        if end - start >= 2 {
+            bands.push((rows[start] - BAND_PADDING, rows[end - 1] + BAND_PADDING));
+        }
+        start = end;
+    }
+    bands
+}
+
+fn is_heuristic_table_evidence(item: &TextItem, redline_bands: &[(f32, f32)]) -> bool {
+    !item.is_strikeout
+        && !redline_bands
+            .iter()
+            .any(|(y_min, y_max)| item.y >= *y_min && item.y <= *y_max)
+}
+
 /// Detect tables in a set of text items from a single page
 pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bool) -> Vec<Table> {
     if items.len() < 6 {
         return vec![];
     }
+    // Compute these before consolidation: adjacent old/new text can merge and
+    // inherit only the first fragment's decoration flags.
+    let redline_bands = redline_edit_bands(items);
 
     // Step 1: Merge adjacent single-char items into words (handles per-character PDFs)
     let (merged_items, merge_map) = merge_adjacent_items(items);
@@ -159,7 +204,11 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
     let table_candidates: Vec<(usize, &TextItem)> = items
         .iter()
         .enumerate()
-        .filter(|(_, item)| item.font_size <= table_font_threshold && item.font_size >= 6.0)
+        .filter(|(_, item)| {
+            is_heuristic_table_evidence(item, &redline_bands)
+                && item.font_size <= table_font_threshold
+                && item.font_size >= 6.0
+        })
         .collect();
 
     if table_candidates.len() >= 6 {
@@ -208,6 +257,7 @@ pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bo
             .enumerate()
             .filter(|(idx, item)| {
                 !claimed_indices.contains(idx)
+                    && is_heuristic_table_evidence(item, &redline_bands)
                     && item.font_size >= body_font_low
                     && item.font_size <= body_font_high
                     && item.font_size >= 6.0
@@ -1646,6 +1696,91 @@ fn try_add_label_column(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ItemType;
+
+    fn body_item(text: &str, x: f32, y: f32, strikeout: bool) -> TextItem {
+        TextItem {
+            text: text.to_string(),
+            x,
+            y,
+            width: 90.0,
+            height: 12.0,
+            font: "F1".to_string(),
+            font_size: 12.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: strikeout,
+            item_type: ItemType::Text,
+            mcid: None,
+        }
+    }
+
+    #[test]
+    fn body_font_redline_deletions_do_not_create_a_table() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("live paragraph text", 50.0, y, false));
+            items.push(body_item("deleted wording", 220.0, y, true));
+        }
+
+        assert!(
+            detect_tables(&items, 12.0, false).is_empty(),
+            "aligned strikeout overlays are source edits, not table columns"
+        );
+    }
+
+    #[test]
+    fn underlined_body_font_table_without_deletions_is_still_detected() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let mut value = body_item("row value", 220.0, y, false);
+            value.is_underline = true;
+            items.push(value);
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "underline-only tables must keep their heuristic evidence"
+        );
+    }
+
+    #[test]
+    fn body_font_table_with_one_deletion_is_still_detected() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            items.push(body_item("row value", 220.0, y, row == 0));
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "one revised cell must not suppress an otherwise complete table"
+        );
+    }
+
+    #[test]
+    fn unrelated_strikeout_does_not_remove_underlined_table_evidence() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            let mut value = body_item("row value", 220.0, y, false);
+            value.is_underline = true;
+            items.push(value);
+        }
+        items.push(body_item("deleted prose", 50.0, 300.0, true));
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "a distant deletion must not suppress underlined table columns"
+        );
+    }
 
     #[test]
     fn is_table_of_contents_rejects_toc() {

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -173,10 +173,11 @@ fn redline_edit_bands(items: &[TextItem]) -> Vec<(f32, f32)> {
 }
 
 fn is_heuristic_table_evidence(item: &TextItem, redline_bands: &[(f32, f32)]) -> bool {
-    !item.is_strikeout
-        && !redline_bands
-            .iter()
-            .any(|(y_min, y_max)| item.y >= *y_min && item.y <= *y_max)
+    !(item.is_strikeout
+        || item.is_underline
+            && redline_bands
+                .iter()
+                .any(|(y_min, y_max)| item.y >= *y_min && item.y <= *y_max))
 }
 
 /// Detect tables in a set of text items from a single page
@@ -1779,6 +1780,24 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "a distant deletion must not suppress underlined table columns"
+        );
+    }
+
+    #[test]
+    fn nearby_redline_rows_do_not_remove_plain_table_evidence() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 50.0, y, false));
+            items.push(body_item("row value", 220.0, y, false));
+        }
+        for y in [700.0, 652.0, 604.0] {
+            items.push(body_item("deleted prose", 400.0, y, true));
+        }
+
+        assert!(
+            !detect_tables(&items, 12.0, false).is_empty(),
+            "redline rows must suppress decorations, not nearby live table cells"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -168,9 +168,20 @@ struct RedlineEditRegion {
 
 #[derive(Clone, Copy)]
 struct UnderlinedTableColumn {
-    region_index: usize,
     x_min: f32,
     x_max: f32,
+}
+
+pub(crate) fn content_width(items: &[TextItem]) -> f32 {
+    let x_min = items
+        .iter()
+        .map(|item| item.x)
+        .fold(f32::INFINITY, f32::min);
+    let x_max = items
+        .iter()
+        .map(|item| item.x + item.width)
+        .fold(f32::NEG_INFINITY, f32::max);
+    (x_max - x_min).max(1.0)
 }
 
 /// Spatial regions where multiple strikeout rows indicate a redline edit block.
@@ -180,22 +191,12 @@ struct UnderlinedTableColumn {
 /// different: together with nearby underlines they form the overlapping
 /// old/new text layers used by legislative redlines, and those decorations
 /// must not become heuristic column evidence.
-fn redline_edit_regions(items: &[TextItem]) -> Vec<RedlineEditRegion> {
+fn redline_edit_regions(items: &[TextItem], page_width: f32) -> Vec<RedlineEditRegion> {
     const ROW_DEDUP_TOLERANCE: f32 = 8.0;
     const MAX_CLUSTER_GAP: f32 = 64.0;
     const Y_PADDING: f32 = 36.0;
     const X_PADDING: f32 = 12.0;
     const PAGE_WIDTH_RATIO: f32 = 0.35;
-
-    let page_x_min = items
-        .iter()
-        .map(|item| item.x)
-        .fold(f32::INFINITY, f32::min);
-    let page_x_max = items
-        .iter()
-        .map(|item| item.x + item.width)
-        .fold(f32::NEG_INFINITY, f32::max);
-    let page_width = (page_x_max - page_x_min).max(1.0);
 
     let mut strikeouts: Vec<&TextItem> = items.iter().filter(|item| item.is_strikeout).collect();
     strikeouts.sort_by(|a, b| a.y.total_cmp(&b.y));
@@ -242,6 +243,19 @@ fn redline_edit_regions(items: &[TextItem]) -> Vec<RedlineEditRegion> {
         }
         start = end;
     }
+    // Padding can make neighboring clusters overlap. Partition that overlap at
+    // its midpoint so each Y position maps to one region without combining
+    // horizontally unrelated edits.
+    for index in 1..regions.len() {
+        let (previous, current) = regions.split_at_mut(index);
+        let previous = &mut previous[index - 1];
+        let current = &mut current[0];
+        if previous.y_max >= current.y_min {
+            let boundary = (previous.y_max + current.y_min) / 2.0;
+            previous.y_max = boundary;
+            current.y_min = boundary;
+        }
+    }
     regions
 }
 
@@ -250,21 +264,34 @@ fn redline_edit_regions(items: &[TextItem]) -> Vec<RedlineEditRegion> {
 fn underlined_table_columns(
     items: &[TextItem],
     redline_regions: &[RedlineEditRegion],
-) -> Vec<UnderlinedTableColumn> {
+) -> Vec<Vec<UnderlinedTableColumn>> {
     const X_ALIGNMENT_TOLERANCE: f32 = 4.0;
     const ROW_DEDUP_TOLERANCE: f32 = 8.0;
 
-    let mut columns: Vec<UnderlinedTableColumn> = Vec::new();
-    for (region_index, region) in redline_regions.iter().enumerate() {
+    // Sort underlines once by Y. Because redline regions are non-overlapping,
+    // the cursor assigns each underline to at most one region.
+    let mut underlined: Vec<&TextItem> = items.iter().filter(|item| item.is_underline).collect();
+    underlined.sort_by(|a, b| a.y.total_cmp(&b.y));
+
+    let mut columns_by_region = Vec::with_capacity(redline_regions.len());
+    let mut underline_start = 0;
+    for region in redline_regions {
         if region.spans_page_width {
+            columns_by_region.push(Vec::new());
             continue;
         }
-        let mut candidates: Vec<&TextItem> = items
-            .iter()
-            .filter(|item| item.is_underline && item.y >= region.y_min && item.y <= region.y_max)
-            .collect();
+        while underline_start < underlined.len() && underlined[underline_start].y < region.y_min {
+            underline_start += 1;
+        }
+        let mut underline_end = underline_start;
+        while underline_end < underlined.len() && underlined[underline_end].y <= region.y_max {
+            underline_end += 1;
+        }
+
+        let mut candidates = underlined[underline_start..underline_end].to_vec();
         candidates.sort_by(|a, b| a.x.total_cmp(&b.x));
 
+        let mut columns: Vec<UnderlinedTableColumn> = Vec::new();
         let mut left = 0;
         let mut min_y_indices = std::collections::VecDeque::new();
         let mut max_y_indices = std::collections::VecDeque::new();
@@ -288,17 +315,10 @@ fn underlined_table_columns(
             if has_aligned_peer {
                 let x_min = item.x - X_ALIGNMENT_TOLERANCE;
                 let x_max = item.x + X_ALIGNMENT_TOLERANCE;
-                if let Some(column) = columns
-                    .last_mut()
-                    .filter(|column| column.region_index == region_index && column.x_max >= x_min)
-                {
+                if let Some(column) = columns.last_mut().filter(|column| column.x_max >= x_min) {
                     column.x_max = column.x_max.max(x_max);
                 } else {
-                    columns.push(UnderlinedTableColumn {
-                        region_index,
-                        x_min,
-                        x_max,
-                    });
+                    columns.push(UnderlinedTableColumn { x_min, x_max });
                 }
             }
 
@@ -317,80 +337,93 @@ fn underlined_table_columns(
             }
             max_y_indices.push_back(index);
         }
+        columns_by_region.push(columns);
+        underline_start = underline_end;
     }
-    columns
+    columns_by_region
+}
+
+fn redline_region_at_y(redline_regions: &[RedlineEditRegion], y: f32) -> Option<usize> {
+    let region_index = redline_regions.partition_point(|region| region.y_max < y);
+    redline_regions
+        .get(region_index)
+        .filter(|region| y >= region.y_min)
+        .map(|_| region_index)
 }
 
 fn is_heuristic_table_evidence(
     item: &TextItem,
     redline_regions: &[RedlineEditRegion],
-    underlined_table_columns: &[UnderlinedTableColumn],
+    underlined_table_columns: &[Vec<UnderlinedTableColumn>],
 ) -> bool {
     if item.is_strikeout {
         return false;
     }
 
-    for (region_index, region) in redline_regions.iter().enumerate() {
-        if item.y < region.y_min || item.y > region.y_max {
-            continue;
-        }
-        if region.spans_page_width {
-            return false;
-        }
-
-        let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
-        if overlaps_x && !is_revised_table_cell(item, region_index, underlined_table_columns) {
-            return false;
-        }
+    let Some(region_index) = redline_region_at_y(redline_regions, item.y) else {
+        return true;
+    };
+    let region = &redline_regions[region_index];
+    if region.spans_page_width {
+        return false;
     }
 
-    true
+    let overlaps_x = item.x + item.width >= region.x_min && item.x <= region.x_max;
+    !overlaps_x || is_revised_table_cell(item, &underlined_table_columns[region_index])
 }
 
 fn is_revised_table_cell(
     item: &TextItem,
-    region_index: usize,
     underlined_table_columns: &[UnderlinedTableColumn],
 ) -> bool {
-    item.is_underline
-        && underlined_table_columns.iter().any(|column| {
-            column.region_index == region_index && item.x >= column.x_min && item.x <= column.x_max
-        })
+    if !item.is_underline {
+        return false;
+    }
+    let column_index = underlined_table_columns.partition_point(|column| column.x_max < item.x);
+    underlined_table_columns
+        .get(column_index)
+        .is_some_and(|column| item.x >= column.x_min)
 }
 
 fn revised_table_cell_indices(
     items: &[TextItem],
     redline_regions: &[RedlineEditRegion],
-    underlined_table_columns: &[UnderlinedTableColumn],
+    underlined_table_columns: &[Vec<UnderlinedTableColumn>],
 ) -> std::collections::HashSet<usize> {
     items
         .iter()
         .enumerate()
         .filter_map(|(item_index, item)| {
-            redline_regions
-                .iter()
-                .enumerate()
-                .any(|(region_index, region)| {
-                    !region.spans_page_width
-                        && item.y >= region.y_min
-                        && item.y <= region.y_max
-                        && item.x + item.width >= region.x_min
-                        && item.x <= region.x_max
-                        && is_revised_table_cell(item, region_index, underlined_table_columns)
-                })
-                .then_some(item_index)
+            let region_index = redline_region_at_y(redline_regions, item.y)?;
+            let region = &redline_regions[region_index];
+            (!region.spans_page_width
+                && item.x + item.width >= region.x_min
+                && item.x <= region.x_max
+                && is_revised_table_cell(item, &underlined_table_columns[region_index]))
+            .then_some(item_index)
         })
         .collect()
 }
 
 /// Detect tables in a set of text items from a single page
 pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bool) -> Vec<Table> {
+    detect_tables_with_page_width(items, base_font_size, skip_body_font, content_width(items))
+}
+
+/// Detect tables in a subset while using the full page's text width for
+/// page-spanning redline classification.
+pub(crate) fn detect_tables_with_page_width(
+    items: &[TextItem],
+    base_font_size: f32,
+    skip_body_font: bool,
+    page_width: f32,
+) -> Vec<Table> {
     if items.len() < 6 {
         return vec![];
     }
     // Compute these before consolidation: adjacent old/new text can merge and
     // inherit only the first fragment's decoration flags.
-    let redline_regions = redline_edit_regions(items);
+    let redline_regions = redline_edit_regions(items, page_width);
     let underlined_table_columns = underlined_table_columns(items, &redline_regions);
     let revised_table_cells =
         revised_table_cell_indices(items, &redline_regions, &underlined_table_columns);
@@ -2082,6 +2115,26 @@ mod tests {
         assert!(
             !detect_tables(&items, 12.0, false).is_empty(),
             "aligned replacement cells must preserve a partially revised table"
+        );
+    }
+
+    #[test]
+    fn narrow_layout_band_uses_full_page_width_for_redline_scope() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            items.push(body_item("row label", 190.0, y, false));
+            items.push(body_item("old value", 300.0, y, true));
+            let mut replacement = body_item("new value", 300.0, y, false);
+            replacement.is_underline = true;
+            items.push(replacement);
+        }
+
+        assert!(redline_edit_regions(&items, content_width(&items))[0].spans_page_width);
+        assert!(!redline_edit_regions(&items, 500.0)[0].spans_page_width);
+        assert!(
+            !detect_tables_with_page_width(&items, 12.0, false, 500.0).is_empty(),
+            "a narrow band must use full-page context to preserve revised table cells"
         );
     }
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -83,8 +83,11 @@ fn merge_adjacent_items_preserving(
                 // Proven replacement cells must retain their own decoration.
                 // Otherwise an adjacent old/new pair inherits only the first
                 // fragment's flags and can lose the live table evidence.
-                let decoration_changes = next_item.is_underline != first_item.is_underline
-                    || next_item.is_strikeout != first_item.is_strikeout;
+                let decoration_changes = indices.iter().any(|index| {
+                    let merged_item = &items[*index];
+                    next_item.is_underline != merged_item.is_underline
+                        || next_item.is_strikeout != merged_item.is_strikeout
+                });
                 if decoration_changes
                     && (indices
                         .iter()
@@ -331,7 +334,9 @@ fn underlined_table_columns(
     let mut candidates_by_region: Vec<Vec<&TextItem>> = vec![Vec::new(); redline_regions.len()];
     for item in live_items {
         if let Some(region_index) = redline_region_at_y(redline_regions, item.y) {
-            candidates_by_region[region_index].push(item);
+            if overlaps_redline_x(item, &redline_regions[region_index]) {
+                candidates_by_region[region_index].push(item);
+            }
         }
     }
 
@@ -2029,6 +2034,24 @@ mod tests {
     }
 
     #[test]
+    fn merge_adjacent_items_keeps_preserved_fragment_out_of_mixed_run() {
+        let mut prefix = body_item("prefix", 20.0, 700.0, false);
+        prefix.is_underline = true;
+        let deleted = body_item("deleted", 111.0, 700.0, true);
+        let mut replacement = body_item("replacement", 202.0, 700.0, false);
+        replacement.is_underline = true;
+        let preserved_indices = std::collections::HashSet::from([2]);
+
+        let (merged, index_map) =
+            merge_adjacent_items_preserving(&[prefix, deleted, replacement], &preserved_indices);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(index_map, vec![vec![0, 1], vec![2]]);
+        assert!(merged[0].is_underline);
+        assert!(merged[1].is_underline);
+    }
+
+    #[test]
     fn body_font_redline_deletions_do_not_create_a_table() {
         let mut items = Vec::new();
         for row in 0..8 {
@@ -2150,6 +2173,26 @@ mod tests {
         assert!(
             detect_tables(&items, 12.0, false).is_empty(),
             "full-width redline prose must not retain table-shaped fragments"
+        );
+    }
+
+    #[test]
+    fn wide_redline_prose_ignores_underlines_outside_edit_span() {
+        let mut items = Vec::new();
+        for row in 0..8 {
+            let y = 700.0 - row as f32 * 16.0;
+            let mut line_number = body_item("line number", 50.0, y, false);
+            line_number.is_underline = row < 2;
+            items.push(line_number);
+            items.push(body_item("live prose fragment", 160.0, y, false));
+            let strikeout_x = if row % 2 == 0 { 280.0 } else { 430.0 };
+            items.push(body_item("deleted prose", strikeout_x, y, true));
+        }
+
+        assert!(redline_edit_regions(&items, content_width(&items))[0].spans_page_width);
+        assert!(
+            detect_tables(&items, 12.0, false).is_empty(),
+            "underlines outside the edit span must not disable the wide-prose veto"
         );
     }
 

--- a/src/tables/grid.rs
+++ b/src/tables/grid.rs
@@ -436,7 +436,8 @@ pub(crate) fn recover_header_row(
         .iter()
         .enumerate()
         .filter(|(_, item)| {
-            item.font_size > small_font_threshold
+            !item.is_strikeout
+                && item.font_size > small_font_threshold
                 && item.y > first_row_y
                 && item.y <= first_row_y + row_gap_limit
         })
@@ -802,6 +803,31 @@ mod tests {
         let rows_before = table.rows.len();
         recover_header_row(&mut table, &all_items, 9.0);
         assert_eq!(table.rows.len(), rows_before);
+    }
+
+    #[test]
+    fn test_recover_header_row_skips_strikeout_candidates() {
+        let mut old_col1 = make_item("Old Col1", 100.0, 520.0, 12.0);
+        old_col1.is_strikeout = true;
+        let mut old_col2 = make_item("Old Col2", 200.0, 520.0, 12.0);
+        old_col2.is_strikeout = true;
+        let all_items = vec![
+            old_col1,
+            old_col2,
+            make_item("A", 100.0, 500.0, 8.0),
+            make_item("B", 200.0, 500.0, 8.0),
+        ];
+        let mut table = Table {
+            columns: vec![100.0, 200.0],
+            rows: vec![500.0, 480.0],
+            cells: vec![vec!["A".into(), "B".into()], vec!["C".into(), "D".into()]],
+            item_indices: vec![2, 3],
+            kind: TableKind::Data,
+        };
+
+        recover_header_row(&mut table, &all_items, 9.0);
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.cells[0], vec!["A", "B"]);
     }
 
     #[test]

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -12,7 +12,9 @@ mod grid;
 pub mod structured;
 
 pub use detect_heuristic::detect_tables;
-pub(crate) use detect_heuristic::is_table_of_contents;
+pub(crate) use detect_heuristic::{
+    content_width, detect_tables_with_page_width, is_table_of_contents,
+};
 pub use detect_lines::detect_tables_from_lines;
 pub(crate) use detect_lines::detect_vector_grid_tables_from_lines;
 pub(crate) use detect_rects::cluster_rects;

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,14 +148,17 @@ impl TextLine {
         self.text_with_formatting(false, false, false)
     }
 
-    /// Get text with optional bold/italic/underline markdown formatting
+    /// Get text with optional bold/italic/decorative markdown formatting.
+    ///
+    /// `format_decorations` enables both geometrically detected source
+    /// decorations: underline (`<u>`) and strikeout (`<s>`).
     pub fn text_with_formatting(
         &self,
         format_bold: bool,
         format_italic: bool,
-        format_underline: bool,
+        format_decorations: bool,
     ) -> String {
-        if !format_bold && !format_italic && !format_underline {
+        if !format_bold && !format_italic && !format_decorations {
             return self.text_plain();
         }
 
@@ -165,6 +168,7 @@ impl TextLine {
         let mut current_bold = false;
         let mut current_italic = false;
         let mut current_underline = false;
+        let mut current_strikeout = false;
 
         for (i, item) in self.items.iter().enumerate() {
             let text = item.text.as_str();
@@ -190,13 +194,16 @@ impl TextLine {
             // we push text_trimmed below (which strips it).
             let has_leading_space = text.starts_with(' ');
 
-            // Check for style changes. Underline is exclusive: `<u>` content
-            // stays free of `**`/`*` markers — consumers (and the eval
-            // harnesses this feeds) match the tag content literally, and
-            // mixed `<u>**x**</u>` nesting breaks that.
-            let item_underline = format_underline && item.is_underline;
-            let item_bold = format_bold && item.is_bold && !item_underline;
-            let item_italic = format_italic && item.is_italic && !item_underline;
+            // Check for style changes. Source decorations are exclusive:
+            // `<u>`/`<s>` content stays free of `**`/`*` markers — consumers
+            // (and the eval harnesses this feeds) match tag content literally,
+            // and mixed nesting breaks that. A struck-and-underlined item is
+            // emitted as struck text because deletion is the stronger semantic
+            // distinction in redline documents.
+            let item_strikeout = format_decorations && item.is_strikeout;
+            let item_underline = format_decorations && item.is_underline && !item_strikeout;
+            let item_bold = format_bold && item.is_bold && !item_underline && !item_strikeout;
+            let item_italic = format_italic && item.is_italic && !item_underline && !item_strikeout;
 
             // Close previous styles if they change
             if current_italic && !item_italic {
@@ -211,6 +218,10 @@ impl TextLine {
                 result.push_str("</u>");
                 current_underline = false;
             }
+            if current_strikeout && !item_strikeout {
+                result.push_str("</s>");
+                current_strikeout = false;
+            }
 
             // Add space: either from spacing logic or preserved from item text
             if needs_space || (has_leading_space && !result.is_empty() && !result.ends_with(' ')) {
@@ -221,6 +232,10 @@ impl TextLine {
             if item_underline && !current_underline {
                 result.push_str("<u>");
                 current_underline = true;
+            }
+            if item_strikeout && !current_strikeout {
+                result.push_str("<s>");
+                current_strikeout = true;
             }
             if item_bold && !current_bold {
                 result.push_str("**");
@@ -243,6 +258,9 @@ impl TextLine {
         }
         if current_underline {
             result.push_str("</u>");
+        }
+        if current_strikeout {
+            result.push_str("</s>");
         }
 
         result
@@ -307,5 +325,90 @@ impl TextLine {
             || was_sub_super
             || should_join
             || space_already_exists)
+    }
+}
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::{ItemType, TextItem, TextLine};
+
+    fn item(text: &str, x: f32, width: f32, strikeout: bool) -> TextItem {
+        TextItem {
+            text: text.to_string(),
+            x,
+            y: 100.0,
+            width,
+            height: 12.0,
+            font: "F1".to_string(),
+            font_size: 12.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: strikeout,
+            item_type: ItemType::Text,
+            mcid: None,
+        }
+    }
+
+    fn line(items: Vec<TextItem>) -> TextLine {
+        TextLine {
+            items,
+            y: 100.0,
+            page: 1,
+            adaptive_threshold: 0.1,
+        }
+    }
+
+    #[test]
+    fn formatting_emits_semantic_strikeout() {
+        let line = line(vec![item("deleted", 10.0, 42.0, true)]);
+
+        assert_eq!(
+            line.text_with_formatting(true, true, true),
+            "<s>deleted</s>"
+        );
+    }
+
+    #[test]
+    fn formatting_closes_strikeout_before_live_text() {
+        let line = line(vec![
+            item("keep", 10.0, 24.0, false),
+            item("remove", 40.0, 42.0, true),
+            item("keep", 88.0, 24.0, false),
+        ]);
+
+        assert_eq!(
+            line.text_with_formatting(true, true, true),
+            "keep <s>remove</s> keep"
+        );
+    }
+
+    #[test]
+    fn formatting_coalesces_adjacent_struck_items() {
+        let line = line(vec![
+            item("deleted", 10.0, 42.0, true),
+            item("words", 58.0, 30.0, true),
+        ]);
+
+        assert_eq!(
+            line.text_with_formatting(true, true, true),
+            "<s>deleted words</s>"
+        );
+    }
+
+    #[test]
+    fn strikeout_takes_precedence_over_other_styles() {
+        let mut decorated = item("deleted", 10.0, 42.0, true);
+        decorated.is_bold = true;
+        decorated.is_italic = true;
+        decorated.is_underline = true;
+        let line = line(vec![decorated]);
+
+        assert_eq!(
+            line.text_with_formatting(true, true, true),
+            "<s>deleted</s>"
+        );
+        assert_eq!(line.text(), "deleted");
     }
 }


### PR DESCRIPTION
## Summary
- keep redline prose out of heuristic table detection without suppressing real underlined or partially revised tables
- preserve detected deletions as semantic `<s>` runs while keeping the existing public formatting signature

## Problem
On the linked enrolled-bill PDF, aligned source edits make the body-font heuristic turn one purpose clause into a 12×4 table. The resulting Markdown reorders the sentence into cells such as `|monitoring|of certain|under|`, and detected deletions are emitted as ordinary live text.

The current head of #234 still reproduces this source-decoration case, so this change is limited to the residual redline path.

## Testing
- `cargo test` — 763 unit tests, 147 integration tests, and 2 doc tests passed
- `cargo fmt --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo build --release` — passed
- linked `sb0818E.pdf`, page 1 — the false 12×4 table is absent; the purpose clause remains ordered and includes `<s>annual</s>`, `<s>to conduct ongoing</s>`, and `<s>implementation</s>`

Fixes #238

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788390974&installation_model_id=11126&pr_number=240&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F240&signature=3ee10c9e38d7e26303d2490d31df11f541f2555123781471a765540cf92aeeac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

