### PR TITLE
docs: clarify that markdown is None for scanned/image-based PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ import pdf_inspector
 
 result = pdf_inspector.process_pdf("document.pdf")
 print(result.pdf_type)   # "text_based", "scanned", "image_based", "mixed"
-print(result.markdown)   # Markdown string or None
+print(result.markdown)   # Markdown string, or None for scanned/image-based PDFs
 ```
+
+> `markdown` is `None` when `pdf_type` is `scanned` or `image_based`: those pages
+> have no text layer, so there is nothing to extract without OCR. This is expected
+> — check `pdf_type` / `pages_needing_ocr` and run OCR (e.g. OCRmyPDF) on those
+> files first. pdf-inspector classifies PDFs; it does not perform OCR itself.
 
 > Full API reference: [docs/python.md](docs/python.md)
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -82,6 +82,24 @@ for page in result.pages:
 result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 ```
 
+> **`markdown` is `None` for scanned and image-based PDFs.** When `pdf_type` is
+> `"scanned"` or `"image_based"`, the page has no text layer (it is typically a
+> single full-page image), so there is nothing to extract without OCR — and
+> pdf-inspector classifies PDFs rather than performing OCR. This is expected, not
+> an error. To handle these files, check `pdf_type` and `pages_needing_ocr`, run
+> OCR (for example with [OCRmyPDF](https://github.com/ocrmypdf/OCRmyPDF), adding
+> the relevant language pack such as `-l chi_sim`), then re-run `process_pdf` on
+> the OCR'd output:
+>
+> ```python
+> result = pdf_inspector.process_pdf(path)
+> if result.markdown is not None:
+>     use(result.markdown)
+> else:
+>     # scanned / image-based → route to your OCR pipeline
+>     ocr_pages = result.pages_needing_ocr   # 1-indexed
+> ```
+
 ## API reference
 
 | Function | Description |


### PR DESCRIPTION
## What

Documents that `process_pdf()` (and friends) return `markdown = None` for `scanned` and `image_based` PDFs, since those pages have no text layer and pdf-inspector classifies rather than performs OCR.

## Why

This is easy to misread as a failure. In #269 the reporter saw `markdown` always `None` (with `confidence` 0.95 and `page_count` 1) across a batch; the inputs turned out to be single-page scanned images (one full-page JPEG each, zero fonts, no text operators), so `None` was correct — the library was flagging them via `pdf_type="scanned"` / `pages_needing_ocr`. A short note next to the usage examples should prevent the same confusion.

## Changes

Docs only — no code changes:

- `docs/python.md`: note after the usage examples explaining `markdown is None` for scanned/image PDFs, with a snippet showing how to route them (check `pdf_type` / `pages_needing_ocr`, run OCR, re-run).
- `README.md`: matching one-paragraph note under the Python example.

Refs #269.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788595597&installation_model_id=11126&pr_number=279&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F279&signature=f876966a8c92c4657c10d8002da808947a064429898cfc884c43386f71ac496c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `process_pdf()` returns `markdown` as `None` for `scanned` and `image_based` PDFs, and adds guidance to route those files to OCR (e.g., `OCRmyPDF`) before re-running extraction. Helps avoid confusion seen in #269 by pointing to `pdf_type` and `pages_needing_ocr` in the docs.

<sup>Written for commit 1f13204b75d6570424cdb7156fc29f5309946d37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

