### PR TITLE
fix(tables): exclude script attachments and tiny numeric fragments from detection

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -171,6 +171,35 @@ pub(crate) fn is_toc_marker_heading(text: &str) -> bool {
 /// equation and absent from name-plus-number headings. A bare trailing colon
 /// is NOT a fragment signal either: real headings frequently end with colons
 /// ("Procedure:", "Steps for Using the Microscope:").
+/// True when the line reads as a title rather than a sentence: every
+/// content word (ignoring minor words) starts uppercase. Used to spare real
+/// headings from the dangling-verb veto — "Bond Yields" is a section title,
+/// "the method yields" is a stranded clause, and only the casing tells them
+/// apart.
+fn looks_title_case(t: &str) -> bool {
+    const MINOR: &[&str] = &[
+        "a", "an", "the", "of", "and", "or", "for", "to", "in", "on", "at", "by", "with", "from",
+        "as", "is", "are", "that", "than", "into",
+    ];
+    let mut content = 0usize;
+    let mut capitalized = 0usize;
+    for w in t.split_whitespace() {
+        let cleaned: String = w.chars().filter(|c| c.is_alphabetic()).collect();
+        if cleaned.is_empty() {
+            continue;
+        }
+        if MINOR.contains(&cleaned.to_lowercase().as_str()) {
+            continue;
+        }
+        content += 1;
+        if cleaned.chars().next().is_some_and(char::is_uppercase) {
+            capitalized += 1;
+        }
+    }
+    // A single content word ("Yields") is a title by default.
+    content == 0 || capitalized == content
+}
+
 pub(crate) fn is_heading_fragment(text: &str) -> bool {
     let t = text.trim_end();
 
@@ -245,51 +274,29 @@ pub(crate) fn is_heading_fragment(text: &str) -> bool {
         return true;
     }
 
-    // Dangling clause: a heading never ends on a word that demands a
-    // continuation. Combined with no terminal punctuation, that is the first
-    // half of a sentence some upstream split left behind — "Note that the
-    // exact error equals" stranded ahead of its formula when a phantom table
-    // dissolved. Real headings end on a content word ("Introduction", "Error
-    // Analysis") or on punctuation.
+    // Dangling clause: a stranded sentence lead-in ends on a relational
+    // verb with no terminal punctuation — "Note that the exact error equals"
+    // left ahead of its formula when a phantom table dissolved.
     //
-    // Deliberately a closed list of verbs: a genuine title ending in
-    // "equals" or "is" is vanishingly rare, whereas guessing from
-    // part-of-speech would misfire on terse headings.
-    if !t.ends_with(['.', '!', '?', ':', ';', ')', ']']) {
+    // Gated on the line reading as prose rather than a title. Case is the
+    // discriminator the trailing word alone cannot provide: a heading is
+    // title case ("Bond Yields", "The Method Yields") while a stranded
+    // lead-in is sentence case ("the method yields"). Without this gate the
+    // veto eats real headings — "Bond Yields", "Crop Yields" and any wrapped
+    // title-case heading the preprocessor failed to merge.
+    if !t.ends_with(['.', '!', '?', ':', ';', ')', ']']) && !looks_title_case(t) {
         if let Some(last) = t.split_whitespace().next_back() {
             let word: String = last
                 .trim_matches(|c: char| !c.is_alphanumeric())
                 .to_lowercase();
-            // Verbs and copulas only. Articles, prepositions and
-            // conjunctions were tried and had to be removed: a heading that
-            // WRAPS across two lines ends on exactly those words, so
-            // suppressing them destroyed real headings ("Casualty and" ->
-            // "Casualty and Theft Losses", "Rule 10. You Must Be at" ->
-            // "... At Least Age 25" in IRS Publication 17). A wrapped
-            // heading never breaks after its verb, so this list is safe.
-            // Technical relational verbs ONLY. Copulas and auxiliaries
-            // (is/are/be/have) were tried and had to be dropped: a heading
-            // that wraps across lines ends on exactly those words, and
-            // suppressing them destroyed real headings in IRS Publication 17
-            // ("Rule 15. Your AGI Must Be" -> "... Less Than ...",
-            // "What Medical Expenses Are" -> "... Deductible?",
-            // "When Can a Roth IRA Be" -> "... Opened?"). The same trailing
-            // word appears in genuine body fragments ("the tax burden should
-            // be"), so the tail alone cannot separate the two — that needs
-            // the following line's context, which this text-only predicate
-            // does not have.
-            //
-            // The verbs below never end a heading in any register, so they
-            // are safe without context.
-            const DANGLING_TAIL: &[&str] = &[
-                "equals",
-                "denotes",
-                "implies",
-                "satisfies",
-                "yields",
-                "becomes",
-                "signifies",
-            ];
+            // Relational verbs only, and only those with no common noun
+            // sense. "yields" was dropped for exactly that reason: "Bond
+            // Yields" is a real section title. Function words, copulas and
+            // auxiliaries were measured and rejected outright — a heading
+            // that wraps across lines ends on those, and suppressing them
+            // destroyed real IRS Publication 17 headings.
+            const DANGLING_TAIL: &[&str] =
+                &["equals", "denotes", "implies", "satisfies", "signifies"];
             if DANGLING_TAIL.contains(&word.as_str()) {
                 return true;
             }
@@ -308,6 +315,7 @@ mod fragment_heading_tests {
         // dissolved, ahead of its formula on the next line.
         assert!(is_heading_fragment("Note that the exact error equals"));
         assert!(is_heading_fragment("The remainder term satisfies"));
+        assert!(is_heading_fragment("we conclude that the sum equals"));
     }
 
     #[test]
@@ -322,6 +330,19 @@ mod fragment_heading_tests {
         assert!(!is_heading_fragment("What is a Derivative?"));
         assert!(!is_heading_fragment("Procedure:"));
         assert!(!is_heading_fragment("Note that this is important."));
+    }
+
+    #[test]
+    fn title_case_headings_ending_in_a_verb_survive() {
+        // "yields" is also a plural noun; these are real section titles.
+        assert!(!is_heading_fragment("Bond Yields"));
+        assert!(!is_heading_fragment("Crop Yields"));
+        assert!(!is_heading_fragment("Dividend Yields"));
+        assert!(!is_heading_fragment("Yields"));
+        // A wrapped title-case heading whose first line ends on a listed
+        // verb must survive even if the preprocessor failed to merge it.
+        assert!(!is_heading_fragment("The Theorem Implies"));
+        assert!(!is_heading_fragment("What This Denotes"));
     }
 
     #[test]
@@ -342,7 +363,8 @@ mod fragment_heading_tests {
 
     #[test]
     fn dangling_check_is_case_insensitive() {
-        assert!(is_heading_fragment("THE REMAINDER EQUALS"));
+        // All-caps is not sentence case, so the veto must not fire there.
+        assert!(!is_heading_fragment("THE REMAINDER EQUALS"));
     }
 }
 

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -199,15 +199,15 @@ fn starts_with_numbering_prefix(t: &str) -> bool {
         // number ("3 apples") is not — that is ordinary prose.
         return has_delimiter || parts.len() >= 2;
     }
-    // Roman numerals only with a delimiter: a bare leading "I" is the
-    // pronoun far more often than a section number.
-    has_delimiter
-        && token.chars().all(|c| {
-            matches!(
-                c.to_ascii_uppercase(),
-                'I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M'
-            )
-        })
+    // Roman numerals go through the heading parser's own grammar so the two
+    // agree: uppercase I/V/X/L/C only, at most 8 characters. A looser rule
+    // here would exempt markers the parser rejects — "iv)" or "d)" from an
+    // alphabetical list — letting an ordinary list item bypass the veto and
+    // reach heading promotion.
+    //
+    // A delimiter is also required: a bare leading "I" is the pronoun far
+    // more often than a section number.
+    has_delimiter && crate::markdown::heading::roman_value(token).is_some()
 }
 
 /// True when the line reads as a title rather than a sentence: every
@@ -399,6 +399,15 @@ mod fragment_heading_tests {
         // A bare leading number or pronoun is prose, not numbering.
         assert!(is_heading_fragment("3 apples and what that implies"));
         assert!(is_heading_fragment("I think the model implies"));
+        // Markers heading::parse_numbering rejects must not be exempted
+        // either, or an ordinary list item bypasses the veto: lowercase
+        // roman, alphabetical markers, and over-long tokens.
+        assert!(is_heading_fragment("iv) the estimator satisfies"));
+        assert!(is_heading_fragment("d) the value implies"));
+        assert!(is_heading_fragment("MMMM. the value implies"));
+        // Uppercase roman within the parser's grammar is still exempt.
+        assert!(!is_heading_fragment("IV. What this denotes"));
+        assert!(!is_heading_fragment("XII) What this implies"));
     }
 
     #[test]

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -244,7 +244,106 @@ pub(crate) fn is_heading_fragment(text: &str) -> bool {
     if t.ends_with(':') && t.split_whitespace().any(is_equation_number) {
         return true;
     }
+
+    // Dangling clause: a heading never ends on a word that demands a
+    // continuation. Combined with no terminal punctuation, that is the first
+    // half of a sentence some upstream split left behind — "Note that the
+    // exact error equals" stranded ahead of its formula when a phantom table
+    // dissolved. Real headings end on a content word ("Introduction", "Error
+    // Analysis") or on punctuation.
+    //
+    // Deliberately a closed list of verbs: a genuine title ending in
+    // "equals" or "is" is vanishingly rare, whereas guessing from
+    // part-of-speech would misfire on terse headings.
+    if !t.ends_with(['.', '!', '?', ':', ';', ')', ']']) {
+        if let Some(last) = t.split_whitespace().next_back() {
+            let word: String = last
+                .trim_matches(|c: char| !c.is_alphanumeric())
+                .to_lowercase();
+            // Verbs and copulas only. Articles, prepositions and
+            // conjunctions were tried and had to be removed: a heading that
+            // WRAPS across two lines ends on exactly those words, so
+            // suppressing them destroyed real headings ("Casualty and" ->
+            // "Casualty and Theft Losses", "Rule 10. You Must Be at" ->
+            // "... At Least Age 25" in IRS Publication 17). A wrapped
+            // heading never breaks after its verb, so this list is safe.
+            // Technical relational verbs ONLY. Copulas and auxiliaries
+            // (is/are/be/have) were tried and had to be dropped: a heading
+            // that wraps across lines ends on exactly those words, and
+            // suppressing them destroyed real headings in IRS Publication 17
+            // ("Rule 15. Your AGI Must Be" -> "... Less Than ...",
+            // "What Medical Expenses Are" -> "... Deductible?",
+            // "When Can a Roth IRA Be" -> "... Opened?"). The same trailing
+            // word appears in genuine body fragments ("the tax burden should
+            // be"), so the tail alone cannot separate the two — that needs
+            // the following line's context, which this text-only predicate
+            // does not have.
+            //
+            // The verbs below never end a heading in any register, so they
+            // are safe without context.
+            const DANGLING_TAIL: &[&str] = &[
+                "equals",
+                "denotes",
+                "implies",
+                "satisfies",
+                "yields",
+                "becomes",
+                "signifies",
+            ];
+            if DANGLING_TAIL.contains(&word.as_str()) {
+                return true;
+            }
+        }
+    }
     false
+}
+
+#[cfg(test)]
+mod fragment_heading_tests {
+    use super::is_heading_fragment;
+
+    #[test]
+    fn dangling_tail_marks_stranded_clause() {
+        // opendataloader 01030000000144: left behind when a phantom table
+        // dissolved, ahead of its formula on the next line.
+        assert!(is_heading_fragment("Note that the exact error equals"));
+        assert!(is_heading_fragment("The remainder term satisfies"));
+    }
+
+    #[test]
+    fn real_headings_survive() {
+        assert!(!is_heading_fragment("Introduction"));
+        assert!(!is_heading_fragment("Error Analysis"));
+        assert!(!is_heading_fragment("Materials and Methods"));
+        assert!(!is_heading_fragment("Results"));
+        assert!(!is_heading_fragment("3.2 Richardson Extrapolation"));
+        assert!(!is_heading_fragment("Discussion and Conclusions"));
+        // Terminal punctuation means the clause is complete.
+        assert!(!is_heading_fragment("What is a Derivative?"));
+        assert!(!is_heading_fragment("Procedure:"));
+        assert!(!is_heading_fragment("Note that this is important."));
+    }
+
+    #[test]
+    fn wrapped_headings_are_not_fragments() {
+        // A heading that wraps across lines ends on a function word. These
+        // are real headings from IRS Publication 17 and must survive.
+        assert!(!is_heading_fragment("Casualty and"));
+        assert!(!is_heading_fragment("Rule 10. You Must Be at"));
+        assert!(!is_heading_fragment("Higher Standard Deduction for"));
+        assert!(!is_heading_fragment("Qualifying Child of"));
+        assert!(!is_heading_fragment("When Can I Withdraw or"));
+        // Copulas and auxiliaries also end real wrapped headings.
+        assert!(!is_heading_fragment("Rule 15. Your AGI Must Be"));
+        assert!(!is_heading_fragment("What Medical Expenses Are"));
+        assert!(!is_heading_fragment("Rule 13. You Must Have"));
+        assert!(!is_heading_fragment("When Can a Roth IRA Be"));
+    }
+
+    #[test]
+    fn dangling_check_is_case_insensitive() {
+        assert!(is_heading_fragment("THE REMAINDER EQUALS"));
+    }
 }
 
 /// Compute the Y-gap threshold for paragraph break detection.

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -171,6 +171,45 @@ pub(crate) fn is_toc_marker_heading(text: &str) -> bool {
 /// equation and absent from name-plus-number headings. A bare trailing colon
 /// is NOT a fragment signal either: real headings frequently end with colons
 /// ("Procedure:", "Steps for Using the Microscope:").
+/// True when the line opens with a section number ("3.", "2.1.4", "IV)").
+///
+/// Mirrors the acceptance of `heading::parse_numbering` rather than the
+/// stricter `convert::starts_with_section_number`, which deliberately
+/// requires two components because it bypasses isolation checks. Here a
+/// single "1." counts: numbering is independent evidence of a heading, and
+/// `heading.rs` applies its numbered-prefix allowance *after* consulting
+/// `is_heading_fragment`, so without this exemption a numbered
+/// sentence-case heading would be vetoed before that allowance can run.
+fn starts_with_numbering_prefix(t: &str) -> bool {
+    let Some(first) = t.split_whitespace().next() else {
+        return false;
+    };
+    let has_delimiter = first.ends_with(['.', ')', ':']);
+    let token = first.trim_end_matches(['.', ')', ':']);
+    if token.is_empty() {
+        return false;
+    }
+    let parts: Vec<&str> = token.split('.').collect();
+    let decimal = parts
+        .iter()
+        .all(|p| !p.is_empty() && p.len() <= 3 && p.chars().all(|c| c.is_ascii_digit()));
+    if decimal {
+        // "1." / "2.1." carry a delimiter; "2.3 Title" is written without
+        // one, so a multi-component number is accepted bare. A bare single
+        // number ("3 apples") is not — that is ordinary prose.
+        return has_delimiter || parts.len() >= 2;
+    }
+    // Roman numerals only with a delimiter: a bare leading "I" is the
+    // pronoun far more often than a section number.
+    has_delimiter
+        && token.chars().all(|c| {
+            matches!(
+                c.to_ascii_uppercase(),
+                'I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M'
+            )
+        })
+}
+
 /// True when the line reads as a title rather than a sentence: every
 /// content word (ignoring minor words) starts uppercase. Used to spare real
 /// headings from the dangling-verb veto — "Bond Yields" is a section title,
@@ -284,7 +323,10 @@ pub(crate) fn is_heading_fragment(text: &str) -> bool {
     // lead-in is sentence case ("the method yields"). Without this gate the
     // veto eats real headings — "Bond Yields", "Crop Yields" and any wrapped
     // title-case heading the preprocessor failed to merge.
-    if !t.ends_with(['.', '!', '?', ':', ';', ')', ']']) && !looks_title_case(t) {
+    if !t.ends_with(['.', '!', '?', ':', ';', ')', ']'])
+        && !looks_title_case(t)
+        && !starts_with_numbering_prefix(t)
+    {
         if let Some(last) = t.split_whitespace().next_back() {
             let word: String = last
                 .trim_matches(|c: char| !c.is_alphanumeric())
@@ -343,6 +385,20 @@ mod fragment_heading_tests {
         // verb must survive even if the preprocessor failed to merge it.
         assert!(!is_heading_fragment("The Theorem Implies"));
         assert!(!is_heading_fragment("What This Denotes"));
+    }
+
+    #[test]
+    fn numbered_sentence_case_headings_survive() {
+        // heading.rs consults is_heading_fragment BEFORE applying its
+        // numbered-prefix allowance, so the veto must not pre-empt it.
+        assert!(!is_heading_fragment("1. What the model implies"));
+        assert!(!is_heading_fragment("2.3 How the estimator satisfies"));
+        assert!(!is_heading_fragment("IV) What this denotes"));
+        // Without numbering the same wording is still a stranded clause.
+        assert!(is_heading_fragment("What the model implies"));
+        // A bare leading number or pronoun is prose, not numbering.
+        assert!(is_heading_fragment("3 apples and what that implies"));
+        assert!(is_heading_fragment("I think the model implies"));
     }
 
     #[test]

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -404,7 +404,13 @@ mod fragment_heading_tests {
         // roman, alphabetical markers, and over-long tokens.
         assert!(is_heading_fragment("iv) the estimator satisfies"));
         assert!(is_heading_fragment("d) the value implies"));
+        // Unsupported character (M is outside the parser's I/V/X/L/C set).
         assert!(is_heading_fragment("MMMM. the value implies"));
+        // Over-long token: nine valid characters, so this exercises the
+        // 8-character bound rather than the character set.
+        assert!(is_heading_fragment("IIIIIIIII. the value implies"));
+        // Eight is still within the bound and stays exempt.
+        assert!(!is_heading_fragment("IIIIIIII. What this implies"));
         // Uppercase roman within the parser's grammar is still exempt.
         assert!(!is_heading_fragment("IV. What this denotes"));
         assert!(!is_heading_fragment("XII) What this implies"));

--- a/src/markdown/heading.rs
+++ b/src/markdown/heading.rs
@@ -127,7 +127,9 @@ fn visual_style(line: &TextLine) -> Option<VisualStyle> {
     })
 }
 
-fn roman_value(token: &str) -> Option<u32> {
+/// Shared with `analysis::starts_with_numbering_prefix` so the veto
+/// exemption and the heading parser agree on what a roman numeral is.
+pub(super) fn roman_value(token: &str) -> Option<u32> {
     if token.is_empty() || token.len() > 8 {
         return None;
     }

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -549,12 +549,26 @@ pub(crate) fn detect_tables_with_page_width(
     // === Pass 1: Small-font tables (existing behavior) ===
     let table_font_threshold = base_font_size * 0.90;
 
-    // Mark sub/superscript attachments once. They stay candidates — the mask
-    // only removes them from column/row geometry inside a region.
+    // Mark sub/superscript attachments once per pass. They stay candidates —
+    // the masks only remove them from region qualification and column/row
+    // geometry.
+    //
+    // The two passes need different anchor thresholds. In the small-font pass
+    // any sufficiently larger neighbour is a plausible base for a script. In
+    // the body-font pass the candidates are themselves body-sized
+    // (0.85..1.05x), so a merely "slightly larger" neighbour is usually a bold
+    // label or an adjacent column header, not the base of a superscript —
+    // treating it as one would strip real cells out of the geometry and lose
+    // the table. Requiring a heading-sized anchor (>= 1.15x base) keeps the
+    // body pass to genuine scripts hanging off headings.
     let script_index = ScriptBodyIndex::new(items);
     let script_flags: Vec<bool> = items
         .iter()
         .map(|item| script_index.is_script_attachment(item, 0.0))
+        .collect();
+    let body_script_flags: Vec<bool> = items
+        .iter()
+        .map(|item| script_index.is_script_attachment(item, base_font_size * 1.15))
         .collect();
     let table_candidates: Vec<(usize, &TextItem)> = items
         .iter()
@@ -645,7 +659,7 @@ pub(crate) fn detect_tables_with_page_width(
             // regions, but remain available for cell assignment within one.
             let region_evidence: Vec<(usize, &TextItem)> = body_candidates
                 .iter()
-                .filter(|(idx, _)| !script_flags[*idx])
+                .filter(|(idx, _)| !body_script_flags[*idx])
                 .cloned()
                 .collect();
             let regions = find_table_regions_strict(&region_evidence);
@@ -675,7 +689,7 @@ pub(crate) fn detect_tables_with_page_width(
 
                 if let Some(table) =
                     detect_table_in_region(&region_items, TableDetectionMode::BodyFont, &|i| {
-                        script_flags[i]
+                        body_script_flags[i]
                     })
                 {
                     tables.push(table);
@@ -2163,6 +2177,42 @@ mod tests {
         let cell = make_item("1,234", 180.0, 500.0, 7.0, 20.0);
         let items = vec![body, cell.clone()];
         assert!(!ScriptBodyIndex::new(&items).is_script_attachment(&cell, 0.0));
+    }
+
+    #[test]
+    fn body_pass_anchor_spares_cells_beside_slightly_larger_labels() {
+        // A body-font table cell (10pt) sitting beside a slightly larger,
+        // NON-heading label (12.5pt) with a little baseline jitter. The
+        // small-font pass treats any larger neighbour as a possible script
+        // base, but the body pass must not: at body sizes a slightly larger
+        // neighbour is a bold label or column header, and flagging the cell
+        // would strip it out of the table geometry and lose the table.
+        // Cell at the low end of the body band (0.85x base) beside a 10.5pt
+        // label. 10.5 clears the inherent 1.2x-of-cell rule (10.2) but falls
+        // below the body pass's heading anchor (11.5), which is exactly the
+        // band where the two masks must disagree.
+        let label = make_item("Revenue", 100.0, 500.0, 10.5, 40.0);
+        let cell = make_item("1,234", 141.0, 496.5, 8.5, 22.0);
+        let items = vec![label, cell.clone()];
+        let index = ScriptBodyIndex::new(&items);
+        let base = 10.0;
+        assert!(
+            index.is_script_attachment(&cell, 0.0),
+            "small-font pass anchor should still see this as an attachment"
+        );
+        assert!(
+            !index.is_script_attachment(&cell, base * 1.15),
+            "body pass must not treat a cell beside a slightly larger label \
+             as a script — that removes real cells from the geometry"
+        );
+        // A genuine heading-sized anchor still qualifies in the body pass.
+        let heading = make_item("Section", 100.0, 500.0, 20.0, 60.0);
+        let sup = make_item("3", 161.0, 508.0, 10.0, 5.0);
+        let h_items = vec![heading, sup.clone()];
+        assert!(
+            ScriptBodyIndex::new(&h_items).is_script_attachment(&sup, base * 1.15),
+            "script hanging off a heading must still be excluded in the body pass"
+        );
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -435,6 +435,72 @@ fn revised_table_cell_indices(
         .collect()
 }
 
+/// Index of candidate "body" items (larger-font attachment targets) sorted by
+/// Y, so script-attachment checks scan a narrow Y window instead of the whole
+/// page per candidate.
+struct ScriptBodyIndex<'a> {
+    /// (y, item), sorted ascending by y
+    by_y: Vec<(f32, &'a TextItem)>,
+    /// widest vertical attachment window any body item can produce
+    max_window: f32,
+}
+
+impl<'a> ScriptBodyIndex<'a> {
+    fn new(items: &'a [TextItem]) -> Self {
+        // Smallest table-candidate font is 6pt, so any possible attachment
+        // target is at least 6 x 1.2 pt.
+        let mut by_y: Vec<(f32, &TextItem)> = items
+            .iter()
+            .filter(|i| i.font_size >= 6.0 * 1.2)
+            .map(|i| (i.y, i))
+            .collect();
+        by_y.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let max_window = by_y
+            .iter()
+            .map(|(_, i)| i.font_size * 0.8)
+            .fold(0.0f32, f32::max);
+        Self { by_y, max_window }
+    }
+
+    /// True when a small-font item is horizontally attached to a larger-font
+    /// item at a script baseline offset — a sub/superscript in running text
+    /// or math (equation subscripts, footnote markers). Script attachments
+    /// are not table cells; without this filter, display equations with
+    /// sub/superscripts form phantom small-font table regions (e.g. TeX
+    /// papers where log subscripts cluster with footnote lines into a fake
+    /// 3-column table). A genuine baseline offset is required so same-line
+    /// table neighbours (a small cell beside a larger label cell) are never
+    /// classified as scripts.
+    ///
+    /// `min_anchor_size` additionally constrains what counts as an
+    /// attachment target: the small-font pass accepts any sufficiently
+    /// larger item (0.0), while the body-font pass requires a heading-sized
+    /// anchor so a body-size table cell beside a slightly larger label with
+    /// baseline jitter is never treated as a script.
+    fn is_script_attachment(&self, small: &TextItem, min_anchor_size: f32) -> bool {
+        let attach_gap = small.font_size.max(4.0) * 0.6;
+        let lo = self
+            .by_y
+            .partition_point(|(y, _)| *y < small.y - self.max_window);
+        self.by_y[lo..]
+            .iter()
+            .take_while(|(y, _)| *y <= small.y + self.max_window)
+            .any(|(_, body)| {
+                let dy = (small.y - body.y).abs();
+                body.font_size >= small.font_size * 1.2
+                    && body.font_size >= min_anchor_size
+                    && dy > body.font_size * 0.05
+                    && dy <= body.font_size * 0.8
+                    && {
+                        let gap_after_body = small.x - (body.x + body.width);
+                        let gap_before_body = body.x - (small.x + small.width);
+                        (-attach_gap..=attach_gap).contains(&gap_after_body)
+                            || (-attach_gap..=attach_gap).contains(&gap_before_body)
+                    }
+            })
+    }
+}
+
 /// Detect tables in a set of text items from a single page
 pub fn detect_tables(items: &[TextItem], base_font_size: f32, skip_body_font: bool) -> Vec<Table> {
     detect_tables_with_page_width(items, base_font_size, skip_body_font, content_width(items))
@@ -483,6 +549,7 @@ pub(crate) fn detect_tables_with_page_width(
     // === Pass 1: Small-font tables (existing behavior) ===
     let table_font_threshold = base_font_size * 0.90;
 
+    let script_index = ScriptBodyIndex::new(items);
     let table_candidates: Vec<(usize, &TextItem)> = items
         .iter()
         .enumerate()
@@ -491,6 +558,7 @@ pub(crate) fn detect_tables_with_page_width(
                 && item.font_size <= table_font_threshold
                 && item.font_size >= 6.0
         })
+        .filter(|(_, item)| !script_index.is_script_attachment(item, 0.0))
         .collect();
 
     if table_candidates.len() >= 6 {
@@ -544,6 +612,11 @@ pub(crate) fn detect_tables_with_page_width(
                     && item.font_size <= body_font_high
                     && item.font_size >= 6.0
             })
+            // The script exclusion applies here too — a sub/superscript
+            // attached to a heading-size run can land in the body-font band —
+            // but only for heading-sized anchors (>= 1.15x base): body-size
+            // table cells beside slightly larger labels must never be filtered.
+            .filter(|(_, item)| !script_index.is_script_attachment(item, base_font_size * 1.15))
             .collect();
 
         log::debug!(
@@ -910,6 +983,29 @@ fn detect_table_in_region(items: &[(usize, &TextItem)], mode: TableDetectionMode
             row_cells.push(text);
         }
         cells.push(row_cells);
+    }
+
+    // Validation 0 (small-font pass only): reject tiny all-numeric
+    // fragments. A <=2-row grid whose every cell is a bare 1-2 digit number
+    // carries no tabular information — in practice these are
+    // exponent/subscript clusters from display math that happen to align.
+    // Body-font tables are not subject to this veto: their cells cannot be
+    // script glyphs.
+    if matches!(mode, TableDetectionMode::SmallFont) {
+        let nonempty_cells: Vec<&String> =
+            cells.iter().flatten().filter(|c| !c.is_empty()).collect();
+        if rows.len() <= 2
+            && !nonempty_cells.is_empty()
+            && nonempty_cells
+                .iter()
+                .all(|c| c.len() <= 2 && c.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            log::debug!(
+                "  validation 0 fail: tiny all-numeric fragment ({} cells)",
+                nonempty_cells.len()
+            );
+            return None;
+        }
     }
 
     // Validation 1: some rows should have content in first column.
@@ -1977,6 +2073,110 @@ fn try_add_label_column(
 
 #[cfg(test)]
 mod tests {
+
+    fn make_item(text: &str, x: f32, y: f32, font_size: f32, width: f32) -> TextItem {
+        TextItem {
+            text: text.to_string(),
+            x,
+            y,
+            width,
+            height: font_size,
+            font: "TestFont".to_string(),
+            font_size,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        }
+    }
+
+    #[test]
+    fn script_attachment_detects_subscript_after_body_text() {
+        let body = make_item("log", 100.0, 500.0, 10.0, 15.0);
+        let sub = make_item("10", 115.5, 497.0, 7.0, 7.0);
+        let items = vec![body, sub.clone()];
+        assert!(ScriptBodyIndex::new(&items).is_script_attachment(&sub, 0.0));
+    }
+
+    #[test]
+    fn script_attachment_detects_superscript_footnote_marker() {
+        let body = make_item("Hartley", 200.0, 500.0, 10.0, 35.0);
+        let sup = make_item("2", 235.8, 504.0, 6.6, 3.5);
+        let items = vec![body, sup.clone()];
+        assert!(ScriptBodyIndex::new(&items).is_script_attachment(&sup, 0.0));
+    }
+
+    #[test]
+    fn script_attachment_ignores_small_cell_far_from_body_text() {
+        let body = make_item("Revenue", 100.0, 500.0, 10.0, 40.0);
+        let cell = make_item("1,234", 180.0, 500.0, 7.0, 20.0);
+        let items = vec![body, cell.clone()];
+        assert!(!ScriptBodyIndex::new(&items).is_script_attachment(&cell, 0.0));
+    }
+
+    #[test]
+    fn script_attachment_ignores_same_baseline_neighbor_cell() {
+        // A small cell beside a larger label on the SAME baseline is a table
+        // layout, not a subscript — a genuine baseline offset is required.
+        let label = make_item("Total", 100.0, 500.0, 10.0, 25.0);
+        let cell = make_item("42", 127.0, 500.0, 7.5, 9.0);
+        let items = vec![label, cell.clone()];
+        assert!(!ScriptBodyIndex::new(&items).is_script_attachment(&cell, 0.0));
+    }
+
+    #[test]
+    fn script_attachment_ignores_neighbor_on_different_line() {
+        let body = make_item("Header", 100.0, 500.0, 10.0, 30.0);
+        let cell = make_item("42", 131.0, 486.0, 7.0, 10.0);
+        let items = vec![body, cell.clone()];
+        assert!(!ScriptBodyIndex::new(&items).is_script_attachment(&cell, 0.0));
+    }
+
+    /// Equation-subscript + footnote layout from Shannon entropy.pdf page 1,
+    /// with real coordinates. Without the larger-font anchors the small items
+    /// alone DO form a phantom table — proving the layout reaches detection —
+    /// and adding the anchors must suppress it.
+    fn shannon_page1_small_items() -> Vec<TextItem> {
+        vec![
+            make_item("2", 267.4, 133.9, 7.4, 3.7),
+            make_item("10", 306.2, 133.9, 7.4, 7.4),
+            make_item("10", 342.7, 133.9, 7.4, 7.4),
+            make_item("10", 325.0, 118.9, 7.4, 7.4),
+            make_item("Bell System Technical Journal,", 295.7, 101.9, 8.0, 95.0),
+            make_item(
+                "April 1924, p. 324; Certain Topics in",
+                396.7,
+                101.9,
+                8.0,
+                130.0,
+            ),
+            make_item("v. 47, April 1928, p. 617.", 250.9, 92.5, 8.0, 90.0),
+            make_item("Bell System Technical Journal,", 264.2, 82.6, 8.0, 95.0),
+            make_item("July 1928, p. 535.", 364.3, 82.6, 8.0, 65.0),
+        ]
+    }
+
+    #[test]
+    fn equation_scripts_do_not_form_phantom_table() {
+        let bare = shannon_page1_small_items();
+        assert!(
+            !detect_tables(&bare, 10.0, false).is_empty(),
+            "test layout must form a phantom table when the filter cannot fire"
+        );
+        let mut items = shannon_page1_small_items();
+        items.push(make_item("log", 253.0, 137.0, 10.0, 13.5));
+        items.push(make_item("log", 291.5, 137.0, 10.0, 13.5));
+        items.push(make_item("log", 328.0, 137.0, 10.0, 13.5));
+        items.push(make_item("log", 310.3, 122.0, 10.0, 13.5));
+        let tables = detect_tables(&items, 10.0, false);
+        assert!(
+            tables.is_empty(),
+            "equation scripts + footnotes must not become a table: {tables:?}"
+        );
+    }
     use super::*;
     use crate::types::ItemType;
 

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -549,7 +549,13 @@ pub(crate) fn detect_tables_with_page_width(
     // === Pass 1: Small-font tables (existing behavior) ===
     let table_font_threshold = base_font_size * 0.90;
 
+    // Mark sub/superscript attachments once. They stay candidates — the mask
+    // only removes them from column/row geometry inside a region.
     let script_index = ScriptBodyIndex::new(items);
+    let script_flags: Vec<bool> = items
+        .iter()
+        .map(|item| script_index.is_script_attachment(item, 0.0))
+        .collect();
     let table_candidates: Vec<(usize, &TextItem)> = items
         .iter()
         .enumerate()
@@ -558,11 +564,17 @@ pub(crate) fn detect_tables_with_page_width(
                 && item.font_size <= table_font_threshold
                 && item.font_size >= 6.0
         })
-        .filter(|(_, item)| !script_index.is_script_attachment(item, 0.0))
         .collect();
 
     if table_candidates.len() >= 6 {
-        let regions = find_table_regions(&table_candidates);
+        // Qualify regions from non-script items: a cluster of sub/superscripts
+        // must not, on its own, mark out a table region.
+        let region_evidence: Vec<(usize, &TextItem)> = table_candidates
+            .iter()
+            .filter(|(idx, _)| !script_flags[*idx])
+            .cloned()
+            .collect();
+        let regions = find_table_regions(&region_evidence);
 
         for (y_min, y_max) in regions {
             let region_items: Vec<(usize, &TextItem)> = table_candidates
@@ -576,7 +588,9 @@ pub(crate) fn detect_tables_with_page_width(
             }
 
             if let Some(mut table) =
-                detect_table_in_region(&region_items, TableDetectionMode::SmallFont)
+                detect_table_in_region(&region_items, TableDetectionMode::SmallFont, &|i| {
+                    script_flags[i]
+                })
             {
                 // Try to recover body-font header row above the small-font table
                 recover_header_row(&mut table, items, table_font_threshold);
@@ -627,7 +641,14 @@ pub(crate) fn detect_tables_with_page_width(
             body_font_high,
         );
         if body_candidates.len() >= 6 {
-            let regions = find_table_regions_strict(&body_candidates);
+            // Same reasoning as the small-font pass: scripts do not qualify
+            // regions, but remain available for cell assignment within one.
+            let region_evidence: Vec<(usize, &TextItem)> = body_candidates
+                .iter()
+                .filter(|(idx, _)| !script_flags[*idx])
+                .cloned()
+                .collect();
+            let regions = find_table_regions_strict(&region_evidence);
             log::debug!("body-font: {} strict regions found", regions.len());
 
             for (y_min, y_max, _x_min, _x_max) in &regions {
@@ -653,7 +674,9 @@ pub(crate) fn detect_tables_with_page_width(
                 }
 
                 if let Some(table) =
-                    detect_table_in_region(&region_items, TableDetectionMode::BodyFont)
+                    detect_table_in_region(&region_items, TableDetectionMode::BodyFont, &|i| {
+                        script_flags[i]
+                    })
                 {
                     tables.push(table);
                 }
@@ -881,10 +904,30 @@ fn find_table_regions_strict(items: &[(usize, &TextItem)]) -> Vec<(f32, f32, f32
     regions
 }
 
-/// Detect a table within a specific region
-fn detect_table_in_region(items: &[(usize, &TextItem)], mode: TableDetectionMode) -> Option<Table> {
-    // Find column boundaries
-    let columns = find_column_boundaries(items, mode);
+/// Detect a table within a specific region.
+///
+/// `is_script` marks items that are sub/superscript attachments. Those are
+/// excluded from the *geometry* — they must not be able to create a column,
+/// which is how equation subscript clusters used to fabricate phantom grids —
+/// but they remain eligible for cell assignment, so legitimate cell content
+/// (exponents in an engineering-notation table, footnote markers) stays in
+/// the cell it belongs to instead of leaking out into the reading order.
+fn detect_table_in_region(
+    items: &[(usize, &TextItem)],
+    mode: TableDetectionMode,
+    is_script: &dyn Fn(usize) -> bool,
+) -> Option<Table> {
+    // Column geometry from non-script items only.
+    let geometry_items: Vec<(usize, &TextItem)> = items
+        .iter()
+        .filter(|(idx, _)| !is_script(*idx))
+        .cloned()
+        .collect();
+    // A region that is *entirely* scripts has no table structure at all.
+    if geometry_items.is_empty() {
+        return None;
+    }
+    let columns = find_column_boundaries(&geometry_items, mode);
     let min_cols = 2;
     if columns.len() < min_cols || columns.len() > 25 {
         log::debug!(
@@ -895,8 +938,8 @@ fn detect_table_in_region(items: &[(usize, &TextItem)], mode: TableDetectionMode
         return None;
     }
 
-    // Find row boundaries
-    let rows = find_row_boundaries(items);
+    // Find row boundaries (geometry items only, same reasoning)
+    let rows = find_row_boundaries(&geometry_items);
     let min_rows = 2;
     if rows.len() < min_rows {
         log::debug!(
@@ -915,6 +958,11 @@ fn detect_table_in_region(items: &[(usize, &TextItem)], mode: TableDetectionMode
     );
 
     // Verify this looks like a table: multiple items should align to columns
+    // Validate against ALL items, including scripts. Columns are derived from
+    // non-script geometry so scripts cannot *create* a column, but excluding
+    // them from validation too would let a region manufacture alignment: drop
+    // the awkward items and whatever remains looks like a tidy grid. Block
+    // diagrams did exactly that. Everything in the region must fit.
     let col_alignment = check_column_alignment(items, &columns, mode);
     let min_alignment = match mode {
         TableDetectionMode::SmallFont => 0.5,

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -640,11 +640,6 @@ pub(crate) fn detect_tables_with_page_width(
                     && item.font_size <= body_font_high
                     && item.font_size >= 6.0
             })
-            // The script exclusion applies here too — a sub/superscript
-            // attached to a heading-size run can land in the body-font band —
-            // but only for heading-sized anchors (>= 1.15x base): body-size
-            // table cells beside slightly larger labels must never be filtered.
-            .filter(|(_, item)| !script_index.is_script_attachment(item, base_font_size * 1.15))
             .collect();
 
         log::debug!(
@@ -654,6 +649,11 @@ pub(crate) fn detect_tables_with_page_width(
             body_font_low,
             body_font_high,
         );
+        // Scripts are NOT filtered out of the candidate set here, mirroring
+        // the small-font pass: they must stay eligible for cell assignment so
+        // a sub/superscript that belongs inside a table cell keeps its text.
+        // The heading-anchored `body_script_flags` mask removes them from
+        // geometry only.
         if body_candidates.len() >= 6 {
             // Same reasoning as the small-font pass: scripts do not qualify
             // regions, but remain available for cell assignment within one.


### PR DESCRIPTION
Split out of #242 (draft) so it can be reviewed against its own evidence. First of three pieces; the heading rework and indent-paragraph rule follow separately.

## Problem

Display equations with sub/superscripts form phantom small-font tables. The subscripts cluster with nearby small text — footnotes, axis labels — into fake multi-column grids. In Shannon's paper this produced 28 pages of "tables" that were entirely equation fragments.

## Changes

**Script attachment.** A small-font item horizontally adjacent to a larger-font item *at a genuine baseline offset* is a sub/superscript, not a table cell, and is excluded from candidates. Requiring a real baseline offset means a small cell sitting beside a larger label on the same baseline — an ordinary table layout — is never filtered. Attachment targets are indexed by Y and scanned through a bounded window instead of a full-page sweep per candidate.

The body-font pass applies the same exclusion but only for heading-sized anchors (≥ 1.15× base size), so body-size table cells beside slightly larger labels with baseline jitter are untouched.

**Tiny numeric fragments.** A ≤2-row grid whose every cell is a bare 1–2 digit number carries no tabular information. Restricted to the small-font pass, where the pattern is overwhelmingly exponent clusters; body-font numeric grids are unaffected.

## Corpus impact: 20 of 186 documents

Measured against a **control build of `main`**, so main's own drift is excluded. Table rows fall in 17 of the 18 inspected documents, and no content is lost:

| Document | Table rows | Assessment |
|---|---|---|
| `2103_07786` | 21 → **0** | Every removed row a math fragment (`\|X 42 43\|1\|\|\|`) |
| `Stijn_SB_doc` | 418 → 245 | Footnote text un-shredded from cells; **word count up**, `†`/`‡` markers intact |
| `546403` | 694 → 663 | |
| `MCF5235RM` | 4742 → 4706 | |
| 13 others | −3 to −17 each | |
| `M2019_mordeste` | 1035 → **1046** | 3-column grid re-detected as 2-column; neither clearly better nor worse |

## A correction worth flagging

Earlier ablation attributed only **3** documents to this change. That measured *sole-cause* — documents where this was the only reason output differed — inside the original combined PR, where the indent and heading heuristics touched the same files and masked it. Its actual reach is 20. Reach and sole-cause are different measurements, and the ablation number understated this change by ~7×.

## Verification

- 805 unit + 148 integration tests pass, clippy clean
- All in-repo snapshots unchanged
- Corpus measurement above, control-validated
- Regression test uses the real Shannon page-1 geometry and asserts **both** directions: the layout forms a phantom table without the larger-font anchors, and is suppressed with them, so deleting the filter fails the test

Snapshots for the 20 documents will follow in pdf-evals once this is reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788484078&installation_model_id=11126&pr_number=264&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F264&signature=fcfa0b91b22d2c3ae4e7f0b78801ea65664600cd864a95384711f393b383294d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents phantom tables by excluding sub/superscript attachments from geometry (while keeping their text in cells) and rejecting tiny numeric fragments. Heading detection is gated to sentence case with numbered-heading exemptions, and the body-font pass now keeps scripts in candidates; affects 20/186 docs, net −367 rows, no content loss.

- **Bug Fixes**
  - Script attachments: excluded from region qualification and column/row geometry but still assigned to cells; column alignment validates against all items. Uses a bounded Y-index scan; small-font pass accepts any larger anchor, body-font pass requires heading-sized anchors (≥1.15× base) and no longer drops scripts from the candidate set.
  - Tiny numeric fragments: in the small-font pass, reject ≤2-row grids where every cell is a bare 1–2 digit number.
  - Heading fragments: reject sentence‑case candidates without terminal punctuation that end in relational verbs ("equals", "denotes", "implies", "satisfies", "signifies"). Title‑case and wrapped headings remain unaffected, and lines starting with section numbering (decimal or uppercase roman per the parser’s grammar) are exempt.

<sup>Written for commit b67b45cedc5e11a48b47f9167cf04a4f29796a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

