### PR TITLE
docs: document OCR reason fields in Python API

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -64,6 +64,8 @@ if result.pdf_type == "text_based":
     print("Can extract locally!")
 else:
     print(f"Pages needing OCR: {result.pages_needing_ocr}")
+    for page in result.ocr_reasons_by_page:
+        print(f"Page {page.page}: {', '.join(page.reasons)}")
 
 # Plain text extraction
 text = pdf_inspector.extract_text("document.pdf")
@@ -76,7 +78,10 @@ for item in items[:5]:
 # Per-page markdown (one Markdown string per page, plus layout metadata)
 result = pdf_inspector.extract_pages_markdown("document.pdf")
 for page in result.pages:
-    print(f"Page {page.page}: {len(page.markdown)} chars, needs_ocr={page.needs_ocr}")
+    print(
+        f"Page {page.page}: {len(page.markdown)} chars, "
+        f"needs_ocr={page.needs_ocr}, reason={page.ocr_reason}"
+    )
 
 # Restrict to specific 0-indexed pages (preserves caller order)
 result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
@@ -111,7 +116,8 @@ class PdfResult:                     # process_pdf / detect_pdf
     markdown: str | None             # extracted Markdown (None for detect_pdf)
     page_count: int
     processing_time_ms: int
-    pages_needing_ocr: list[int]
+    pages_needing_ocr: list[int]     # 1-indexed
+    ocr_reasons_by_page: list[PageOcrReasons]
     title: str | None
     confidence: float                # 0.0 - 1.0
     is_complex_layout: bool
@@ -124,6 +130,10 @@ class PdfClassification:             # classify_pdf
     page_count: int
     pages_needing_ocr: list[int]     # 0-indexed
     confidence: float
+
+class PageOcrReasons:
+    page: int                        # 1-indexed
+    reasons: list[str]               # e.g. "scanned", "no_text", "suspected_garbled_text"
 
 class TextItem:                      # extract_text_with_positions
     text: str
@@ -142,12 +152,13 @@ class TextItem:                      # extract_text_with_positions
 
 class PageRegionTexts:               # extract_text_in_regions
     page: int                        # 0-indexed
-    regions: list[RegionText]        # RegionText: text: str, needs_ocr: bool
+    regions: list[RegionText]        # RegionText: text, needs_ocr, ocr_reason
 
 class PagesExtractionResult:         # extract_pages_markdown
-    pages: list[PageMarkdown]        # PageMarkdown: page (0-indexed), markdown, needs_ocr
+    pages: list[PageMarkdown]        # PageMarkdown: page, markdown, needs_ocr, ocr_reason
     pages_with_tables: list[int]     # 1-indexed
     pages_with_columns: list[int]    # 1-indexed
     pages_needing_ocr: list[int]     # 1-indexed
+    ocr_reasons_by_page: list[PageOcrReasons]
     is_complex: bool                 # any page has tables or multi-column layout
 ```

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -10,12 +10,22 @@ class PdfResult:
     page_count: int
     processing_time_ms: int
     pages_needing_ocr: list[int]
+    """1-indexed page numbers that need OCR."""
+    ocr_reasons_by_page: list["PageOcrReasons"]
+    """Machine-readable OCR reasons for pages that need OCR."""
     title: Optional[str]
     confidence: float
     is_complex_layout: bool
     pages_with_tables: list[int]
     pages_with_columns: list[int]
     has_encoding_issues: bool
+
+class PageOcrReasons:
+    """OCR reasons for a single page."""
+    page: int
+    """1-indexed page number."""
+    reasons: list[str]
+    """Machine-readable OCR reason identifiers."""
 
 class PdfClassification:
     """Lightweight PDF classification result."""
@@ -47,6 +57,8 @@ class RegionText:
     text: str
     needs_ocr: bool
     """True when the text should not be trusted."""
+    ocr_reason: Optional[str]
+    """Machine-readable OCR reason when the cause is known."""
 
 class PageRegionTexts:
     """Extracted text for one page's regions."""
@@ -62,6 +74,8 @@ class PageMarkdown:
     """Formatted markdown for this page (empty string when needs_ocr is True)."""
     needs_ocr: bool
     """True when text on this page is unreliable and OCR should be used instead."""
+    ocr_reason: Optional[str]
+    """Machine-readable OCR reason when the cause is known."""
 
 class PagesExtractionResult:
     """Per-page markdown output with document-wide layout classification."""
@@ -73,6 +87,8 @@ class PagesExtractionResult:
     """1-indexed pages where multi-column layout was detected."""
     pages_needing_ocr: list[int]
     """1-indexed pages that need OCR."""
+    ocr_reasons_by_page: list[PageOcrReasons]
+    """Machine-readable OCR reasons for pages that need OCR."""
     is_complex: bool
     """True if any page has tables or multi-column layout."""
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -50,6 +50,7 @@ class TestProcessPdf:
         assert isinstance(result.page_count, int)
         assert isinstance(result.processing_time_ms, int)
         assert isinstance(result.pages_needing_ocr, list)
+        assert isinstance(result.ocr_reasons_by_page, list)
         assert isinstance(result.confidence, float)
         assert isinstance(result.is_complex_layout, bool)
         assert isinstance(result.pages_with_tables, list)
@@ -220,6 +221,9 @@ class TestExtractTextInRegions:
         assert len(results[0].regions) == 1
         assert isinstance(results[0].regions[0].text, str)
         assert isinstance(results[0].regions[0].needs_ocr, bool)
+        assert results[0].regions[0].ocr_reason is None or isinstance(
+            results[0].regions[0].ocr_reason, str
+        )
 
     def test_bytes(self):
         data = fixture_bytes("thermo-freon12.pdf")
@@ -309,6 +313,7 @@ class TestExtractPagesMarkdown:
         assert isinstance(page.page, int)
         assert isinstance(page.markdown, str)
         assert isinstance(page.needs_ocr, bool)
+        assert page.ocr_reason is None or isinstance(page.ocr_reason, str)
         assert not page.needs_ocr  # text-based fixture
         assert len(page.markdown) > 0
 
@@ -320,6 +325,7 @@ class TestExtractPagesMarkdown:
         assert isinstance(result.pages_with_tables, list)
         assert isinstance(result.pages_with_columns, list)
         assert isinstance(result.pages_needing_ocr, list)
+        assert isinstance(result.ocr_reasons_by_page, list)
         assert isinstance(result.is_complex, bool)
 
     def test_out_of_range_page_marks_needs_ocr(self):


### PR DESCRIPTION
## Summary

- Document Python OCR reason fields in the API guide.
- Add missing OCR reason attributes to `pdf_inspector.pyi`.
- Add Python binding test assertions for the exposed OCR reason fields.

## Why

The Python bindings already expose OCR reason metadata such as `ocr_reasons_by_page` and per-page/per-region `ocr_reason`, but the Python docs and type stubs did not fully reflect those fields. This updates the public Python API documentation so users and type checkers can discover the existing OCR routing metadata.

## Testing

- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788462619&installation_model_id=11126&pr_number=256&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F256&signature=19a86afd1ec1ca06af70b28fd0393884452205bae814389ad6c861ab55499ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents OCR reason metadata in the Python API and updates type stubs to include `ocr_reasons_by_page` plus per-page/per-region `ocr_reason`, with clarified 1-indexed page fields. Adds tests to verify these fields are present and typed.

<sup>Written for commit 162c54634419df31b9d23a73ea30f5bac0da9306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

