### PR TITLE
fix(text): handle broken Thai glyph spacing

### DIFF
--- a/src/text_quality.rs
+++ b/src/text_quality.rs
@@ -24,6 +24,7 @@
 //! - **Substitution-cipher letter statistics**: pure-ASCII output whose letter
 //!   distribution is a permutation of natural language ([`CipherGarbleStats`]).
 
+use crate::text_utils::is_legacy_thai_pua_char;
 use crate::types::TextItem;
 use crate::{add_ocr_reason, OCR_REASON_SUSPECTED_GARBLED_TEXT};
 use std::collections::BTreeMap;
@@ -472,10 +473,11 @@ fn token_has_cid_control(token: &str) -> bool {
 }
 
 fn is_private_use_char(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0xE000..=0xF8FF | 0xF0000..=0xFFFFD | 0x100000..=0x10FFFD
-    )
+    !is_legacy_thai_pua_char(ch)
+        && matches!(
+            ch as u32,
+            0xE000..=0xF8FF | 0xF0000..=0xFFFFD | 0x100000..=0x10FFFD
+        )
 }
 
 /// Check if extracted text is predominantly garbage (non-alphanumeric).
@@ -594,8 +596,8 @@ mod tests {
     }
 
     #[test]
-    fn thai_and_private_use_in_one_span_route_page_to_ocr() {
-        let report = analyze_text_quality(&[text_item("ภาษาไทย \u{F70B}", 20)]);
+    fn thai_and_unknown_private_use_in_one_span_route_page_to_ocr() {
+        let report = analyze_text_quality(&[text_item("ภาษาไทย \u{E123}", 20)]);
 
         assert_eq!(report.pages_needing_ocr, vec![20]);
         assert_eq!(
@@ -610,8 +612,13 @@ mod tests {
     }
 
     #[test]
-    fn thai_private_use_glyph_is_an_encoding_issue() {
-        assert!(detect_encoding_issues("ไม่ได้ ได\u{F70B} สามารถ"));
+    fn unknown_thai_private_use_glyph_is_an_encoding_issue() {
+        assert!(detect_encoding_issues("ไม่ได้ ได\u{E123} สามารถ"));
+    }
+
+    #[test]
+    fn known_legacy_thai_pua_does_not_force_ocr_fallback() {
+        assert!(!detect_encoding_issues("ไม่ได้ ได\u{F70B} \u{F88E} สามารถ"));
     }
 
     #[test]

--- a/src/text_quality.rs
+++ b/src/text_quality.rs
@@ -48,7 +48,18 @@ pub(crate) fn detect_encoding_issues(markdown: &str) -> bool {
         return true;
     }
 
-    // Heuristic 3: substitution-cipher letter statistics (broken ToUnicode)
+    // Heuristic 3: broken Thai cluster spacing. This commonly indicates a
+    // legacy ToUnicode map that lost NIKHAHIT from SARA AM (for example
+    // `ค าน า` instead of `คำนำ`).
+    if has_broken_thai_spacing(markdown) {
+        return true;
+    }
+
+    if has_thai_private_use_token(markdown) {
+        return true;
+    }
+
+    // Heuristic 4: substitution-cipher letter statistics (broken ToUnicode)
     let mut stats = CipherGarbleStats::default();
     stats.add_text(markdown);
     stats.looks_garbled()
@@ -73,6 +84,43 @@ fn has_dollar_as_space_pattern(markdown: &str) -> bool {
     }
 
     false
+}
+
+fn has_broken_thai_spacing(text: &str) -> bool {
+    let chars: Vec<char> = text.chars().collect();
+    for (index, ch) in chars.iter().copied().enumerate() {
+        if !matches!(ch, '\u{0E01}'..='\u{0E2E}') {
+            continue;
+        }
+
+        let mut next = index + 1;
+        while next < chars.len() && matches!(chars[next], ' ' | '\t' | '\u{00A0}') {
+            next += 1;
+        }
+        if next == index + 1 || next >= chars.len() {
+            continue;
+        }
+
+        if chars[next] == '\u{0E32}'
+            || matches!(
+                chars[next],
+                '\u{0E31}' | '\u{0E34}'..='\u{0E3A}' | '\u{0E47}'..='\u{0E4E}'
+            )
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_thai_private_use_token(text: &str) -> bool {
+    text.split_whitespace().any(has_thai_private_use_span)
+}
+
+fn has_thai_private_use_span(text: &str) -> bool {
+    text.chars().any(|ch| matches!(ch, '\u{0E00}'..='\u{0E7F}'))
+        && text.chars().any(is_private_use_char)
 }
 
 /// English letter frequencies (percent, a–z). Used as a natural-language
@@ -318,6 +366,8 @@ fn text_span_decoding_issue_kind(text: &str) -> Option<TextSpanIssueKind> {
     }
 
     if has_dollar_as_space_pattern(text)
+        || has_broken_thai_spacing(text)
+        || has_thai_private_use_span(text)
         || has_private_use_text_run(text)
         || is_cid_garbage(text)
         || has_cid_control_token(text)
@@ -517,4 +567,62 @@ pub(crate) fn is_cid_garbage(text: &str) -> bool {
     // page to OCR.
     let ascii_letters = text.chars().filter(|c| c.is_ascii_alphabetic()).count();
     total >= 20 && high_latin * 5 >= total * 2 && ascii_letters * 3 < total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ItemType;
+
+    fn text_item(text: &str, page: u32) -> TextItem {
+        TextItem {
+            text: text.to_string(),
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 12.0,
+            font: "ThaiTest".to_string(),
+            font_size: 12.0,
+            page,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        }
+    }
+
+    #[test]
+    fn thai_and_private_use_in_one_span_route_page_to_ocr() {
+        let report = analyze_text_quality(&[text_item("ภาษาไทย \u{F70B}", 20)]);
+
+        assert_eq!(report.pages_needing_ocr, vec![20]);
+        assert_eq!(
+            report.reasons_by_page.get(&20),
+            Some(&vec![OCR_REASON_SUSPECTED_GARBLED_TEXT.to_string()])
+        );
+    }
+
+    #[test]
+    fn broken_thai_sara_am_spacing_is_an_encoding_issue() {
+        assert!(detect_encoding_issues("ค าน า"));
+    }
+
+    #[test]
+    fn thai_private_use_glyph_is_an_encoding_issue() {
+        assert!(detect_encoding_issues("ไม่ได้ ได\u{F70B} สามารถ"));
+    }
+
+    #[test]
+    fn separate_private_use_icon_does_not_condemn_thai_page() {
+        assert!(!detect_encoding_issues(
+            "\u{E000} ข้อมูล ภาษาไทย สำหรับประชาชน"
+        ));
+    }
+
+    #[test]
+    fn normal_thai_spaces_are_not_an_encoding_issue() {
+        assert!(!detect_encoding_issues("ข้อมูล ภาษาไทย สำหรับประชาชน"));
+    }
 }

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -5,6 +5,7 @@
 //! and markdown pipelines.
 
 use crate::types::TextItem;
+use std::borrow::Cow;
 use unicode_normalization::UnicodeNormalization;
 
 /// Return whether text is an explicit page-number expression.
@@ -166,8 +167,14 @@ pub(crate) fn is_legacy_thai_pua_char(c: char) -> bool {
     normalize_legacy_thai_pua_char(c) != c
 }
 
-pub(crate) fn normalize_legacy_thai_pua(text: &str) -> String {
-    text.chars().map(normalize_legacy_thai_pua_char).collect()
+pub(crate) fn normalize_legacy_thai_pua(text: &str) -> Cow<'_, str> {
+    if !text.chars().any(is_legacy_thai_pua_char) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut normalized = String::with_capacity(text.len());
+    normalized.extend(text.chars().map(normalize_legacy_thai_pua_char));
+    Cow::Owned(normalized)
 }
 
 pub(crate) fn is_rtl_char(c: char) -> bool {
@@ -967,6 +974,23 @@ mod tests {
     #[test]
     fn legacy_thai_pua_is_normalized_outside_tounicode_path() {
         assert_eq!(expand_ligatures("ก\u{F70B} \u{F89E}\u{F89B}"), "ก้ ฐุ");
+    }
+
+    #[test]
+    fn legacy_thai_pua_normalization_borrows_unchanged_text() {
+        let text = "Plain text ภาษาไทย";
+        assert!(matches!(
+            normalize_legacy_thai_pua(text),
+            std::borrow::Cow::Borrowed(value) if value == text
+        ));
+    }
+
+    #[test]
+    fn legacy_thai_pua_normalization_owns_changed_text() {
+        assert!(matches!(
+            normalize_legacy_thai_pua("ก\u{F70B}"),
+            std::borrow::Cow::Owned(value) if value == "ก้"
+        ));
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -5,7 +5,6 @@
 //! and markdown pipelines.
 
 use crate::types::TextItem;
-use std::borrow::Cow;
 use unicode_normalization::UnicodeNormalization;
 
 /// Return whether text is an explicit page-number expression.
@@ -167,14 +166,10 @@ pub(crate) fn is_legacy_thai_pua_char(c: char) -> bool {
     normalize_legacy_thai_pua_char(c) != c
 }
 
-pub(crate) fn normalize_legacy_thai_pua(text: &str) -> Cow<'_, str> {
-    if !text.chars().any(is_legacy_thai_pua_char) {
-        return Cow::Borrowed(text);
-    }
-
+pub(crate) fn normalize_legacy_thai_pua(text: &str) -> String {
     let mut normalized = String::with_capacity(text.len());
     normalized.extend(text.chars().map(normalize_legacy_thai_pua_char));
-    Cow::Owned(normalized)
+    normalized
 }
 
 pub(crate) fn is_rtl_char(c: char) -> bool {
@@ -977,20 +972,21 @@ mod tests {
     }
 
     #[test]
-    fn legacy_thai_pua_normalization_borrows_unchanged_text() {
-        let text = "Plain text ภาษาไทย";
-        assert!(matches!(
-            normalize_legacy_thai_pua(text),
-            std::borrow::Cow::Borrowed(value) if value == text
-        ));
+    fn legacy_thai_pua_normalization_returns_owned_unchanged_text() {
+        fn assert_owned_string(_: String) {}
+
+        let normalized = normalize_legacy_thai_pua("Plain text ภาษาไทย");
+        assert_eq!(normalized, "Plain text ภาษาไทย");
+        assert_owned_string(normalized);
     }
 
     #[test]
-    fn legacy_thai_pua_normalization_owns_changed_text() {
-        assert!(matches!(
-            normalize_legacy_thai_pua("ก\u{F70B}"),
-            std::borrow::Cow::Owned(value) if value == "ก้"
-        ));
+    fn legacy_thai_pua_normalization_returns_owned_changed_text() {
+        fn assert_owned_string(_: String) {}
+
+        let normalized = normalize_legacy_thai_pua("ก\u{F70B}");
+        assert_eq!(normalized, "ก้");
+        assert_owned_string(normalized);
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -101,6 +101,20 @@ pub(crate) fn is_cjk_char(c: char) -> bool {
     )
 }
 
+/// Thai glyphs are often emitted as separate CID text operators. In
+/// particular, dependent vowels and tone marks must remain attached to the
+/// preceding base glyph even when PDF positioning introduces a small gap.
+fn is_thai_char(c: char) -> bool {
+    matches!(c, '\u{0E00}'..='\u{0E7F}')
+}
+
+fn is_thai_combining_mark(c: char) -> bool {
+    matches!(
+        c,
+        '\u{0E31}' | '\u{0E34}'..='\u{0E3A}' | '\u{0E47}'..='\u{0E4E}'
+    )
+}
+
 pub(crate) fn is_rtl_char(c: char) -> bool {
     matches!(c,
         '\u{0590}'..='\u{05FF}'   // Hebrew
@@ -247,6 +261,23 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
             '\u{2000}'..='\u{200A}' => result.push(' '), // en/em/thin/hair spaces etc.
             _ => result.push(ch),
         }
+    }
+
+    // Some Thai PDFs emit dependent vowels and tone marks in the same text
+    // item but insert a synthetic ASCII space before the mark. A combining
+    // mark cannot begin an independent Thai cluster, so removing only that
+    // inline whitespace is safe while preserving real inter-word spaces.
+    if result.chars().any(is_thai_combining_mark) {
+        let mut normalized = String::with_capacity(result.len());
+        for ch in result.chars() {
+            if is_thai_combining_mark(ch) {
+                while matches!(normalized.chars().last(), Some(' ' | '\t' | '\u{00A0}')) {
+                    normalized.pop();
+                }
+            }
+            normalized.push(ch);
+        }
+        result = normalized;
     }
 
     // If the original text had Arabic presentation forms, the characters are in
@@ -666,6 +697,12 @@ pub(crate) fn should_join_items(
             return false;
         }
 
+        // A standalone Thai combining mark is always part of the preceding
+        // cluster. Explicit source spaces were already handled above.
+        if curr_first.is_some_and(is_thai_combining_mark) {
+            return true;
+        }
+
         // CID fonts (C2_*, C0_*) emit one word per text operator with gaps ≈ 0
         // between words. Detect these and add spaces. Only applies to CID fonts —
         // non-CID fonts (Type1/TrueType) emit phrases or fragments with small gaps
@@ -677,8 +714,15 @@ pub(crate) fn should_join_items(
         let curr_first_char = curr_item.text.trim().chars().next();
         let is_cjk =
             prev_last_char.is_some_and(is_cjk_char) || curr_first_char.is_some_and(is_cjk_char);
+        let is_thai =
+            prev_last_char.is_some_and(is_thai_char) && curr_first_char.is_some_and(is_thai_char);
 
-        if !is_cjk && gap >= 0.0 && gap < font_size * 0.01 && is_cid_font(&prev_item.font) {
+        if !is_cjk
+            && !is_thai
+            && gap >= 0.0
+            && gap < font_size * 0.01
+            && is_cid_font(&prev_item.font)
+        {
             let prev_word_count = prev_item.text.split_whitespace().count();
 
             if prev_word_count >= 3 {
@@ -800,6 +844,10 @@ pub(crate) fn should_join_items(
         return false;
     }
 
+    if curr_first.is_some_and(is_thai_combining_mark) {
+        return gap < char_width * 2.0;
+    }
+
     // CJK text: always join adjacent items — CJK languages don't use spaces between words.
     // The Latin case-based heuristics below would incorrectly insert spaces within CJK words.
     let is_cjk = prev_last.is_some_and(is_cjk_char) || curr_first.is_some_and(is_cjk_char);
@@ -851,6 +899,16 @@ mod tests {
         assert!(!is_bold_font("NimbusRomNo9L-ReguItal"));
         // Medium-Italic exclusion still holds
         assert!(!is_bold_font("Foo-MediumItalic"));
+    }
+
+    #[test]
+    fn thai_combining_marks_drop_synthetic_spaces() {
+        assert_eq!(expand_ligatures("ถ ึง กรณ ีที่ ต ้องการ"), "ถึง กรณีที่ ต้องการ");
+    }
+
+    #[test]
+    fn thai_normalization_preserves_real_spaces() {
+        assert_eq!(expand_ligatures("ข้อมูล ภาษาไทย"), "ข้อมูล ภาษาไทย");
     }
 
     #[test]
@@ -1178,6 +1236,44 @@ mod tests {
             item_type: ItemType::Text,
             mcid: None,
         }
+    }
+
+    #[test]
+    fn thai_cid_fragments_with_zero_gap_join() {
+        let fs = 12.0;
+        let mut consonant = make_text_item("ค", 100.0, 6.0, fs);
+        let mut vowel = make_text_item("า", 106.0, 6.0, fs);
+        consonant.font = "C2_1".to_string();
+        vowel.font = "C2_1".to_string();
+
+        assert!(
+            should_join_items(&consonant, &vowel, 0.10),
+            "adjacent Thai CID fragments must not receive a synthetic space"
+        );
+    }
+
+    #[test]
+    fn thai_combining_mark_joins_across_positioning_gap() {
+        let fs = 12.0;
+        let consonant = make_text_item("ถ", 100.0, 6.0, fs);
+        let mark = make_text_item("ึ", 109.0, 0.0, fs);
+
+        assert!(
+            should_join_items(&consonant, &mark, 0.10),
+            "Thai combining marks must remain attached to their base glyph"
+        );
+    }
+
+    #[test]
+    fn thai_fragments_preserve_explicit_space() {
+        let fs = 12.0;
+        let first = make_text_item("ข้อมูล", 100.0, 30.0, fs);
+        let second = make_text_item(" ภาษาไทย", 130.0, 42.0, fs);
+
+        assert!(
+            !should_join_items(&first, &second, 0.10),
+            "an explicit source space must remain a boundary"
+        );
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -115,6 +115,61 @@ fn is_thai_combining_mark(c: char) -> bool {
     )
 }
 
+/// Map positional Thai glyphs from the legacy Microsoft Windows and Apple
+/// MacOS PUA extensions back to their semantic Unicode characters.
+///
+/// Mapping source: https://linux.thai.net/~thep/th-otf/shaping.html
+pub(crate) fn normalize_legacy_thai_pua_char(c: char) -> char {
+    match c {
+        // Microsoft Windows Thai PUA extension (U+F700-U+F71A).
+        '\u{F700}' => '\u{0E10}',
+        '\u{F701}' => '\u{0E34}',
+        '\u{F702}' => '\u{0E35}',
+        '\u{F703}' => '\u{0E36}',
+        '\u{F704}' => '\u{0E37}',
+        '\u{F705}' | '\u{F70A}' | '\u{F713}' => '\u{0E48}',
+        '\u{F706}' | '\u{F70B}' | '\u{F714}' => '\u{0E49}',
+        '\u{F707}' | '\u{F70C}' | '\u{F715}' => '\u{0E4A}',
+        '\u{F708}' | '\u{F70D}' | '\u{F716}' => '\u{0E4B}',
+        '\u{F709}' | '\u{F70E}' | '\u{F717}' => '\u{0E4C}',
+        '\u{F70F}' => '\u{0E0D}',
+        '\u{F710}' => '\u{0E31}',
+        '\u{F711}' => '\u{0E4D}',
+        '\u{F712}' => '\u{0E47}',
+        '\u{F718}' => '\u{0E38}',
+        '\u{F719}' => '\u{0E39}',
+        '\u{F71A}' => '\u{0E3A}',
+
+        // Apple MacOS Thai PUA extension (U+F884-U+F89E).
+        '\u{F884}' => '\u{0E31}',
+        '\u{F885}' => '\u{0E34}',
+        '\u{F886}' => '\u{0E35}',
+        '\u{F887}' => '\u{0E36}',
+        '\u{F888}' => '\u{0E37}',
+        '\u{F889}' => '\u{0E47}',
+        '\u{F88A}' | '\u{F88B}' | '\u{F88C}' => '\u{0E48}',
+        '\u{F88D}' | '\u{F88E}' | '\u{F88F}' => '\u{0E49}',
+        '\u{F890}' | '\u{F891}' | '\u{F892}' => '\u{0E4A}',
+        '\u{F893}' | '\u{F894}' | '\u{F895}' => '\u{0E4B}',
+        '\u{F896}' | '\u{F897}' | '\u{F898}' => '\u{0E4C}',
+        '\u{F899}' => '\u{0E4D}',
+        '\u{F89A}' => '\u{0E0D}',
+        '\u{F89B}' => '\u{0E38}',
+        '\u{F89C}' => '\u{0E39}',
+        '\u{F89D}' => '\u{0E3A}',
+        '\u{F89E}' => '\u{0E10}',
+        _ => c,
+    }
+}
+
+pub(crate) fn is_legacy_thai_pua_char(c: char) -> bool {
+    normalize_legacy_thai_pua_char(c) != c
+}
+
+pub(crate) fn normalize_legacy_thai_pua(text: &str) -> String {
+    text.chars().map(normalize_legacy_thai_pua_char).collect()
+}
+
 pub(crate) fn is_rtl_char(c: char) -> bool {
     matches!(c,
         '\u{0590}'..='\u{05FF}'   // Hebrew
@@ -259,7 +314,7 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
             // Excludes NBSP (U+00A0) which is common in PDFs and handled
             // correctly by existing coordinate-based spacing.
             '\u{2000}'..='\u{200A}' => result.push(' '), // en/em/thin/hair spaces etc.
-            _ => result.push(ch),
+            _ => result.push(normalize_legacy_thai_pua_char(ch)),
         }
     }
 
@@ -271,7 +326,10 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
         let mut normalized = String::with_capacity(result.len());
         for ch in result.chars() {
             if is_thai_combining_mark(ch) {
-                while matches!(normalized.chars().last(), Some(' ' | '\t' | '\u{00A0}')) {
+                while matches!(
+                    normalized.chars().next_back(),
+                    Some(' ' | '\t' | '\u{00A0}')
+                ) {
                     normalized.pop();
                 }
             }
@@ -904,6 +962,11 @@ mod tests {
     #[test]
     fn thai_combining_marks_drop_synthetic_spaces() {
         assert_eq!(expand_ligatures("ถ ึง กรณ ีที่ ต ้องการ"), "ถึง กรณีที่ ต้องการ");
+    }
+
+    #[test]
+    fn legacy_thai_pua_is_normalized_outside_tounicode_path() {
+        assert_eq!(expand_ligatures("ก\u{F70B} \u{F89E}\u{F89B}"), "ก้ ฐุ");
     }
 
     #[test]

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::glyph_names::glyph_to_char;
+use crate::text_utils::{normalize_legacy_thai_pua, normalize_legacy_thai_pua_char};
 
 #[cfg(target_arch = "wasm32")]
 static BUILTIN_CMAPS: include_dir::Dir<'_> =
@@ -399,7 +400,7 @@ impl ToUnicodeCMap {
     pub fn lookup(&self, cid: u16) -> Option<String> {
         // First check direct mappings
         if let Some(s) = self.char_map.get(&cid) {
-            return Some(s.clone());
+            return Some(normalize_legacy_thai_pua(s));
         }
 
         // Binary search through sorted ranges
@@ -414,7 +415,7 @@ impl ToUnicodeCMap {
             if cid >= start && cid <= end {
                 let unicode = base + (cid - start) as u32;
                 if let Some(c) = char::from_u32(unicode) {
-                    return Some(c.to_string());
+                    return Some(normalize_legacy_thai_pua_char(c).to_string());
                 }
             }
         }
@@ -425,7 +426,7 @@ impl ToUnicodeCMap {
             if cid >= start && cid <= end {
                 let unicode = base + (cid - start) as u32;
                 if let Some(c) = char::from_u32(unicode) {
-                    return Some(c.to_string());
+                    return Some(normalize_legacy_thai_pua_char(c).to_string());
                 }
             }
         }
@@ -2645,6 +2646,88 @@ endbfchar
         // "AB " in 2-byte CID encoding
         let cids = [0x00, 0x24, 0x00, 0x25, 0x00, 0x03];
         assert_eq!(cmap.decode_cids(&cids), "AB ");
+    }
+
+    #[test]
+    fn legacy_windows_thai_pua_is_normalized_during_lookup() {
+        let expected = [
+            '\u{0E10}', '\u{0E34}', '\u{0E35}', '\u{0E36}', '\u{0E37}', '\u{0E48}', '\u{0E49}',
+            '\u{0E4A}', '\u{0E4B}', '\u{0E4C}', '\u{0E48}', '\u{0E49}', '\u{0E4A}', '\u{0E4B}',
+            '\u{0E4C}', '\u{0E0D}', '\u{0E31}', '\u{0E4D}', '\u{0E47}', '\u{0E48}', '\u{0E49}',
+            '\u{0E4A}', '\u{0E4B}', '\u{0E4C}', '\u{0E38}', '\u{0E39}', '\u{0E3A}',
+        ];
+        let mut cmap = ToUnicodeCMap::new();
+        for (index, pua) in ('\u{F700}'..='\u{F71A}').enumerate() {
+            cmap.char_map.insert(index as u16, pua.to_string());
+            assert_eq!(cmap.lookup(index as u16), Some(expected[index].to_string()));
+        }
+    }
+
+    #[test]
+    fn legacy_mac_thai_pua_is_normalized_during_lookup() {
+        let mappings = [
+            ('\u{F884}', '\u{0E31}'),
+            ('\u{F885}', '\u{0E34}'),
+            ('\u{F886}', '\u{0E35}'),
+            ('\u{F887}', '\u{0E36}'),
+            ('\u{F888}', '\u{0E37}'),
+            ('\u{F889}', '\u{0E47}'),
+            ('\u{F88A}', '\u{0E48}'),
+            ('\u{F88B}', '\u{0E48}'),
+            ('\u{F88C}', '\u{0E48}'),
+            ('\u{F88D}', '\u{0E49}'),
+            ('\u{F88E}', '\u{0E49}'),
+            ('\u{F88F}', '\u{0E49}'),
+            ('\u{F890}', '\u{0E4A}'),
+            ('\u{F891}', '\u{0E4A}'),
+            ('\u{F892}', '\u{0E4A}'),
+            ('\u{F893}', '\u{0E4B}'),
+            ('\u{F894}', '\u{0E4B}'),
+            ('\u{F895}', '\u{0E4B}'),
+            ('\u{F896}', '\u{0E4C}'),
+            ('\u{F897}', '\u{0E4C}'),
+            ('\u{F898}', '\u{0E4C}'),
+            ('\u{F899}', '\u{0E4D}'),
+            ('\u{F89A}', '\u{0E0D}'),
+            ('\u{F89B}', '\u{0E38}'),
+            ('\u{F89C}', '\u{0E39}'),
+            ('\u{F89D}', '\u{0E3A}'),
+            ('\u{F89E}', '\u{0E10}'),
+        ];
+        let mut cmap = ToUnicodeCMap::new();
+        for (index, (pua, thai)) in mappings.into_iter().enumerate() {
+            cmap.char_map.insert(index as u16, pua.to_string());
+            assert_eq!(cmap.lookup(index as u16), Some(thai.to_string()));
+        }
+    }
+
+    #[test]
+    fn legacy_thai_pua_in_bfrange_and_multiscalar_bfchar_is_normalized() {
+        let cmap_content = r#"
+1 begincodespacerange
+<0000><FFFF>
+endcodespacerange
+1 beginbfchar
+<0001> <0E01F70B>
+endbfchar
+1 beginbfrange
+<0002> <0004> <F700>
+endbfrange
+"#;
+        let cmap = ToUnicodeCMap::parse(cmap_content.as_bytes()).unwrap();
+
+        assert_eq!(cmap.lookup(0x0001), Some("ก้".to_string()));
+        assert_eq!(cmap.lookup(0x0002), Some("ฐ".to_string()));
+        assert_eq!(cmap.lookup(0x0003), Some("ิ".to_string()));
+        assert_eq!(cmap.lookup(0x0004), Some("ี".to_string()));
+    }
+
+    #[test]
+    fn unknown_private_use_codepoint_is_preserved() {
+        let mut cmap = ToUnicodeCMap::new();
+        cmap.char_map.insert(1, "\u{E123}".to_string());
+
+        assert_eq!(cmap.lookup(1), Some("\u{E123}".to_string()));
     }
 
     #[test]

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -400,7 +400,7 @@ impl ToUnicodeCMap {
     pub fn lookup(&self, cid: u16) -> Option<String> {
         // First check direct mappings
         if let Some(s) = self.char_map.get(&cid) {
-            return Some(normalize_legacy_thai_pua(s).into_owned());
+            return Some(normalize_legacy_thai_pua(s));
         }
 
         // Binary search through sorted ranges

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -400,7 +400,7 @@ impl ToUnicodeCMap {
     pub fn lookup(&self, cid: u16) -> Option<String> {
         // First check direct mappings
         if let Some(s) = self.char_map.get(&cid) {
-            return Some(normalize_legacy_thai_pua(s));
+            return Some(normalize_legacy_thai_pua(s).into_owned());
         }
 
         // Binary search through sorted ranges


### PR DESCRIPTION
## Bug Description

Thai PDFs can encode dependent vowels and tone marks as separate CID fragments or include synthetic spaces before combining marks. This produced output such as:

- `ถ ึง` instead of `ถึง`
- `กรณ ีที่` instead of `กรณีที่`
- `ต ้องการ` instead of `ต้องการ`

Legacy Thai ToUnicode maps can also lose part of SARA AM (`ค าน า`) or emit Thai glyphs through the Private Use Area. Those cases should fall back to OCR rather than serving corrupted text.

Related to #214.

## Root Cause

The text joining heuristics had special handling for CJK and generic CID fonts, but no Thai cluster awareness. Synthetic whitespace embedded inside a decoded `TextItem` was also retained before dependent Thai marks.

The text-quality checks did not recognize common Thai broken-ToUnicode signatures or PUA glyphs within Thai text spans.

## Fix

- Classify Thai characters and dependent combining marks.
- Remove only inline whitespace immediately before Thai combining marks while preserving real word/phrase spaces.
- Join standalone Thai combining-mark fragments to their preceding cluster.
- Prevent the generic CID zero-gap rule from inserting synthetic spaces inside adjacent Thai fragments.
- Detect suspicious Thai consonant + whitespace + SARA AA sequences and route the affected page to OCR instead of guessing missing Unicode characters.
- Route Thai text spans containing PUA glyphs to OCR while avoiding false positives from unrelated, whitespace-separated PUA icons at page level.
- Add regression coverage for normalization, CID joining, explicit-space preservation, PUA locality, and page-level OCR reason reporting.

## How to Verify

```bash
cargo test thai_ --lib
cargo test
cargo clippy -- -D warnings
cargo fmt --all -- --check
cargo fmt --manifest-path wasm/Cargo.toml -- --check
cargo build --release
# plus the WebAssembly check/clippy/wasm-pack gates from CI
git diff --check
```

Representative inputs:

```text
ถ ึง กรณ ีที่ ต ้องการ
```

Expected normalized output:

```text
ถึง กรณีที่ ต้องการ
```

A Thai `TextItem` containing a PUA glyph, including when separated by whitespace, should produce `OCR_REASON_SUSPECTED_GARBLED_TEXT` for its page.

## Test Plan

- [x] Added regression tests for Thai combining-mark normalization
- [x] Added regression tests for separate CID fragments and explicit spaces
- [x] Added Thai PUA locality and OCR-routing regressions
- [x] Existing tests pass on Rust stable 1.97.1: 851 library + 2 binary + 152 integration + 2 doc tests (**1,007 total**)
- [x] Developer-script tests pass: **13/13**
- [x] Root/WASM formatting and `git diff --check` pass
- [x] Full `cargo clippy -- -D warnings` passes without allowances
- [x] Release build and WebAssembly CI-equivalent gates pass
- [x] Manual verification against two Thai government PDFs

### Manual government-document smoke test

A 39-page text-based Thai government guide was tested with the release CLI:

- whitespace immediately before Thai combining marks: **8 -> 0** after the fix; remains **0** after rebasing onto current upstream
- the page containing a Thai PUA glyph is now routed to OCR
- malformed SARA-AM-style sequences are not guessed; affected pages are routed to OCR

A separate three-page scanned government guide remains correctly classified as image-based with all three pages requiring OCR.

The larger corpus files are not included in this PR.

## Risk Assessment

**Medium** — normalization is narrowly limited to whitespace before dependent Thai marks, but the new broken-ToUnicode quality signal is intentionally conservative. On the 39-page government guide, OCR routing increases from 4 pages to 31 because malformed `ค า` / `ท า`-style sequences are pervasive. This avoids returning corrupt text but can increase OCR cost. The branch is rebased onto upstream `main` at `493fed4`; focused, full, release, WebAssembly, and real-document gates pass. Maintainer feedback on this trade-off and threshold is still welcome.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440959&installation_model_id=11126&pr_number=249&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F249&signature=b588afe628a03a2c73c068631722eadc9aee8a474159a231bc4b05cc3a189b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Thai glyph spacing and normalizes legacy Thai PUA so extracted Thai text renders correctly and only truly garbled pages fall back to OCR, with small performance gains.

- **Key changes**
  - Text joining: remove inline spaces immediately before Thai combining marks, always attach marks to the preceding base, preserve explicit inter-word spaces, and prevent the CID zero-gap rule from inserting spaces inside adjacent Thai fragments.
  - Unicode mapping: normalize Windows `U+F700–U+F71A` and macOS `U+F884–U+F89E` Thai PUA to standard Unicode during `ToUnicode` lookup and in post-processing; leave unknown PUA unchanged.
  - OCR routing: detect broken Thai cluster spacing and unknown Thai PUA within Thai spans; route only those pages; ignore unrelated, whitespace-separated PUA icons; known legacy Thai PUA no longer trigger OCR.
  - Performance: avoid unnecessary allocation during Thai PUA normalization and avoid double-scanning `ToUnicode` mappings.

<sup>Written for commit 38fc921d9f5615ccef61fb4eab7f4ba80d66deb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

