### PR TITLE
fix: sync Python type stubs (.pyi) with actual bindings + fix doc bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The converter handles:
 |---|---|
 | Headings (H1-H4) | Font size tiers relative to body text, with 0.5pt clustering |
 | Bold/italic | Font name patterns (Bold, Italic, Oblique) |
-| Bullet lists | `*`, `-`, `*`, `○`, `●`, `◦` prefixes |
+| Bullet lists | `•`, `-`, `*`, `○`, `●`, `◦` prefixes |
 | Numbered lists | `1.`, `1)`, `(1)` patterns |
 | Letter lists | `a.`, `a)`, `(a)` patterns |
 | Code blocks | Monospace fonts (Courier, Consolas, Monaco, Menlo, Fira Code, JetBrains Mono) and keyword detection |

--- a/docs/python.md
+++ b/docs/python.md
@@ -111,13 +111,18 @@ class PdfResult:                     # process_pdf / detect_pdf
     markdown: str | None             # extracted Markdown (None for detect_pdf)
     page_count: int
     processing_time_ms: int
-    pages_needing_ocr: list[int]
+    pages_needing_ocr: list[int]     # 1-indexed
+    ocr_reasons_by_page: list[PageOcrReasons]
     title: str | None
     confidence: float                # 0.0 - 1.0
     is_complex_layout: bool
     pages_with_tables: list[int]
     pages_with_columns: list[int]
     has_encoding_issues: bool        # broken font encodings — consider OCR fallback
+
+class PageOcrReasons:                # per-page OCR diagnostics
+    page: int                        # 1-indexed
+    reasons: list[str]               # machine-readable reason identifiers
 
 class PdfClassification:             # classify_pdf
     pdf_type: str
@@ -140,14 +145,20 @@ class TextItem:                      # extract_text_with_positions
     is_strikeout: bool
     item_type: str
 
+class RegionText:                    # extract_text_in_regions
+    text: str
+    needs_ocr: bool
+    ocr_reason: str | None           # machine-readable OCR reason
+
 class PageRegionTexts:               # extract_text_in_regions
     page: int                        # 0-indexed
-    regions: list[RegionText]        # RegionText: text: str, needs_ocr: bool
+    regions: list[RegionText]
 
 class PagesExtractionResult:         # extract_pages_markdown
-    pages: list[PageMarkdown]        # PageMarkdown: page (0-indexed), markdown, needs_ocr
+    pages: list[PageMarkdown]        # PageMarkdown: page (0-indexed), markdown, needs_ocr, ocr_reason
     pages_with_tables: list[int]     # 1-indexed
     pages_with_columns: list[int]    # 1-indexed
     pages_needing_ocr: list[int]     # 1-indexed
+    ocr_reasons_by_page: list[PageOcrReasons]
     is_complex: bool                 # any page has tables or multi-column layout
 ```

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -10,12 +10,22 @@ class PdfResult:
     page_count: int
     processing_time_ms: int
     pages_needing_ocr: list[int]
+    """1-indexed page numbers that need OCR."""
+    ocr_reasons_by_page: list["PageOcrReasons"]
+    """Machine-readable OCR reasons by 1-indexed page."""
     title: Optional[str]
     confidence: float
     is_complex_layout: bool
     pages_with_tables: list[int]
     pages_with_columns: list[int]
     has_encoding_issues: bool
+
+class PageOcrReasons:
+    """OCR reasons for a single 1-indexed page."""
+    page: int
+    """1-indexed page number."""
+    reasons: list[str]
+    """Machine-readable OCR reason identifiers."""
 
 class PdfClassification:
     """Lightweight PDF classification result."""
@@ -47,6 +57,8 @@ class RegionText:
     text: str
     needs_ocr: bool
     """True when the text should not be trusted."""
+    ocr_reason: Optional[str]
+    """Machine-readable OCR reason when the cause is known."""
 
 class PageRegionTexts:
     """Extracted text for one page's regions."""
@@ -62,6 +74,8 @@ class PageMarkdown:
     """Formatted markdown for this page (empty string when needs_ocr is True)."""
     needs_ocr: bool
     """True when text on this page is unreliable and OCR should be used instead."""
+    ocr_reason: Optional[str]
+    """Machine-readable OCR reason when the cause is known."""
 
 class PagesExtractionResult:
     """Per-page markdown output with document-wide layout classification."""
@@ -73,6 +87,8 @@ class PagesExtractionResult:
     """1-indexed pages where multi-column layout was detected."""
     pages_needing_ocr: list[int]
     """1-indexed pages that need OCR."""
+    ocr_reasons_by_page: list[PageOcrReasons]
+    """Machine-readable OCR reasons by 1-indexed page."""
     is_complex: bool
     """True if any page has tables or multi-column layout."""
 


### PR DESCRIPTION
## Summary

This PR fixes **4 real bugs** found by auditing the Python bindings source (`src/python.rs`) against the type stubs (`pdf_inspector.pyi`) and documentation (`docs/python.md`, `README.md`).

---

## Bug 1: Python Type Stubs Missing 5 Fields/Classes (Code Bug)

**Impact**: All Python users with type checking (PyCharm, VS Code/Pylance, mypy) see errors when accessing these fields. IDE autocompletion does not suggest them.

**Root Cause**: `pdf_inspector.pyi` was not updated when new fields were added to the Python bindings in `src/python.rs`.

**Missing items (verified against `#[pyo3(get)]` attributes)**:

| Field / Class | Exposed in `python.rs` | Status |
|---|---|---|
| `PdfResult.ocr_reasons_by_page` | Line 35 | **Missing from .pyi** |
| `PageOcrReasons` class | Lines 67-86 | **Entire class missing** |
| `RegionText.ocr_reason` | Line 136 | **Missing from .pyi** |
| `PageMarkdown.ocr_reason` | Line 193 | **Missing from .pyi** |
| `PagesExtractionResult.ocr_reasons_by_page` | Line 226 | **Missing from .pyi** |

**Evidence** (from `src/python.rs`):
```rust
// python.rs:33-35
/// Machine-readable OCR reasons by 1-indexed page.
#[pyo3(get)]
pub ocr_reasons_by_page: Vec<PyPageOcrReasons>,

// python.rs:134-136
/// Machine-readable OCR reason when the cause is known.
#[pyo3(get)]
pub ocr_reason: Option<String>,
```

But `pdf_inspector.pyi` had **no declaration** for these fields — any `result.ocr_reasons_by_page` access would trigger a type checker error.

---

## Bug 2: `PdfResult.pages_needing_ocr` Indexing Undocumented

**Impact**: Users mixing `PdfResult` (1-indexed) and `PdfClassification` (0-indexed, annotated) APIs get **wrong page numbers** when they assume both use the same indexing.

**Root Cause**: `python.rs:30` documents this field as `/// 1-indexed page numbers that need OCR.` but neither the `.pyi` stubs nor `docs/python.md` annotated it — while `PdfClassification.pages_needing_ocr` was clearly annotated as `0-indexed`.

**Fix**: Added `# 1-indexed` annotation to both `.pyi` and `docs/python.md`.

---

## Bug 3: README.md Duplicate Bullet Character

**Impact**: Incorrect API documentation — `*` listed twice instead of `•` (U+2022).

**Evidence** (from `src/markdown/mod.rs:34`):
```rust
let is_bare_bullet = matches!(text, "•" | "●" | "○" | "◦" | "-" | "*");
```

README had: `` `*`, `-`, `*`, `○`, `●`, `◦` `` (note `*` appears twice)
Fixed to: `` `•`, `-`, `*`, `○`, `●`, `◦` ``

---

## Bug 4: `docs/python.md` Types Section Missing Fields

The type reference was missing `PageOcrReasons` class, `RegionText` class definition, `ocr_reason` fields, and `ocr_reasons_by_page` fields — all exposed via `#[pyo3(get)]`.

---

## Files Changed

| File | Change |
|---|---|
| `pdf_inspector.pyi` | +16 lines: Added 5 missing fields/classes + indexing annotation |
| `docs/python.md` | +14 lines: Added missing types and annotations to reference |
| `README.md` | 1 line: Fixed duplicate bullet `*` to `•` |

## Verification

- Cross-referenced every `#[pyo3(get)]` in `src/python.rs` against `.pyi` declarations
- Verified bullet characters against `src/markdown/mod.rs:34` source
- All changes are additive (no breaking changes)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788441453&installation_model_id=11126&pr_number=250&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F250&signature=a2b32b811d48bdbfe246ac4d12be32dfb410a2a719873dd8bf935f01162c2d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs Python `.pyi` stubs with the actual `src/python.rs` bindings and fixes doc mismatches. Restores accurate IDE type hints and clarifies 1‑indexed fields.

- **Bug Fixes**
  - Added missing `.pyi` declarations: `PdfResult.ocr_reasons_by_page`, `PageOcrReasons`, `RegionText.ocr_reason`, `PageMarkdown.ocr_reason`, `PagesExtractionResult.ocr_reasons_by_page`.
  - Marked `PdfResult.pages_needing_ocr` as 1‑indexed in `.pyi` and `docs/python.md`.
  - Updated `docs/python.md` types to include `PageOcrReasons`, `RegionText`, `ocr_reason`, and `ocr_reasons_by_page`.
  - Fixed README bullet list example to use `•` instead of a duplicate `*`.

<sup>Written for commit 7ed78c64caf75879d1814289494fcf6bf807b337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

