### PR TITLE
fix(tables): preserve wrapped ruled tables

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -808,6 +808,32 @@ fn rect_cluster_spans_band_boundary(
     })
 }
 
+/// True when explicit vector-grid geometry proves that a proposed text gutter
+/// cuts through one ruled table. Physical cell boundaries outrank the
+/// text-only side-by-side guess; independent tables remain in separate bands.
+fn line_grid_spans_band_boundary(
+    items: &[TextItem],
+    lines: &[PdfLine],
+    page: u32,
+    bands: &[(f32, f32)],
+) -> bool {
+    if bands.len() < 2 {
+        return false;
+    }
+    let boundaries: Vec<f32> = bands[..bands.len() - 1].iter().map(|&(_, hi)| hi).collect();
+    crate::tables::detect_vector_grid_tables_from_lines(items, lines, page)
+        .iter()
+        .any(|table| {
+            let Some((&left, &right)) = table.columns.first().zip(table.columns.last()) else {
+                return false;
+            };
+            table.rows.len() >= 2
+                && boundaries
+                    .iter()
+                    .any(|&boundary| left < boundary && right > boundary)
+        })
+}
+
 fn split_from_hint_regions(items: &[TextItem], rects: &[PdfRect], page: u32) -> Vec<(f32, f32)> {
     use crate::tables::{cluster_rects, RectHintRegion};
 
@@ -1381,12 +1407,15 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         // safely from folios; cleaned evidence is reserved for column and
         // final non-table layout decisions.
         let mut bands = split_side_by_side(&page_items);
-        // A rect table crossing a proposed split boundary means the "gutter"
-        // is really the gap between ruled and borderless table columns —
-        // splitting there cleaves the table in half. Veto the split.
-        if !bands.is_empty() && rect_cluster_spans_band_boundary(&page_items, rects, page, &bands) {
+        // Explicit table geometry crossing a proposed split boundary means the
+        // "gutter" is really a cell gap. Veto before band-local detection can
+        // accept plausible partial tables and discard the remaining columns.
+        if !bands.is_empty()
+            && (rect_cluster_spans_band_boundary(&page_items, rects, page, &bands)
+                || line_grid_spans_band_boundary(&page_items, pdf_lines, page, &bands))
+        {
             log::debug!(
-                "page {}: side-by-side split vetoed by spanning rect cluster",
+                "page {}: side-by-side split vetoed by spanning table geometry",
                 page
             );
             bands.clear();

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -811,27 +811,61 @@ fn rect_cluster_spans_band_boundary(
 /// True when explicit vector-grid geometry proves that a proposed text gutter
 /// cuts through one ruled table. Physical cell boundaries outrank the
 /// text-only side-by-side guess; independent tables remain in separate bands.
-fn line_grid_spans_band_boundary(
-    items: &[TextItem],
-    lines: &[PdfLine],
-    page: u32,
-    bands: &[(f32, f32)],
-) -> bool {
+fn line_grid_spans_band_boundary(lines: &[PdfLine], page: u32, bands: &[(f32, f32)]) -> bool {
     if bands.len() < 2 {
         return false;
     }
     let boundaries: Vec<f32> = bands[..bands.len() - 1].iter().map(|&(_, hi)| hi).collect();
-    crate::tables::detect_vector_grid_tables_from_lines(items, lines, page)
+    let mut horizontal_rules: Vec<(f32, f32, f32)> = lines
         .iter()
-        .any(|table| {
-            let Some((&left, &right)) = table.columns.first().zip(table.columns.last()) else {
-                return false;
-            };
-            table.rows.len() >= 2
-                && boundaries
-                    .iter()
-                    .any(|&boundary| left < boundary && right > boundary)
+        .filter(|line| line.page == page)
+        .filter_map(|line| {
+            let dx = (line.x2 - line.x1).abs();
+            let dy = (line.y2 - line.y1).abs();
+            (dx >= 20.0 && dy / dx <= 2.0_f32.to_radians().tan()).then_some((
+                (line.y1 + line.y2) / 2.0,
+                line.x1.min(line.x2),
+                line.x1.max(line.x2),
+            ))
         })
+        .collect();
+    horizontal_rules.sort_by(|left, right| {
+        right
+            .0
+            .total_cmp(&left.0)
+            .then_with(|| left.1.total_cmp(&right.1))
+    });
+
+    boundaries.into_iter().any(|boundary| {
+        let mut crossing_rows = Vec::new();
+        let mut index = 0;
+        while index < horizontal_rules.len() {
+            let y = horizontal_rules[index].0;
+            let mut group_end = index + 1;
+            while group_end < horizontal_rules.len()
+                && (horizontal_rules[group_end].0 - y).abs() <= 2.0
+            {
+                group_end += 1;
+            }
+
+            let mut span = (horizontal_rules[index].1, horizontal_rules[index].2);
+            for &(_, left, right) in &horizontal_rules[index + 1..group_end] {
+                if left <= span.1 + 6.0 {
+                    span.1 = span.1.max(right);
+                } else {
+                    if span.0 < boundary && span.1 > boundary {
+                        break;
+                    }
+                    span = (left, right);
+                }
+            }
+            if span.0 < boundary && span.1 > boundary {
+                crossing_rows.push(y);
+            }
+            index = group_end;
+        }
+        crossing_rows.len() >= 3
+    })
 }
 
 fn split_from_hint_regions(items: &[TextItem], rects: &[PdfRect], page: u32) -> Vec<(f32, f32)> {
@@ -1412,7 +1446,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         // accept plausible partial tables and discard the remaining columns.
         if !bands.is_empty()
             && (rect_cluster_spans_band_boundary(&page_items, rects, page, &bands)
-                || line_grid_spans_band_boundary(&page_items, pdf_lines, page, &bands))
+                || line_grid_spans_band_boundary(pdf_lines, page, &bands))
         {
             log::debug!(
                 "page {}: side-by-side split vetoed by spanning table geometry",
@@ -2414,6 +2448,48 @@ mod tests {
         let mut it = make_item(x, y, page);
         it.width = width;
         it
+    }
+
+    fn make_rule(x1: f32, y1: f32, x2: f32, y2: f32) -> PdfLine {
+        PdfLine {
+            x1,
+            y1,
+            x2,
+            y2,
+            page: 1,
+        }
+    }
+
+    #[test]
+    fn independent_side_by_side_line_grids_do_not_veto_band_split() {
+        let mut lines = Vec::new();
+        for (left, right) in [(50.0, 200.0), (300.0, 450.0)] {
+            for y in [400.0, 370.0, 335.0] {
+                lines.push(make_rule(left, y, right, y));
+            }
+            for x in [left, (left + right) / 2.0, right] {
+                lines.push(make_rule(x, 335.0, x, 400.0));
+            }
+        }
+
+        assert!(
+            !line_grid_spans_band_boundary(&lines, 1, &[(50.0, 200.0), (300.0, 450.0)]),
+            "disjoint ruled tables must retain their physical gutter"
+        );
+    }
+
+    #[test]
+    fn connected_line_grid_vetoes_band_split() {
+        let lines: Vec<PdfLine> = [400.0, 370.0, 335.0]
+            .into_iter()
+            .map(|y| make_rule(50.0, y, 450.0, y))
+            .collect();
+
+        assert!(line_grid_spans_band_boundary(
+            &lines,
+            1,
+            &[(50.0, 200.0), (300.0, 450.0)]
+        ));
     }
 
     #[test]

--- a/tests/fixtures/wrapped_cell_ruled_table.pdf
+++ b/tests/fixtures/wrapped_cell_ruled_table.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260805111916-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260805111916-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (anydoc table reproduction) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1120
+>>
+stream
+Gau0Dhf"u<&:Vr4EK=>S0cLOPa*$\p9pN;lB^_0FNOs_?D>N;-hjFU6\'eB]&8dZl4+DIohjmIi&A2]N=]PN83IL`sJVK8iJ[0elIKAX-ibh'VSe2>SQEUL$Q3>Aj95trgUk@4B!ZC2e8qRuO$7S>E>/o(G(\$kXWAY]56jYm*#(H)3.e=_P>KBTV\=\#Z(m5:N`srspZ@jJ80UduA$8U94@9U']$n3GV7GfqV%lh0<'SlA'ZfJa_PA^6UJ!3Y>b&E`gPX!>+T:@&O'u__]r95jRXpQCa%:?UtQ"]OYkpK*@J24_.O*;r4+8B,XgZ_9uBcNp"N;\Ci`?UlfH9)1eOnh_t%7<gm8r-XonJ`forlD-P>1di;JhU?A@2U]&N79,&!gsuXIEkFkTuXS+a*f86B$3IVgK0WgbL89G;aO#?aDke:`';>kP<XJ\I?:9Iqs3%N,%oh/!9`IEa7-S[PNW:!3[IAI,02Xs8@d/FP]s6+Hj*F,p/#dLO5JP]<a[gPXe7,-&R9seTr:6eIJ6$pc&SMoopp!(Dg?'480#gh?ou81g'H/N6PR9I'o)jC*WV.RN_T&^'t!W@5B6$T=Z"B(Pf5Ll]Z&9E]*l?=SJtI@Y'%^!".5I;X5c)"]-s@oQ2*mgX0Gg[LDlY;]s"`pSp^Yko;o=_Gbt4Us(GEC_;-)BDd)7A3:R@i3U:]4r]us$r:Z6<U.ddp2dO_ES_.GbDtdlS-g.==p]"e$]bXlm`D+.HU=T$\">j3SU;Tga.![IHfU&e6YYgamWjjNIYm#N!_+lQR`\uVG7>omhg:H%9>ejOmkZZ,4[l=k4C#F\n@CM`YTaF@#5AVlL]8<h"/$WE%L!a`uRN%?jZ!<helZ0r7>nuL,B!XoC$I(NH13>$(?[fInRtVm+c0KKX/g6!GE8aW4FI2^EWq$HkM7]X4peuB&H)6#5**]lg]q^sBW*_P[I)l9A4l*;[Mh&X]n68M-pbg$Z>I`r@1'Yh+gLTA)Eg\&E,f'W(@!AB$ZZ(kseH6,'5-2);O<nBBXW\V[-Q!dlZ$<HtS*FB$;N3B6:A,GFN"NeJG-^N)hDjFENe.lChDjFJNH`7EpgB'MA\)+E%e#Aus4L\^p^=i4?&n~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000884 00000 n 
+0000000943 00000 n 
+trailer
+<<
+/ID 
+[<fefa024d077145ecec94f5a7f970c440><fefa024d077145ecec94f5a7f970c440>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2154
+%%EOF

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1322,6 +1322,26 @@ fn test_snapshot_shannon_entropy() {
     assert_snapshot("shannon-entropy-p1-2");
 }
 
+#[test]
+fn test_wrapped_cell_keeps_ruled_table_intact() {
+    let buf = std::fs::read("tests/fixtures/wrapped_cell_ruled_table.pdf").unwrap();
+    let result = process_pdf_mem(&buf).unwrap();
+    let markdown = result.markdown.unwrap_or_default();
+
+    assert!(
+        markdown.contains("|Code|Operation Description|Book Value|Tax Base|Tax|Exempt|Other|"),
+        "wrapped cells must not split a seven-column ruled table: {markdown}"
+    );
+    assert!(
+        markdown.contains("|1004|Acquisition of transport services"),
+        "wrapped row must remain separate from the total row: {markdown}"
+    );
+    assert!(
+        markdown.contains("|T O T A L||10,000.00|8,000.00|1,440.00|0.00|2,000.00|"),
+        "all totals must retain their row and column identity: {markdown}"
+    );
+}
+
 // ============================================================================
 // Pages Needing OCR Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- keep wrapped cells inside a single ruled table when text-only layout detection proposes a false page split
- let complete-page vector-grid evidence veto only the band boundaries it crosses
- add the attached synthetic PDF as a deterministic regression fixture

## What Problem This Solves

A ruled 7-column table can be split into partial 2- and 3-column tables when long cell text wraps. The remaining columns are emitted as prose, detaching numeric values from their row and column identity without reporting an error.

## Why This Change Was Made

The PDF already contains the complete physical grid. Before table detection is partitioned into side-by-side bands, this change checks the full-page vector-grid candidate. A proposed text gutter is rejected only when that explicit table crosses the boundary; independent side-by-side tables keep their existing band-local path.

## User Impact

Wrapped descriptions no longer fragment otherwise valid ruled tables. Rows and totals retain their full column structure, while the short-cell control output remains unchanged.

## Evidence

- `cargo test --test integration_tests test_wrapped_cell_keeps_ruled_table_intact -- --exact` — failed on `371de80b` with split tables; passes with the fix
- short-cell control Markdown compared byte-for-byte before and after the change — unchanged
- `cargo fmt --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — passed (813 library, 2 binary, 152 integration, and 2 doc tests)
- `cargo build --release` — passed
- `git diff --check` — passed

The sibling `pdf-evals` corpus was not available in this checkout, so no private-corpus result is claimed.

Fixes #270

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788564086&installation_model_id=11126&pr_number=274&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F274&signature=de424c5ed1b6cd99c4381d2ca4e88bfa9844e49054856d65bed6561219ec2a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves wrapped ruled tables by vetoing side‑by‑side splits when explicit table geometry spans a proposed gutter. Previously, wrapped text could split a ruled table into partial tables; now combined rect‑ and line‑grid checks veto those splits while disjoint ruled grids keep their gutter. Fixes #270.

- Add `line_grid_spans_band_boundary` and integrate with the existing rect‑cluster veto in `to_markdown_from_items_with_rects_and_lines`.
- Add tests: `independent_side_by_side_line_grids_do_not_veto_band_split`, `connected_line_grid_vetoes_band_split`, and integration `test_wrapped_cell_keeps_ruled_table_intact` with fixture `tests/fixtures/wrapped_cell_ruled_table.pdf`.

<sup>Written for commit 31b48543e3a064dc0ec420d878b7a99ddb412bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

