### PR TITLE
fix(extractor): make the comment stripper escape-aware

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -41,6 +41,17 @@ fn strip_pdf_comments(data: &[u8]) -> Vec<u8> {
     while i < data.len() {
         let b = data[i];
         match b {
+            // Inside a string literal, a backslash escapes the next byte —
+            // `\(`, `\)`, and `\\` must not touch the nesting depth, or a
+            // later `%` glyph inside a string gets stripped as a comment,
+            // corrupting the stream.
+            b'\\' if in_string > 0 => {
+                result.push(b);
+                if let Some(&next) = data.get(i + 1) {
+                    result.push(next);
+                    i += 1;
+                }
+            }
             b'(' if !in_hex_string => {
                 in_string += 1;
                 result.push(b);
@@ -1848,5 +1859,27 @@ BT 30 700 Tm <41> Tj ET";
             output_str.contains("ET"),
             "ET should be preserved after comment stripping"
         );
+    }
+
+    #[test]
+    fn test_strip_pdf_comments_escaped_parens() {
+        // An escaped `\)` must not close the string: the `%` after it is
+        // still string content, not a comment (subset fonts routinely map
+        // glyphs to `%` and to escaped parens in the same TJ array).
+        let input = b"[ (a\\)b) 1 (%) 1 (c) ] TJ\n";
+        let output = strip_pdf_comments(input);
+        assert_eq!(output, input.to_vec());
+
+        // Same for an escaped `\(` — must not open a phantom string that
+        // shields a real comment.
+        let input = b"(x\\(y) Tj % real comment\nET\n";
+        let output = strip_pdf_comments(input);
+        assert_eq!(output, b"(x\\(y) Tj  \nET\n");
+
+        // Escaped backslash before a real close-paren: `\\` ends the escape,
+        // the `)` does close the string, and the comment is stripped.
+        let input = b"(x\\\\) Tj % comment\nET\n";
+        let output = strip_pdf_comments(input);
+        assert_eq!(output, b"(x\\\\) Tj  \nET\n");
     }
 }


### PR DESCRIPTION
Fixes #258 

## What

`strip_pdf_comments()` tracks parenthesis nesting so `%` inside string literals
survives comment stripping — but it ignored backslash escapes. An escaped `\)`
desynced the depth counter, after which a `%` glyph inside a string was stripped
as a top-level comment, eating string bytes to end-of-line and corrupting the
stream for `Content::decode`. Result: silent partial text loss (the reporter's
PDF lost 141 of page 1's 155 text operators, cutting off mid-sentence).

The fix treats `\` inside a string literal as escaping the next byte, so `\(`,
`\)`, and `\\` never touch the nesting depth.

## Trigger shape (from the issue's PDF — Quartz-generated, subset fonts)

```
[ (\(') 1 (-) 1 ... (\).) 1 ... (\)%) 1 ... ] TJ
     escaped `\)` desyncs depth ─┘        └─ `%` then stripped as a "comment"
```

## Tests

- 3 new unit cases in `test_strip_pdf_comments_escaped_parens`:
  - escaped `\)` shielding a `%` glyph (the reported corruption) — stream
    unchanged;
  - escaped `\(` not opening a phantom string — a real trailing comment is
    still stripped;
  - escaped backslash `\\` before a real close-paren — string closes, comment
    stripped.
- Full suite: 789 + 147 lib/integration tests pass; `cargo fmt --check` clean;
  clippy warning count unchanged from baseline.
- On the issue's PDF: extraction goes from 2,051 chars (truncated at "Damit man
  damit") to 3,927 chars, restoring the missing paragraph and a previously
  missing "Aufgabe:" section, matching pypdf's ground truth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788465878&installation_model_id=11126&pr_number=259&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F259&signature=9fccdf6a9f54fa22b9d21a9304978750e3130d720d329cb23835d66fc3838b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make PDF comment stripping escape-aware so `%` inside string literals aren’t removed and streams aren’t corrupted. Escaped `\(`, `\)`, and `\\` no longer affect parenthesis depth tracking.

- **Bug Fixes**
  - Treat backslash inside a string as escaping the next byte; escaped parens/backslashes don’t change nesting.
  - Prevent `%` glyphs in strings from being misread as comments, avoiding text loss during extraction.
  - Add unit tests for escaped `\)`, `\(`, and `\\` cases.

<sup>Written for commit 437a5f3145981edfb887051994f8b4675ef64dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

