### PR TITLE
fix(markdown): reject non-text strikeout rules

### DIFF
--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -396,64 +396,139 @@ fn rule_strikes_item(rule: &Rule, item: &TextItem) -> bool {
     overlap >= min_overlap
 }
 
-fn is_list_bullet(text: &str) -> bool {
+fn is_bare_list_marker(text: &str) -> bool {
     matches!(
         text.trim(),
-        "•" | "◦" | "▪" | "▫" | "‣" | "⁃" | "●" | "○" | "■" | "□"
+        "•" | "◦" | "▪" | "▫" | "‣" | "⁃" | "●" | "○" | "■" | "□" | "-" | "*"
     )
 }
 
-/// True when a mid-glyph rule is owned by the text row it intersects.
+fn same_strike_row(left: &TextItem, right: &TextItem) -> bool {
+    let font_size = left.font_size.max(right.font_size);
+    let tolerance = (font_size * STRIKE_ROW_Y_TOLERANCE_EM).max(STRIKE_ROW_Y_TOLERANCE_MIN);
+    (left.y - right.y).abs() <= tolerance
+}
+
+fn is_inline_script(rule: &Rule, candidate: &TextItem, parent: &TextItem) -> bool {
+    if !is_underline_candidate(candidate)
+        || is_bare_list_marker(&candidate.text)
+        || candidate.font_size <= 0.0
+        || candidate.font_size >= parent.font_size * 0.75
+        || candidate.text.len() > 4
+        || !candidate.text.chars().all(|c| c.is_ascii_digit())
+        || (candidate.y - parent.y).abs() > 5.0
+    {
+        return false;
+    }
+
+    let parent_ends_with_letter = parent.text.chars().last().is_some_and(char::is_alphabetic);
+    if !parent_ends_with_letter {
+        return false;
+    }
+
+    let parent_right = parent.x + parent.width;
+    let gap = candidate.x - parent_right;
+    if gap >= parent.font_size * 0.2 || gap <= -parent.font_size * 0.3 {
+        return false;
+    }
+
+    let overlap = rule.x2.min(candidate.x + candidate.width) - rule.x1.max(candidate.x);
+    overlap >= candidate.width * MIN_X_OVERLAP
+}
+
+/// Return the items owned by a snug mid-glyph rule.
 ///
 /// Real strikeout decorations track the width of the deleted text, including
-/// runs split by font/style changes. Non-text graphics can cross the same
-/// vertical window, but arrow shafts, signature lines, fraction bars, and
-/// chart rules extend materially beyond the intersected glyphs. Requiring the
-/// rule to stay within a small em-sized pad of the contiguous matched row
-/// separates those cases without relying on document-specific fonts or
-/// coordinates.
-fn has_snug_strike_owner(rule: &Rule, item: &TextItem, items: &[TextItem]) -> bool {
-    if is_list_bullet(&item.text) {
-        return false;
-    }
-
-    let y_tolerance = (item.font_size * STRIKE_ROW_Y_TOLERANCE_EM).max(STRIKE_ROW_Y_TOLERANCE_MIN);
-    let mut matched: Vec<&TextItem> = items
+/// runs split by font/style changes and adjacent numeric super/subscripts.
+/// Non-text graphics can cross the same vertical window, but arrow shafts,
+/// signature lines, fraction bars, and chart rules extend materially beyond
+/// the intersected glyphs. Requiring the rule to stay within a small em-sized
+/// pad of a contiguous matched row separates those cases without relying on
+/// document-specific fonts or coordinates.
+///
+/// Ownership is computed once per rule. This keeps the strikeout pass at the
+/// same rule-by-item scale as underline detection instead of rescanning the
+/// whole page for every matching item.
+fn snug_strike_owner_indices(rule: &Rule, items: &[TextItem]) -> Vec<usize> {
+    let mut struck_indices: Vec<usize> = items
         .iter()
-        .filter(|candidate| {
-            is_underline_candidate(candidate)
-                && !is_list_bullet(&candidate.text)
-                && (candidate.y - item.y).abs() <= y_tolerance
-                && rule_strikes_item(rule, candidate)
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            (is_underline_candidate(candidate)
+                && !is_bare_list_marker(&candidate.text)
+                && rule_strikes_item(rule, candidate))
+            .then_some(index)
         })
         .collect();
-    if matched.is_empty() {
-        return false;
+    if struck_indices.is_empty() {
+        return Vec::new();
+    }
+    struck_indices.sort_by(|&left, &right| items[left].y.total_cmp(&items[right].y));
+
+    let mut rows: Vec<Vec<usize>> = Vec::new();
+    for index in struck_indices {
+        if let Some(row) = rows
+            .last_mut()
+            .filter(|row| same_strike_row(&items[row[0]], &items[index]))
+        {
+            row.push(index);
+        } else {
+            rows.push(vec![index]);
+        }
     }
 
-    matched.sort_by(|a, b| a.x.total_cmp(&b.x));
-    let x1 = matched
-        .iter()
-        .map(|candidate| candidate.x)
-        .fold(f32::INFINITY, f32::min);
-    let x2 = matched
-        .iter()
-        .map(|candidate| candidate.x + candidate.width)
-        .fold(f32::NEG_INFINITY, f32::max);
-    let max_font_size = matched
-        .iter()
-        .map(|candidate| candidate.font_size)
-        .fold(0.0, f32::max);
-    let pad = (max_font_size * STRIKE_OWNER_PAD_EM).max(STRIKE_OWNER_MIN_PAD);
+    let mut owned_indices = Vec::new();
+    for mut row in rows {
+        row.sort_by(|&left, &right| items[left].x.total_cmp(&items[right].x));
 
-    if rule.x1 < x1 - pad || rule.x2 > x2 + pad {
-        return false;
+        // Underline detection runs before the extractor's script-merging
+        // pass. Include the same tightly adjacent numeric script shape here
+        // when the rule spans it, so the owner width and semantic mark both
+        // survive that later merge.
+        let scripts: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                let parent_pos =
+                    row.partition_point(|&row_index| items[row_index].x <= candidate.x);
+                let parent_index = parent_pos.checked_sub(1).map(|pos| row[pos])?;
+                is_inline_script(rule, candidate, &items[parent_index]).then_some(index)
+            })
+            .collect();
+        row.extend(scripts);
+        row.sort_by(|&left, &right| items[left].x.total_cmp(&items[right].x));
+        row.dedup();
+
+        let x1 = row
+            .iter()
+            .map(|&index| items[index].x)
+            .fold(f32::INFINITY, f32::min);
+        let x2 = row
+            .iter()
+            .map(|&index| items[index].x + items[index].width)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let max_font_size = row
+            .iter()
+            .map(|&index| items[index].font_size)
+            .fold(0.0, f32::max);
+        let pad = (max_font_size * STRIKE_OWNER_PAD_EM).max(STRIKE_OWNER_MIN_PAD);
+
+        if rule.x1 < x1 - pad || rule.x2 > x2 + pad {
+            continue;
+        }
+
+        let contiguous = row.windows(2).all(|pair| {
+            let gap = items[pair[1]].x - (items[pair[0]].x + items[pair[0]].width);
+            gap <= (max_font_size * 2.0).max(12.0)
+        });
+        if contiguous {
+            owned_indices.extend(row);
+        }
     }
 
-    matched.windows(2).all(|pair| {
-        let gap = pair[1].x - (pair[0].x + pair[0].width);
-        gap <= (max_font_size * 2.0).max(12.0)
-    })
+    owned_indices.sort_unstable();
+    owned_indices.dedup();
+    owned_indices
 }
 
 /// Diagram and table rules participate in larger path geometry. A vertical
@@ -541,16 +616,27 @@ pub(crate) fn mark_underlined_items(
         .map(|(i, _)| i)
         .collect();
 
-    let strikeout_items: HashSet<usize> = items
+    let mut strikeout_items = vec![false; items.len()];
+    for (rule_idx, rule) in rules.iter().enumerate() {
+        if tabular_rules.contains(&rule_idx)
+            || has_connected_nonhorizontal_segment(rule, lines, page)
+        {
+            continue;
+        }
+        for item_idx in snug_strike_owner_indices(rule, items) {
+            strikeout_items[item_idx] = true;
+        }
+    }
+
+    let underlined_items: HashSet<usize> = items
         .iter()
         .enumerate()
         .filter(|(_, item)| {
             is_underline_candidate(item)
                 && rules.iter().enumerate().any(|(rule_idx, rule)| {
                     !tabular_rules.contains(&rule_idx)
-                        && rule_strikes_item(rule, item)
-                        && has_snug_strike_owner(rule, item, items)
-                        && !has_connected_nonhorizontal_segment(rule, lines, page)
+                        && !fraction_rules.contains(&rule_idx)
+                        && rule_matches_item(rule, item)
                 })
         })
         .map(|(item_idx, _)| item_idx)
@@ -561,23 +647,11 @@ pub(crate) fn mark_underlined_items(
             continue;
         }
 
-        if strikeout_items.contains(&item_idx) {
+        if strikeout_items[item_idx] {
             item.is_strikeout = true;
         }
-
-        for (rule_idx, rule) in rules.iter().enumerate() {
-            if tabular_rules.contains(&rule_idx) {
-                continue;
-            }
-            // The fraction guard only gates UNDERLINE marking — a rule that
-            // reads as a fraction bar from below can still legitimately
-            // strike through a line above it.
-            if !fraction_rules.contains(&rule_idx) && rule_matches_item(rule, item) {
-                item.is_underline = true;
-            }
-            if item.is_underline && item.is_strikeout {
-                break;
-            }
+        if underlined_items.contains(&item_idx) {
+            item.is_underline = true;
         }
     }
 }
@@ -739,12 +813,14 @@ mod tests {
 
     #[test]
     fn list_bullet_is_not_a_strikeout() {
-        let mut items = vec![item("•", 100.0, 500.0, 6.0, 10.0)];
-        let lines = vec![hline(99.0, 107.0, 503.0)];
+        for marker in ["•", "-", "*"] {
+            let mut items = vec![item(marker, 100.0, 500.0, 6.0, 10.0)];
+            let lines = vec![hline(99.0, 107.0, 503.0)];
 
-        mark_underlined_items(&mut items, &[], &lines, 1);
+            mark_underlined_items(&mut items, &[], &lines, 1);
 
-        assert!(!items[0].is_strikeout);
+            assert!(!items[0].is_strikeout, "marker {marker:?}");
+        }
     }
 
     #[test]
@@ -754,6 +830,32 @@ mod tests {
             item("text", 142.0, 500.0, 25.0, 10.0),
         ];
         let lines = vec![hline(99.0, 168.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(items.iter().all(|item| item.is_strikeout));
+    }
+
+    #[test]
+    fn snug_rule_keeps_inline_superscript_in_strike_owner() {
+        let mut items = vec![
+            item("deleted", 100.0, 500.0, 40.0, 10.0),
+            item("2", 140.5, 503.0, 4.0, 6.0),
+        ];
+        let lines = vec![hline(99.0, 145.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(items.iter().all(|item| item.is_strikeout));
+    }
+
+    #[test]
+    fn snug_rule_keeps_inline_subscript_in_strike_owner() {
+        let mut items = vec![
+            item("deleted", 100.0, 500.0, 40.0, 10.0),
+            item("2", 140.5, 497.0, 4.0, 6.0),
+        ];
+        let lines = vec![hline(99.0, 145.0, 503.0)];
 
         mark_underlined_items(&mut items, &[], &lines, 1);
 

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -52,6 +52,7 @@ const STRIKE_OWNER_MIN_PAD: f32 = 4.0;
 const STRIKE_ROW_Y_TOLERANCE_EM: f32 = 0.15;
 const STRIKE_ROW_Y_TOLERANCE_MIN: f32 = 1.5;
 const GRAPHIC_CONNECTION_EPS: f32 = 2.0;
+const GRAPHIC_CONNECTOR_MAX_THICKNESS: f32 = 4.0;
 
 #[derive(Clone)]
 pub(crate) struct UnderlineLine {
@@ -563,6 +564,39 @@ fn has_connected_nonhorizontal_segment(rule: &Rule, lines: &[UnderlineLine], pag
     })
 }
 
+/// Filled diagrams often build connectors from intersecting thin rectangles
+/// instead of stroked path segments. Treat only narrow, vertically elongated
+/// rectangles as connector geometry; broad fills can legitimately sit behind
+/// struck text and must not veto its decoration.
+fn has_connected_nonhorizontal_rect(rule: &Rule, rects: &[PdfRect], page: u32) -> bool {
+    rects.iter().any(|rect| {
+        if rect.page != page {
+            return false;
+        }
+
+        let (x1, x2) = if rect.width >= 0.0 {
+            (rect.x, rect.x + rect.width)
+        } else {
+            (rect.x + rect.width, rect.x)
+        };
+        let (y1, y2) = if rect.height >= 0.0 {
+            (rect.y, rect.y + rect.height)
+        } else {
+            (rect.y + rect.height, rect.y)
+        };
+        let width = x2 - x1;
+        let height = y2 - y1;
+
+        width > 0.0
+            && width <= GRAPHIC_CONNECTOR_MAX_THICKNESS
+            && height > width * 2.0
+            && rule.y >= y1 - GRAPHIC_CONNECTION_EPS
+            && rule.y <= y2 + GRAPHIC_CONNECTION_EPS
+            && x2 >= rule.x1 - GRAPHIC_CONNECTION_EPS
+            && x1 <= rule.x2 + GRAPHIC_CONNECTION_EPS
+    })
+}
+
 /// Mark `is_underline` on text items that have a horizontal rule just
 /// below their baseline, and `is_strikeout` on items whose glyphs a rule
 /// crosses at mid x-height. `items`, `rects`, and `lines` are a single
@@ -620,6 +654,7 @@ pub(crate) fn mark_underlined_items(
     for (rule_idx, rule) in rules.iter().enumerate() {
         if tabular_rules.contains(&rule_idx)
             || has_connected_nonhorizontal_segment(rule, lines, page)
+            || has_connected_nonhorizontal_rect(rule, rects, page)
         {
             continue;
         }
@@ -809,6 +844,44 @@ mod tests {
         mark_underlined_items(&mut items, &[], &lines, 1);
 
         assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn connected_filled_rect_is_not_a_strikeout() {
+        let mut items = vec![item("V8", 100.0, 500.0, 12.0, 10.0)];
+        let rects = vec![
+            thin_rect(99.0, 502.6, 14.0),
+            PdfRect {
+                x: 106.0,
+                y: 496.0,
+                width: 2.0,
+                height: 14.0,
+                page: 1,
+            },
+        ];
+
+        mark_underlined_items(&mut items, &rects, &[], 1);
+
+        assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn broad_fill_behind_text_does_not_block_strikeout() {
+        let mut items = vec![item("deleted", 100.0, 500.0, 40.0, 10.0)];
+        let rects = vec![
+            thin_rect(99.0, 502.6, 42.0),
+            PdfRect {
+                x: 90.0,
+                y: 490.0,
+                width: 100.0,
+                height: 20.0,
+                page: 1,
+            },
+        ];
+
+        mark_underlined_items(&mut items, &rects, &[], 1);
+
+        assert!(items[0].is_strikeout);
     }
 
     #[test]

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -44,6 +44,15 @@ const MIN_TABULAR_RULE_ITEMS: usize = 3;
 const MIN_TABULAR_RULE_GAPS: usize = 2;
 const TABULAR_RULE_GAP_EM: f32 = 2.0;
 
+/// Strikeout decorations are text-sized. Diagram connectors, signature
+/// lines, and chart rules often cross glyphs too, but extend well beyond the
+/// text they happen to intersect.
+const STRIKE_OWNER_PAD_EM: f32 = 0.75;
+const STRIKE_OWNER_MIN_PAD: f32 = 4.0;
+const STRIKE_ROW_Y_TOLERANCE_EM: f32 = 0.15;
+const STRIKE_ROW_Y_TOLERANCE_MIN: f32 = 1.5;
+const GRAPHIC_CONNECTION_EPS: f32 = 2.0;
+
 #[derive(Clone)]
 pub(crate) struct UnderlineLine {
     pub(crate) x1: f32,
@@ -387,6 +396,98 @@ fn rule_strikes_item(rule: &Rule, item: &TextItem) -> bool {
     overlap >= min_overlap
 }
 
+fn is_list_bullet(text: &str) -> bool {
+    matches!(
+        text.trim(),
+        "•" | "◦" | "▪" | "▫" | "‣" | "⁃" | "●" | "○" | "■" | "□"
+    )
+}
+
+/// True when a mid-glyph rule is owned by the text row it intersects.
+///
+/// Real strikeout decorations track the width of the deleted text, including
+/// runs split by font/style changes. Non-text graphics can cross the same
+/// vertical window, but arrow shafts, signature lines, fraction bars, and
+/// chart rules extend materially beyond the intersected glyphs. Requiring the
+/// rule to stay within a small em-sized pad of the contiguous matched row
+/// separates those cases without relying on document-specific fonts or
+/// coordinates.
+fn has_snug_strike_owner(rule: &Rule, item: &TextItem, items: &[TextItem]) -> bool {
+    if is_list_bullet(&item.text) {
+        return false;
+    }
+
+    let y_tolerance = (item.font_size * STRIKE_ROW_Y_TOLERANCE_EM).max(STRIKE_ROW_Y_TOLERANCE_MIN);
+    let mut matched: Vec<&TextItem> = items
+        .iter()
+        .filter(|candidate| {
+            is_underline_candidate(candidate)
+                && !is_list_bullet(&candidate.text)
+                && (candidate.y - item.y).abs() <= y_tolerance
+                && rule_strikes_item(rule, candidate)
+        })
+        .collect();
+    if matched.is_empty() {
+        return false;
+    }
+
+    matched.sort_by(|a, b| a.x.total_cmp(&b.x));
+    let x1 = matched
+        .iter()
+        .map(|candidate| candidate.x)
+        .fold(f32::INFINITY, f32::min);
+    let x2 = matched
+        .iter()
+        .map(|candidate| candidate.x + candidate.width)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let max_font_size = matched
+        .iter()
+        .map(|candidate| candidate.font_size)
+        .fold(0.0, f32::max);
+    let pad = (max_font_size * STRIKE_OWNER_PAD_EM).max(STRIKE_OWNER_MIN_PAD);
+
+    if rule.x1 < x1 - pad || rule.x2 > x2 + pad {
+        return false;
+    }
+
+    matched.windows(2).all(|pair| {
+        let gap = pair[1].x - (pair[0].x + pair[0].width);
+        gap <= (max_font_size * 2.0).max(12.0)
+    })
+}
+
+/// Diagram and table rules participate in larger path geometry. A vertical
+/// or diagonal segment meeting the candidate rule is strong evidence that
+/// the horizontal segment is a connector, border, arrow, or symbol rather
+/// than an isolated text decoration.
+fn has_connected_nonhorizontal_segment(rule: &Rule, lines: &[UnderlineLine], page: u32) -> bool {
+    lines.iter().any(|line| {
+        if line.page != page {
+            return false;
+        }
+
+        let dx = line.x2 - line.x1;
+        let dy = line.y2 - line.y1;
+        if dy.abs() <= MAX_RULE_THICKNESS {
+            return false;
+        }
+
+        let y_min = line.y1.min(line.y2) - GRAPHIC_CONNECTION_EPS;
+        let y_max = line.y1.max(line.y2) + GRAPHIC_CONNECTION_EPS;
+        if rule.y < y_min || rule.y > y_max {
+            return false;
+        }
+
+        let t = (rule.y - line.y1) / dy;
+        if !(-0.05..=1.05).contains(&t) {
+            return false;
+        }
+        let intersection_x = line.x1 + t * dx;
+        intersection_x >= rule.x1 - GRAPHIC_CONNECTION_EPS
+            && intersection_x <= rule.x2 + GRAPHIC_CONNECTION_EPS
+    })
+}
+
 /// Mark `is_underline` on text items that have a horizontal rule just
 /// below their baseline, and `is_strikeout` on items whose glyphs a rule
 /// crosses at mid x-height. `items`, `rects`, and `lines` are a single
@@ -440,9 +541,28 @@ pub(crate) fn mark_underlined_items(
         .map(|(i, _)| i)
         .collect();
 
-    for item in items.iter_mut() {
+    let strikeout_items: HashSet<usize> = items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| {
+            is_underline_candidate(item)
+                && rules.iter().enumerate().any(|(rule_idx, rule)| {
+                    !tabular_rules.contains(&rule_idx)
+                        && rule_strikes_item(rule, item)
+                        && has_snug_strike_owner(rule, item, items)
+                        && !has_connected_nonhorizontal_segment(rule, lines, page)
+                })
+        })
+        .map(|(item_idx, _)| item_idx)
+        .collect();
+
+    for (item_idx, item) in items.iter_mut().enumerate() {
         if !is_underline_candidate(item) {
             continue;
+        }
+
+        if strikeout_items.contains(&item_idx) {
+            item.is_strikeout = true;
         }
 
         for (rule_idx, rule) in rules.iter().enumerate() {
@@ -454,9 +574,6 @@ pub(crate) fn mark_underlined_items(
             // strike through a line above it.
             if !fraction_rules.contains(&rule_idx) && rule_matches_item(rule, item) {
                 item.is_underline = true;
-            }
-            if rule_strikes_item(rule, item) {
-                item.is_strikeout = true;
             }
             if item.is_underline && item.is_strikeout {
                 break;
@@ -578,6 +695,69 @@ mod tests {
         mark_underlined_items(&mut items, &[], &lines, 1);
         assert!(items[0].is_strikeout);
         assert!(!items[0].is_underline);
+    }
+
+    #[test]
+    fn long_connector_crossing_text_is_not_a_strikeout() {
+        let mut items = vec![item("diagram label", 160.0, 500.0, 60.0, 10.0)];
+        let lines = vec![hline(100.0, 280.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn chart_rule_ending_inside_short_label_is_not_a_strikeout() {
+        let mut items = vec![item("T 18", 300.0, 500.0, 20.0, 10.0)];
+        let lines = vec![hline(100.0, 315.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn connected_diagram_segment_is_not_a_strikeout() {
+        let mut items = vec![item("V8", 100.0, 500.0, 12.0, 10.0)];
+        let lines = vec![
+            hline(99.0, 113.0, 503.0),
+            UnderlineLine {
+                x1: 106.0,
+                y1: 496.0,
+                x2: 109.0,
+                y2: 510.0,
+                stroke_width: 1.0,
+                page: 1,
+            },
+        ];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn list_bullet_is_not_a_strikeout() {
+        let mut items = vec![item("•", 100.0, 500.0, 6.0, 10.0)];
+        let lines = vec![hline(99.0, 107.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(!items[0].is_strikeout);
+    }
+
+    #[test]
+    fn snug_rule_marks_adjacent_split_runs_as_strikeout() {
+        let mut items = vec![
+            item("deleted", 100.0, 500.0, 40.0, 10.0),
+            item("text", 142.0, 500.0, 25.0, 10.0),
+        ];
+        let lines = vec![hline(99.0, 168.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(items.iter().all(|item| item.is_strikeout));
     }
 
     #[test]

--- a/src/extractor/underline.rs
+++ b/src/extractor/underline.rs
@@ -50,7 +50,7 @@ const TABULAR_RULE_GAP_EM: f32 = 2.0;
 const STRIKE_OWNER_PAD_EM: f32 = 0.75;
 const STRIKE_OWNER_MIN_PAD: f32 = 4.0;
 const STRIKE_ROW_Y_TOLERANCE_EM: f32 = 0.15;
-const STRIKE_ROW_Y_TOLERANCE_MIN: f32 = 1.5;
+const STRIKE_ROW_Y_TOLERANCE_MIN: f32 = 5.0;
 const GRAPHIC_CONNECTION_EPS: f32 = 2.0;
 const GRAPHIC_CONNECTOR_MAX_THICKNESS: f32 = 4.0;
 
@@ -901,6 +901,19 @@ mod tests {
         let mut items = vec![
             item("deleted", 100.0, 500.0, 40.0, 10.0),
             item("text", 142.0, 500.0, 25.0, 10.0),
+        ];
+        let lines = vec![hline(99.0, 168.0, 503.0)];
+
+        mark_underlined_items(&mut items, &[], &lines, 1);
+
+        assert!(items.iter().all(|item| item.is_strikeout));
+    }
+
+    #[test]
+    fn snug_rule_groups_split_runs_with_baseline_drift() {
+        let mut items = vec![
+            item("deleted", 100.0, 500.0, 40.0, 10.0),
+            item("text", 142.0, 498.0, 25.0, 10.0),
         ];
         let lines = vec![hline(99.0, 168.0, 503.0)];
 


### PR DESCRIPTION
## Summary

Tightens geometric strikeout detection so a horizontal rule must be snugly owned by a contiguous text row and isolated from connected diagram geometry. This prevents bullets, formula bars, signature lines, chart rules, and schematic connectors from being emitted as deleted text while preserving genuine redline strikeouts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454133&installation_model_id=11126&pr_number=253&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F253&signature=1eef5560f5c181a0b60d94e98dfc9375315a0a876d2c14f88ec0510a617e1eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened strikeout detection so only real text strikeouts are marked. Handles split runs, inline scripts, and small baseline drift, and rejects non-text lines like connectors, bullets, chart rules, and thin filled connectors.

- **Bug Fixes**
  - Require a strike rule to be “owned” by a contiguous text row within a small em-based pad; ignore bullets.
  - Include adjacent numeric super/subscripts and group slight baseline drift in the owner to keep marks across script merges and split runs.
  - Reject rules connected to vertical/diagonal segments or thin, vertically elongated filled rectangles; skip chart rules that end inside short labels; allow broad fills behind text.
  - Compute ownership once per rule for consistent marking; added tests for connectors (incl. filled rects), short-label chart rules, bullets, split runs, baseline drift, and inline scripts.

<sup>Written for commit f729f92ddf49cb3917ccae64d8a2250f0e02322a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

