### PR TITLE
feat(render): add optional selected-page rasterization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
       - name: Install WebAssembly test tools
         run: |
           cargo install wasm-pack --version 0.15.0 --locked
+          # Keep in sync with wasm-bindgen in wasm/Cargo.lock: the test
+          # runner's protocol matches that exact version.
           cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Test WebAssembly package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,22 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      - name: Run tests with optional page rendering
+        run: cargo test --features render --verbose
+
+      - name: Check out pinned PDF renderer corpus
+        run: |
+          git clone https://github.com/py-pdf/sample-files.git "$RUNNER_TEMP/pdf-inspector-sample-files"
+          git -C "$RUNNER_TEMP/pdf-inspector-sample-files" checkout --detach 89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf
+
+      - name: Run PDF renderer corpus
+        env:
+          PDF_INSPECTOR_SAMPLE_FILES: ${{ runner.temp }}/pdf-inspector-sample-files
+        run: cargo test --features render --test render_corpus_tests -- --ignored
+
+      - name: Check rendering API documentation
+        run: cargo doc --no-deps --features render
+
       - name: Test developer scripts
         run: python3 -m unittest discover -s scripts/tests
 
@@ -71,6 +87,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings
 
+      - name: Run clippy with optional page rendering
+        run: cargo clippy --features render -- -D warnings
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -92,6 +111,33 @@ jobs:
 
       - name: Build
         run: cargo build --release --verbose
+
+      - name: Build optional page rendering
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo build --release --features render --verbose
+
+  render-msrv:
+    name: Page rendering MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust 1.92
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: 1.92.0
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: render-msrv
+
+      - name: Check optional page rendering
+        run: cargo check --features render
+
+      - name: Check optional page rendering for WebAssembly
+        run: cargo check --target wasm32-unknown-unknown --features render
 
   wasm:
     name: WebAssembly
@@ -116,14 +162,43 @@ jobs:
       - name: Check WebAssembly bindings
         run: cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown
 
+      - name: Check WebAssembly bindings with optional page rendering
+        run: cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown --features render
+
       - name: Check root package for WebAssembly
         run: cargo check --target wasm32-unknown-unknown
+
+      - name: Check root page rendering for WebAssembly
+        run: cargo check --target wasm32-unknown-unknown --features render
 
       - name: Lint WebAssembly bindings
         run: cargo clippy --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.15.0 --locked
+      - name: Lint WebAssembly bindings with optional page rendering
+        run: cargo clippy --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown --features render -- -D warnings
+
+      - name: Lint root page rendering for WebAssembly
+        run: cargo clippy --target wasm32-unknown-unknown --features render -- -D warnings
+
+      - name: Install WebAssembly test tools
+        run: |
+          cargo install wasm-pack --version 0.15.0 --locked
+          cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Test WebAssembly package
         run: wasm-pack test --node --release wasm
+
+      - name: Test optional page rendering in WebAssembly
+        run: wasm-pack test --node --release wasm --features render
+
+      - name: Install matching Chrome and ChromeDriver
+        id: chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
+        with:
+          install-chromedriver: true
+
+      - name: Test optional page rendering in Chrome
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+          CHROMEDRIVER: ${{ steps.chrome.outputs.chromedriver-path }}
+        run: cargo test --manifest-path wasm/Cargo.toml --release --target wasm32-unknown-unknown --features render --test render_browser

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Fast PDF text extraction to structured Markdown. CLI binary: `pdf2md`. Detection
 cargo fmt                                    # format
 cargo clippy -- -D warnings                  # lint (enforced, zero warnings)
 cargo test                                   # unit + integration tests (267+ unit, 73+ integration)
+cargo clippy --features render -- -D warnings # lint the optional renderer, zero warnings
+cargo test --features render                 # renderer tests (opt-in via the 'render' feature)
 cargo build --release                        # release binary for benchmarks
 ```
 
@@ -27,6 +29,7 @@ src/
   types.rs                      – TextItem, TextLine, PdfRect, PdfLine
   tounicode.rs                  – CMap/ToUnicode parsing, CID decoding
   text_utils.rs                 – CJK/RTL handling, Otsu threshold, ligature expansion, NFKC
+  render.rs                     – optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/
     mod.rs                      – top-level extraction orchestrator
     content_stream.rs           – PDF operator state machine (Tj/TJ/Td/Tm/q/Q)
@@ -63,6 +66,8 @@ src/
 - **Integration tests**: `tests/integration_tests.rs` with fixture PDFs in `tests/fixtures/`.
 - **Regression suite**: sibling repo `pdf-evals` with ~200 snapshot PDFs. Run `cargo build --release` then `bench.py test` in that repo before committing. While iterating, prefer a subset run (`bench.py test -q` for the quick set, or `-s <name>` for a named test set) and save the full `bench.py test` for the final pre-commit check.
 - **Semantic quality**: run `bench.py score` in `pdf-evals` for the semantic verdict (TEDS + MHS + reading order + char/word + list preservation, composited). Character-level diff alone misclassifies structural improvements (e.g., column-detection rewrites) as regressions — `score` is the tie-breaker. See `pdf-evals/CLAUDE.md` "Semantic scoring".
+- **Render corpus**: pinned external `py-pdf/sample-files` render corpus, ignored by default; enable with `PDF_INSPECTOR_SAMPLE_FILES` (checksum-verified).
+- **WebAssembly runtime tests**: `wasm-pack test --node --release wasm` and `wasm-pack test --node --release wasm --features render`.
 
 ## Debugging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Fast PDF text extraction to structured Markdown. CLI binary: `pdf2md`. Detection
 cargo fmt                                    # format
 cargo clippy -- -D warnings                  # lint (enforced, zero warnings)
 cargo test                                   # unit + integration tests (267+ unit, 73+ integration)
+cargo clippy --features render -- -D warnings # lint the optional renderer, zero warnings
+cargo test --features render                 # renderer tests (opt-in via the 'render' feature)
 cargo build --release                        # release binary for benchmarks
 ```
 
@@ -27,6 +29,7 @@ src/
   types.rs                      – TextItem, TextLine, PdfRect, PdfLine
   tounicode.rs                  – CMap/ToUnicode parsing, CID decoding
   text_utils.rs                 – CJK/RTL handling, Otsu threshold, ligature expansion, NFKC
+  render.rs                     – optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/
     mod.rs                      – top-level extraction orchestrator
     content_stream.rs           – PDF operator state machine (Tj/TJ/Td/Tm/q/Q)
@@ -63,6 +66,8 @@ src/
 - **Integration tests**: `tests/integration_tests.rs` with fixture PDFs in `tests/fixtures/`.
 - **Regression suite**: sibling repo `pdf-evals` with ~200 snapshot PDFs. Run `cargo build --release` then `bench.py test` in that repo before committing. While iterating, prefer a subset run (`bench.py test -q` for the quick set, or `-s <name>` for a named test set) and save the full `bench.py test` for the final pre-commit check.
 - **Semantic quality**: run `bench.py score` in `pdf-evals` for the semantic verdict (TEDS + MHS + reading order + char/word + list preservation, composited). Character-level diff alone misclassifies structural improvements (e.g., column-detection rewrites) as regressions — `score` is the tie-breaker. See `pdf-evals/CLAUDE.md` "Semantic scoring".
+- **Render corpus**: pinned external `py-pdf/sample-files` render corpus, ignored by default; enable with `PDF_INSPECTOR_SAMPLE_FILES` (checksum-verified).
+- **WebAssembly runtime tests**: `wasm-pack test --node --release wasm` and `wasm-pack test --node --release wasm --features render`.
 
 ## Debugging
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ thiserror = "2.0"
 # Logging
 log = "0.4"
 
+# Optional pure-Rust PDF rasterization. Keep the embedded fallback assets so
+# OCR-routed pages also render when their fonts or CMaps are not embedded.
+hayro = { version = "0.7.1", optional = true, default-features = false, features = ["embed-fonts", "embed-cmaps"] }
+bytemuck = { version = "1.25", optional = true, default-features = false, features = ["extern_crate_alloc"] }
+
 # Text processing
 regex = "1.10"
 once_cell = "1.19"
@@ -57,11 +62,13 @@ lopdf = { version = "0.42.0", default-features = false, features = ["wasm_js"] }
 include_dir = "0.7"
 
 [dev-dependencies]
+sha2 = "0.10"
 tempfile = "3.3"
 
 [features]
 default = []
 python = ["pyo3"]
+render = ["dep:bytemuck", "dep:hayro"]
 
 [[bin]]
 name = "pdf2md"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Encoding issue detection** — Automatically flags broken font encodings so callers can fall back to OCR.
 - **Single document load** — The document is parsed once and shared between detection and extraction, avoiding redundant I/O.
 - **Browser WebAssembly** — Run the same Rust parser locally in browsers and Web Workers, with embedded CMaps and no server round trip.
-- **Lightweight** — Pure Rust, no ML models, no external services. Single dependency on `lopdf` for PDF parsing.
+- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Lightweight by default** — Pure Rust, no ML models, no external services. The default feature set keeps `lopdf` as its only PDF dependency.
 
 ## Benchmark
 
@@ -204,6 +205,7 @@ src/
   detector.rs           — Fast PDF type detection without full document load
   glyph_names.rs        — Adobe Glyph List → Unicode mapping
   tounicode.rs          — ToUnicode CMap parsing for CID-encoded text
+  render.rs             — optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/            — Text extraction pipeline
   tables/               — Table detection and formatting
   markdown/             — Markdown conversion and structure detection

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Encoding issue detection** — Automatically flags broken font encodings so callers can fall back to OCR.
 - **Single document load** — The document is parsed once and shared between detection and extraction, avoiding redundant I/O.
 - **Browser WebAssembly** — Run the same Rust parser locally in browsers and Web Workers, with embedded CMaps and no server round trip.
-- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, on a wasm32-compatible backend (no JS API exposed yet).
 - **Lightweight by default** — Pure Rust, no ML models, no external services. The default feature set keeps `lopdf` as its only PDF dependency.
 
 ## Benchmark

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -39,6 +39,50 @@ warm-up run; quality scores come from the benchmark evaluator over all 200
 outputs. Raw timings, predictions, evaluations, and charts are available in the
 [results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
+## Optional renderer compatibility and timing
+
+Selected-page rendering has a separate ignored test over the external
+[`py-pdf/sample-files`](https://github.com/py-pdf/sample-files) corpus. The
+files are CC-BY-SA-4.0 and are not vendored into this MIT repository. The test
+pins commit `89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf` and verifies every selected
+file's SHA-256 digest before rendering it.
+
+```bash
+git clone https://github.com/py-pdf/sample-files.git ../sample-files
+git -C ../sample-files checkout 89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf
+
+PDF_INSPECTOR_SAMPLE_FILES=../sample-files \
+  cargo test --release --features render --test render_corpus_tests \
+  renders_pinned -- --ignored --nocapture
+```
+
+The cases cover structured text, image-only pages, CMYK images, page
+crop/rotation/scaling, repeated image references, and caller-ordered page
+selection. The printed per-file durations are a smoke-test aid, not directly
+comparable benchmark results. For reportable measurements, record the corpus
+revision, compiler, target, CPU, and peak memory; discard one warm-up and report
+the median of at least five release-profile runs at each tested DPI.
+
+### Reference rasterization measurements
+
+The following reference run used the checksum-verified
+`018-base64-image/base64image.pdf` input from the pinned corpus revision above.
+`pdf-inspector` classifies its only page as needing OCR. Measurements were made
+on macOS 26.6, an Apple M3 Pro (12 cores, 18 GB), with Rust 1.95.0. Each row is
+20 release-profile process runs after one discarded warm-up. Render time covers
+PDF cloning, parsing, and rasterization; peak RSS is for the complete test
+process. Nearest-rank p95 is reported.
+
+| DPI | Output | RGBA8 bytes | Median | p95 | Min–max | Sample SD | Median peak RSS | p95 peak RSS |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 150 | 1,240 x 1,753 | 8,694,880 | 7.286 ms | 7.821 ms | 6.876–9.268 ms | 0.503 ms | 30,408,704 B | 31,391,744 B |
+| 200 | 1,653 x 2,338 | 15,458,856 | 8.554 ms | 9.059 ms | 8.359–9.528 ms | 0.280 ms | 36,454,400 B | 37,404,672 B |
+| 300 | 2,480 x 3,507 | 34,789,440 | 11.985 ms | 12.723 ms | 11.817–12.942 ms | 0.370 ms | 59,817,984 B | 60,768,256 B |
+
+These figures measure rasterization only, not OCR inference. They should be
+treated as one-machine reference data, not a cross-platform performance claim.
+The returned RGBA8 buffer dominates the DPI-dependent memory increase.
+
 ## Optional backend evidence probe
 
 The evidence probe compares positioned `pdf2md` items with MuPDF structured

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -1,6 +1,6 @@
 # pdf-inspector
 
-Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Pure Rust, no ML models, no external services; the only PDF dependency is [lopdf](https://crates.io/crates/lopdf). Also available for [Python](https://pypi.org/project/pdf-inspector/) and [Node.js](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
+Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Pure Rust, no ML models, and no external services; the default feature set uses [lopdf](https://crates.io/crates/lopdf), while an opt-in feature adds selected-page rasterization. Also available for [Python](https://pypi.org/project/pdf-inspector/) and [Node.js](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
 
 Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
 
@@ -10,7 +10,8 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Markdown conversion** — headings, lists, code blocks, bold/italic, URL linking, and dual-mode table detection (PDF drawing ops + text-alignment heuristics).
 - **Layout-aware extraction** — multi-column reading order, position and font info per text item, RTL support.
 - **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
-- **Lightweight** — pure Rust, no ML models, no external services; single PDF dependency ([lopdf](https://crates.io/crates/lopdf)).
+- **Optional page rendering** — selected pages can be rasterized to bounded RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Lightweight by default** — pure Rust, no ML models, no external services; the default feature set keeps [lopdf](https://crates.io/crates/lopdf) as its only PDF dependency.
 
 ## Benchmark
 
@@ -117,6 +118,85 @@ let bytes = std::fs::read("document.pdf")?;
 let result = process_pdf_mem(&bytes)?;
 ```
 
+### Optional selected-page rendering
+
+Enable the non-default `render` feature when an OCR pipeline needs pixels for
+pages already identified by `pages_needing_ocr`:
+
+```bash
+cargo add pdf-inspector --features render
+```
+
+```rust
+use pdf_inspector::{classify_pdf_mem, render_pages_mem, RenderOptions, RenderWarning};
+
+let bytes = std::fs::read("scan.pdf")?;
+let classification = classify_pdf_mem(&bytes)?;
+
+// PdfClassification uses the renderer's zero-based page indexes. Only pages
+// routed to OCR are rasterized, in caller-supplied order.
+if !classification.pages_needing_ocr.is_empty() {
+    let pages = render_pages_mem(
+        &bytes,
+        &classification.pages_needing_ocr,
+        RenderOptions::new().dpi(200.0),
+    )?;
+
+    for page in pages {
+        if page.warnings.contains(&RenderWarning::ImageDecodeFailure) {
+            // Do not OCR pixels from an image resource that failed to decode.
+            continue;
+        }
+        // Opaque, row-major RGBA8 pixels on a white background.
+        run_ocr(page.width, page.height, &page.pixels);
+    }
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+# fn run_ocr(_: u32, _: u32, _: &[u8]) {}
+```
+
+Do not pass `PdfProcessResult::pages_needing_ocr` directly: that high-level
+field is one-based for display, while `PdfClassification::pages_needing_ocr`,
+`PageMarkdown::page`, and `render_pages_mem` are zero-based.
+
+Even with an empty page list, `render_pages_mem` still copies and parses the
+PDF, so integrators must skip the call entirely on the no-OCR fast path.
+
+The renderer is CPU-only and byte-oriented, with no filesystem access, and
+compiles for `wasm32-unknown-unknown`. It is intentionally not enabled in the
+default feature set. The `render` feature currently requires Rust 1.92 because
+of its rendering backend; default builds keep the existing compiler behavior.
+
+Every request's output viewport and returned buffers are validated before the
+first page is rendered:
+
+| Limit | Value |
+|---|---:|
+| Default DPI | 200 |
+| Maximum DPI | 300 |
+| Maximum width or height | 16,384 px |
+| Maximum pixels per page | 25,000,000 |
+| Maximum combined RGBA8 output | 100,000,000 bytes |
+| Maximum page entries per call | 1,024 |
+
+For large scanned documents, render small batches and release each page buffer
+after OCR instead of retaining the whole document in memory. Rendering handles
+common page crops, rotations, transforms, images, and soft masks before
+returning pixels. Each page also carries typed warnings for unsupported fonts
+and failed image decoding; an image-decode warning means its pixels must not be
+silently accepted as OCR input.
+
+The optional backend is still evolving. Hayro 0.7.1 documents missing or
+incomplete support for blending and isolation, knockout groups, and color-key
+masking. Preserve a fallback for documents it cannot render faithfully, even
+when no interpreter warning is available for that unsupported construct.
+
+These limits bound output dimensions and returned RGBA memory. The current
+backend can still allocate internal image-decoder and compositing scratch
+buffers from PDF resources. Until it exposes comprehensive internal resource
+limits, isolate untrusted rendering in a process or Web Worker with its own
+memory/input limits; output preflight alone is not an adversarial-PDF sandbox.
+
 Extract per-page Markdown (one string per page, plus document-wide layout
 metadata):
 
@@ -193,6 +273,7 @@ for item in extract_text_with_positions("tagged.pdf")? {
 | `extract_pages_markdown_mem(bytes, pages)` | Per-page Markdown from bytes |
 | `extract_structure_elements(path, pages)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
 | `extract_structure_elements_mem(bytes, pages)` | Structure-tree elements from bytes |
+| `render_pages_mem(bytes, pages, options)` | Selected pages as bounded RGBA8 buffers (`render` feature) |
 
 Low-level detection functions are also available via the `detector` module (`detect_pdf_type`, `detect_pdf_type_with_config`, etc.) for callers who need `PdfTypeResult` instead of `PdfProcessResult`.
 
@@ -214,3 +295,7 @@ Low-level detection functions are also available via the `detector` module (`det
 | `PageMarkdown` | Per-page result: page (0-indexed), markdown, needs_ocr |
 | `PagesExtractionResult` | Per-page output + 1-indexed pages_with_tables / pages_with_columns / pages_needing_ocr, is_complex |
 | `PdfError` | `Io`, `Parse`, `Encrypted`, `InvalidStructure`, `NotAPdf` |
+| `RenderOptions` | DPI and optional password for selected-page rendering (`render` feature) |
+| `RenderedPage` | Zero-based source page, dimensions, and opaque RGBA8 pixels (`render` feature) |
+| `RenderError` | Typed parse, password, page-selection, and resource-limit failures (`render` feature) |
+| `RenderWarning` | Per-page unsupported-font or image-decode fidelity warning (`render` feature) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@
 #[cfg(feature = "python")]
 pub mod python;
 
+#[cfg(feature = "render")]
+mod render;
+
 pub mod adobe_korea1;
 pub mod detector;
 pub mod extractor;
@@ -57,6 +60,12 @@ pub use markdown::{
     to_markdown_from_items_with_rects_and_page_count, MarkdownOptions, MarkdownProfile,
 };
 pub use process_mode::ProcessMode;
+#[cfg(feature = "render")]
+pub use render::{
+    render_pages_mem, RenderError, RenderOptions, RenderWarning, RenderedPage, DEFAULT_RENDER_DPI,
+    MAX_RENDER_DIMENSION, MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
+    MAX_RENDER_PIXELS_PER_PAGE,
+};
 pub use types::{LayoutComplexity, PdfLine, PdfRect, TextItem};
 
 use lopdf::Document;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,390 @@
+//! Optional PDF page rasterization with bounded output buffers.
+
+use hayro::hayro_interpret::{InterpreterSettings, InterpreterWarning};
+use hayro::hayro_syntax::{LoadPdfError, Pdf};
+use hayro::vello_cpu::color::palette::css::WHITE;
+use hayro::{render, RenderCache, RenderSettings};
+use std::sync::{Arc, Mutex};
+
+/// Default DPI for page rasterization
+pub const DEFAULT_RENDER_DPI: f32 = 200.0;
+
+/// Hard cap on the requested DPI
+pub const MAX_RENDER_DPI: f32 = 300.0;
+
+/// Max output width or height, in pixels
+pub const MAX_RENDER_DIMENSION: u32 = 16_384;
+
+/// Max output area for a single page
+pub const MAX_RENDER_PIXELS_PER_PAGE: u64 = 25_000_000;
+
+/// Max combined RGBA8 bytes for one call
+pub const MAX_RENDER_OUTPUT_BYTES: u64 = 100_000_000;
+
+/// Max page entries for one call. Duplicates count separately, since
+/// each entry produce its own buffer: for big documents is better to
+/// render in batches and release the buffers in between.
+pub const MAX_RENDER_PAGES_PER_REQUEST: usize = 1_024;
+
+/// Options for [`render_pages_mem`].
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct RenderOptions {
+    /// Output DPI. Must be finite, positive and at most [`MAX_RENDER_DPI`].
+    pub dpi: f32,
+    /// Password for an encrypted PDF
+    pub password: Option<String>,
+}
+
+impl std::fmt::Debug for RenderOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderOptions")
+            .field("dpi", &self.dpi)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            dpi: DEFAULT_RENDER_DPI,
+            password: None,
+        }
+    }
+}
+
+impl RenderOptions {
+    /// Default options at 200 DPI
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the output DPI
+    pub fn dpi(mut self, dpi: f32) -> Self {
+        self.dpi = dpi;
+        self
+    }
+
+    /// Set the password for an encrypted PDF
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+}
+
+/// One rasterized PDF page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RenderedPage {
+    /// Zero-based page index in the source PDF
+    pub page: u32,
+    /// Width in pixels
+    pub width: u32,
+    /// Height in pixels
+    pub height: u32,
+    /// Opaque row-major RGBA8, white background
+    pub pixels: Vec<u8>,
+    /// Non-fatal interpreter warnings for this page. An
+    /// [`RenderWarning::ImageDecodeFailure`] means the pixels are not safe
+    /// to OCR without an independent check.
+    pub warnings: Vec<RenderWarning>,
+}
+
+/// A non-fatal issue reported while interpreting one rendered page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RenderWarning {
+    /// The page uses a font kind we can't draw, glyphs may be missing
+    UnsupportedFont,
+    /// An image failed to decode, its pixels may be missing
+    ImageDecodeFailure,
+}
+
+fn map_interpreter_warning(warning: InterpreterWarning) -> RenderWarning {
+    match warning {
+        InterpreterWarning::UnsupportedFont => RenderWarning::UnsupportedFont,
+        InterpreterWarning::ImageDecodeFailure => RenderWarning::ImageDecodeFailure,
+    }
+}
+
+/// An error returned while rasterizing PDF pages.
+#[derive(Debug, thiserror::Error, PartialEq)]
+#[non_exhaustive]
+pub enum RenderError {
+    /// The requested DPI is zero, negative, non-finite, or above the hard cap
+    #[error("render DPI must be finite and greater than 0 and at most {max}, got {dpi}")]
+    InvalidDpi { dpi: f32, max: f32 },
+
+    /// Too many page entries were requested in one call
+    #[error("requested {requested} page entries, maximum is {max}")]
+    TooManyPages { requested: usize, max: usize },
+
+    /// The PDF is encrypted or the supplied password is not accepted
+    #[error("PDF is encrypted or the password is invalid")]
+    Encrypted,
+
+    /// The input could not be parsed as a PDF
+    #[error("PDF parsing error")]
+    Parse,
+
+    /// A requested zero-based page index does not exist
+    #[error("page index {page} is out of range for a PDF with {page_count} pages")]
+    PageOutOfRange { page: u32, page_count: usize },
+
+    /// A page has missing, non-finite, non-positive, or sub-pixel dimensions
+    #[error("page {page} has invalid render dimensions {width_points} x {height_points} points")]
+    InvalidPageDimensions {
+        page: u32,
+        width_points: f32,
+        height_points: f32,
+    },
+
+    /// A scaled page width or height exceeds the hard cap
+    #[error("page {page} would render at {width} x {height} pixels, maximum dimension is {max}")]
+    PageDimensionsTooLarge {
+        page: u32,
+        width: u64,
+        height: u64,
+        max: u32,
+    },
+
+    /// A page's output area exceeds the hard cap
+    #[error("page {page} would contain {pixels} pixels, maximum is {max}")]
+    PagePixelsTooLarge { page: u32, pixels: u64, max: u64 },
+
+    /// The combined RGBA8 output would exceed the hard cap
+    #[error("rendered output would require {bytes} bytes, maximum is {max}")]
+    OutputTooLarge { bytes: u64, max: u64 },
+
+    /// The renderer returned a pixel buffer with an unexpected memory layout
+    #[error("renderer returned an unsupported pixel-buffer layout")]
+    PixelBufferLayout,
+}
+
+impl From<LoadPdfError> for RenderError {
+    fn from(error: LoadPdfError) -> Self {
+        match error {
+            LoadPdfError::Decryption(_) => Self::Encrypted,
+            LoadPdfError::Invalid => Self::Parse,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PreparedPage {
+    page: u32,
+    width: u16,
+    height: u16,
+}
+
+/// Rasterize the selected pages of a PDF into opaque RGBA8 buffers.
+///
+/// `pages` holds zero-based indexes; results keep the caller order and
+/// the duplicates. Everything (every page, the whole output budget) is
+/// validated before the first page renders. An empty selection still
+/// parses the PDF and returns an empty vec.
+///
+/// Only available with the `render` feature. CPU-only, no filesystem,
+/// so it compiles for `wasm32-unknown-unknown` too.
+pub fn render_pages_mem(
+    pdf_bytes: &[u8],
+    pages: &[u32],
+    options: RenderOptions,
+) -> Result<Vec<RenderedPage>, RenderError> {
+    validate_options(pages, &options)?;
+
+    let pdf = Pdf::new_with_password(
+        pdf_bytes.to_vec(),
+        options.password.as_deref().unwrap_or(""),
+    )?;
+    let scale = options.dpi / 72.0;
+    let prepared = prepare_pages(&pdf, pages, scale)?;
+
+    let cache = RenderCache::new();
+    let mut rendered_pages = Vec::with_capacity(prepared.len());
+
+    for prepared_page in prepared {
+        // prepare_pages already validated every index against this same PDF,
+        // but better to not have any indexing panic here anyway.
+        let page =
+            pdf.pages()
+                .get(prepared_page.page as usize)
+                .ok_or(RenderError::PageOutOfRange {
+                    page: prepared_page.page,
+                    page_count: pdf.pages().len(),
+                })?;
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warning_sink = Arc::clone(&warnings);
+        let interpreter_settings = InterpreterSettings {
+            warning_sink: Arc::new(move |warning| {
+                let mut warnings = warning_sink
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let warning = map_interpreter_warning(warning);
+                if !warnings.contains(&warning) {
+                    warnings.push(warning);
+                }
+            }),
+            ..InterpreterSettings::default()
+        };
+        let pixmap = render(
+            page,
+            &cache,
+            &interpreter_settings,
+            &RenderSettings {
+                x_scale: scale,
+                y_scale: scale,
+                width: Some(prepared_page.width),
+                height: Some(prepared_page.height),
+                bg_color: WHITE,
+            },
+        );
+
+        let width = u32::from(pixmap.width());
+        let height = u32::from(pixmap.height());
+        let pixels = bytemuck::allocation::try_cast_vec(pixmap.take())
+            .map_err(|_| RenderError::PixelBufferLayout)?;
+        let warnings = warnings
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+
+        rendered_pages.push(RenderedPage {
+            page: prepared_page.page,
+            width,
+            height,
+            pixels,
+            warnings,
+        });
+    }
+
+    Ok(rendered_pages)
+}
+
+fn validate_options(pages: &[u32], options: &RenderOptions) -> Result<(), RenderError> {
+    if !options.dpi.is_finite() || options.dpi <= 0.0 || options.dpi > MAX_RENDER_DPI {
+        return Err(RenderError::InvalidDpi {
+            dpi: options.dpi,
+            max: MAX_RENDER_DPI,
+        });
+    }
+
+    if pages.len() > MAX_RENDER_PAGES_PER_REQUEST {
+        return Err(RenderError::TooManyPages {
+            requested: pages.len(),
+            max: MAX_RENDER_PAGES_PER_REQUEST,
+        });
+    }
+
+    Ok(())
+}
+
+fn prepare_pages(pdf: &Pdf, pages: &[u32], scale: f32) -> Result<Vec<PreparedPage>, RenderError> {
+    let page_count = pdf.pages().len();
+    let mut total_bytes = 0_u64;
+    let mut prepared = Vec::with_capacity(pages.len());
+
+    for &page_index in pages {
+        let page = pdf
+            .pages()
+            .get(page_index as usize)
+            .ok_or(RenderError::PageOutOfRange {
+                page: page_index,
+                page_count,
+            })?;
+        let (width_points, height_points) = page.render_dimensions();
+        let (width, height) = scaled_dimensions(width_points, height_points, scale).ok_or(
+            RenderError::InvalidPageDimensions {
+                page: page_index,
+                width_points,
+                height_points,
+            },
+        )?;
+
+        if width > u64::from(MAX_RENDER_DIMENSION) || height > u64::from(MAX_RENDER_DIMENSION) {
+            return Err(RenderError::PageDimensionsTooLarge {
+                page: page_index,
+                width,
+                height,
+                max: MAX_RENDER_DIMENSION,
+            });
+        }
+
+        let pixels = width
+            .checked_mul(height)
+            .ok_or(RenderError::PagePixelsTooLarge {
+                page: page_index,
+                pixels: u64::MAX,
+                max: MAX_RENDER_PIXELS_PER_PAGE,
+            })?;
+        if pixels > MAX_RENDER_PIXELS_PER_PAGE {
+            return Err(RenderError::PagePixelsTooLarge {
+                page: page_index,
+                pixels,
+                max: MAX_RENDER_PIXELS_PER_PAGE,
+            });
+        }
+
+        let page_bytes = pixels.checked_mul(4).ok_or(RenderError::OutputTooLarge {
+            bytes: u64::MAX,
+            max: MAX_RENDER_OUTPUT_BYTES,
+        })?;
+        total_bytes = total_bytes
+            .checked_add(page_bytes)
+            .ok_or(RenderError::OutputTooLarge {
+                bytes: u64::MAX,
+                max: MAX_RENDER_OUTPUT_BYTES,
+            })?;
+        if total_bytes > MAX_RENDER_OUTPUT_BYTES {
+            return Err(RenderError::OutputTooLarge {
+                bytes: total_bytes,
+                max: MAX_RENDER_OUTPUT_BYTES,
+            });
+        }
+
+        prepared.push(PreparedPage {
+            page: page_index,
+            width: width as u16,
+            height: height as u16,
+        });
+    }
+
+    Ok(prepared)
+}
+
+fn scaled_dimensions(width_points: f32, height_points: f32, scale: f32) -> Option<(u64, u64)> {
+    if !width_points.is_finite()
+        || !height_points.is_finite()
+        || width_points <= 0.0
+        || height_points <= 0.0
+    {
+        return None;
+    }
+
+    // Match the same f32 multiplication Hayro does before to floor to pixel.
+    let width = f64::from(width_points * scale);
+    let height = f64::from(height_points * scale);
+    if !width.is_finite() || !height.is_finite() || width < 1.0 || height < 1.0 {
+        return None;
+    }
+
+    Some((width.floor() as u64, height.floor() as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_every_interpreter_warning_to_the_public_type() {
+        assert_eq!(
+            map_interpreter_warning(InterpreterWarning::UnsupportedFont),
+            RenderWarning::UnsupportedFont
+        );
+        assert_eq!(
+            map_interpreter_warning(InterpreterWarning::ImageDecodeFailure),
+            RenderWarning::ImageDecodeFailure
+        );
+    }
+}

--- a/tests/render_corpus_tests.rs
+++ b/tests/render_corpus_tests.rs
@@ -1,0 +1,179 @@
+#![cfg(all(feature = "render", not(target_arch = "wasm32")))]
+
+use pdf_inspector::{
+    classify_pdf_mem, render_pages_mem, RenderOptions, RenderWarning, RenderedPage,
+};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+struct CorpusCase {
+    relative_path: &'static str,
+    sha256: &'static str,
+    pages: &'static [u32],
+    dpi: f32,
+}
+
+const CASES: &[CorpusCase] = &[
+    CorpusCase {
+        relative_path: "001-trivial/minimal-document.pdf",
+        sha256: "f723638db6e763cf4ccadad38a3d38a02d9ecab95dab1f0bbf00e801991b5f92",
+        pages: &[0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "007-imagemagick-images/imagemagick-images.pdf",
+        sha256: "0f2076573bfed1107300a2383b88bbbbc2b85a57f06b3ff478a0faa7ded57b4e",
+        pages: &[5, 0, 3],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "018-base64-image/base64image.pdf",
+        sha256: "aaad90df16fce40ec768629d2135479b98f65b39bb27c7f80fb106393187d619",
+        pages: &[0],
+        dpi: 200.0,
+    },
+    CorpusCase {
+        relative_path: "023-cmyk-image/cmyk-image.pdf",
+        sha256: "5a5f76a951e403a5b357992789afc5164fd6c2914583741de7a1dd08ec029ab2",
+        pages: &[0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "027-cropped-rotated-scaled/cropped-rotated-scaled.pdf",
+        sha256: "cc195eac510b81123de4f55ac9f8185f2120975a7b75a106460b98615737aacd",
+        pages: &[3, 0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "028-image-references-deduplication/wrong-references.pdf",
+        sha256: "16cb8e10bd59e30b4d350f11d0ed9c7d0bd7e7bb962a46022c89836e2aa44f63",
+        pages: &[2, 0],
+        dpi: 72.0,
+    },
+];
+
+/// Exercise an immutable, checksum-verified external compatibility corpus.
+///
+/// The PDF files are CC-BY-SA-4.0 and are deliberately not vendored into this
+/// MIT repository. Check out py-pdf/sample-files at commit
+/// `89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf`, set
+/// `PDF_INSPECTOR_SAMPLE_FILES` to its root, then run:
+///
+/// `cargo test --features render --test render_corpus_tests renders_pinned -- --ignored --nocapture`
+#[test]
+#[ignore = "requires the external py-pdf/sample-files corpus"]
+fn renders_pinned_py_pdf_sample_files() {
+    let root = std::env::var_os("PDF_INSPECTOR_SAMPLE_FILES")
+        .map(PathBuf::from)
+        .expect("set PDF_INSPECTOR_SAMPLE_FILES to the pinned corpus checkout");
+
+    for case in CASES {
+        let path = root.join(case.relative_path);
+        let bytes = std::fs::read(&path).unwrap_or_else(|error| {
+            panic!("failed to read {}: {error}", path.display());
+        });
+        assert_sha256(&path, &bytes, case.sha256);
+
+        let started = Instant::now();
+        let rendered = render_pages_mem(&bytes, case.pages, RenderOptions::new().dpi(case.dpi))
+            .unwrap_or_else(|error| panic!("failed to render {}: {error}", path.display()));
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            rendered.iter().map(|page| page.page).collect::<Vec<_>>(),
+            case.pages
+        );
+        for page in &rendered {
+            assert_valid_rgba(page, &path);
+        }
+
+        eprintln!(
+            "rendered {} page buffer(s) from {} at {} DPI in {:.3?}",
+            rendered.len(),
+            case.relative_path,
+            case.dpi,
+            elapsed
+        );
+    }
+}
+
+/// Print one release-profile data point for the OCR-positive image PDF.
+///
+/// Set `PDF_INSPECTOR_RENDER_DPI` to run the same pinned input at a specific
+/// resolution. This is kept separate from the compatibility loop so an
+/// external process monitor can capture peak memory for one DPI at a time.
+#[test]
+#[ignore = "requires the external py-pdf/sample-files corpus"]
+fn measures_ocr_positive_page_at_configured_dpi() {
+    let root = std::env::var_os("PDF_INSPECTOR_SAMPLE_FILES")
+        .map(PathBuf::from)
+        .expect("set PDF_INSPECTOR_SAMPLE_FILES to the pinned corpus checkout");
+    let dpi = std::env::var("PDF_INSPECTOR_RENDER_DPI")
+        .unwrap_or_else(|_| "200".to_string())
+        .parse::<f32>()
+        .expect("PDF_INSPECTOR_RENDER_DPI must be a number");
+    let case = &CASES[2];
+    let path = root.join(case.relative_path);
+    let bytes = std::fs::read(&path).expect("read OCR-positive corpus PDF");
+    assert_sha256(&path, &bytes, case.sha256);
+    let classification = classify_pdf_mem(&bytes).expect("classify OCR-positive corpus PDF");
+    assert_eq!(classification.pages_needing_ocr, [0]);
+
+    let started = Instant::now();
+    let rendered = render_pages_mem(&bytes, &[0], RenderOptions::new().dpi(dpi))
+        .expect("render OCR-positive page");
+    let elapsed = started.elapsed();
+    assert_valid_rgba(&rendered[0], &path);
+
+    eprintln!(
+        "rendered {} at {} DPI to {}x{} ({} RGBA bytes) in {:.3?}",
+        case.relative_path,
+        dpi,
+        rendered[0].width,
+        rendered[0].height,
+        rendered[0].pixels.len(),
+        elapsed
+    );
+}
+
+fn assert_sha256(path: &Path, bytes: &[u8], expected: &str) {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    assert_eq!(
+        actual,
+        expected,
+        "unexpected corpus revision for {}",
+        path.display()
+    );
+}
+
+fn assert_valid_rgba(page: &RenderedPage, path: &Path) {
+    assert!(
+        !page.warnings.contains(&RenderWarning::ImageDecodeFailure),
+        "an image resource failed to decode for {}",
+        path.display()
+    );
+    assert!(page.width > 0, "zero-width output for {}", path.display());
+    assert!(page.height > 0, "zero-height output for {}", path.display());
+    assert_eq!(
+        page.pixels.len(),
+        page.width as usize * page.height as usize * 4,
+        "invalid RGBA length for {}",
+        path.display()
+    );
+    assert!(
+        page.pixels.chunks_exact(4).all(|pixel| pixel[3] == 255),
+        "non-opaque output for {}",
+        path.display()
+    );
+    let non_white = page
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[..3] != [255, 255, 255])
+        .count();
+    assert!(
+        non_white > 0,
+        "rendered content is unexpectedly blank for {}",
+        path.display()
+    );
+}

--- a/tests/render_tests.rs
+++ b/tests/render_tests.rs
@@ -19,47 +19,22 @@ fn make_solid_page_pdf_with_page_options(
     colors: &[[u8; 3]],
     page_options: &str,
 ) -> Vec<u8> {
-    let mut pdf = b"%PDF-1.4\n".to_vec();
-    let mut offsets = vec![0_usize];
+    let mut object_bodies = vec![b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(), {
+        let kids = (0..colors.len())
+            .map(|index| format!("{} 0 R", 3 + index * 2))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).into_bytes()
+    }];
 
-    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
-        assert_eq!(id, offsets.len());
-        offsets.push(pdf.len());
-        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
-        pdf.extend_from_slice(body);
-        pdf.extend_from_slice(b"\nendobj\n");
-    }
-
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        1,
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-    );
-
-    let kids = (0..colors.len())
-        .map(|index| format!("{} 0 R", 3 + index * 2))
-        .collect::<Vec<_>>()
-        .join(" ");
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        2,
-        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).as_bytes(),
-    );
-
-    for (index, [red, green, blue]) in colors.iter().copied().enumerate() {
-        let page_id = 3 + index * 2;
-        let content_id = page_id + 1;
-        add_object(
-            &mut pdf,
-            &mut offsets,
-            page_id,
+    for [red, green, blue] in colors.iter().copied() {
+        let content_id = object_bodies.len() + 2;
+        object_bodies.push(
             format!(
                 "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}] \
                  {page_options} /Resources << >> /Contents {content_id} 0 R >>"
             )
-            .as_bytes(),
+            .into_bytes(),
         );
 
         let content = format!(
@@ -68,32 +43,16 @@ fn make_solid_page_pdf_with_page_options(
             f32::from(green) / 255.0,
             f32::from(blue) / 255.0
         );
-        add_object(
-            &mut pdf,
-            &mut offsets,
-            content_id,
+        object_bodies.push(
             format!(
                 "<< /Length {} >>\nstream\n{content}\nendstream",
                 content.len()
             )
-            .as_bytes(),
+            .into_bytes(),
         );
     }
 
-    let xref_start = pdf.len();
-    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
-    pdf.extend_from_slice(b"0000000000 65535 f \n");
-    for offset in offsets.iter().skip(1) {
-        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-    }
-    pdf.extend_from_slice(
-        format!(
-            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
-            offsets.len()
-        )
-        .as_bytes(),
-    );
-    pdf
+    render_fixture::build_pdf_from_objects(&object_bodies)
 }
 
 fn center_pixel(pixels: &[u8], width: u32, height: u32) -> [u8; 4] {

--- a/tests/render_tests.rs
+++ b/tests/render_tests.rs
@@ -1,0 +1,303 @@
+#![cfg(feature = "render")]
+
+use pdf_inspector::{
+    render_pages_mem, RenderError, RenderOptions, RenderWarning, DEFAULT_RENDER_DPI,
+    MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
+    MAX_RENDER_PIXELS_PER_PAGE,
+};
+
+#[path = "support/render_fixture.rs"]
+mod render_fixture;
+
+fn make_solid_page_pdf(width: f32, height: f32, colors: &[[u8; 3]]) -> Vec<u8> {
+    make_solid_page_pdf_with_page_options(width, height, colors, "")
+}
+
+fn make_solid_page_pdf_with_page_options(
+    width: f32,
+    height: f32,
+    colors: &[[u8; 3]],
+    page_options: &str,
+) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
+        assert_eq!(id, offsets.len());
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+    );
+
+    let kids = (0..colors.len())
+        .map(|index| format!("{} 0 R", 3 + index * 2))
+        .collect::<Vec<_>>()
+        .join(" ");
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).as_bytes(),
+    );
+
+    for (index, [red, green, blue]) in colors.iter().copied().enumerate() {
+        let page_id = 3 + index * 2;
+        let content_id = page_id + 1;
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            page_id,
+            format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}] \
+                 {page_options} /Resources << >> /Contents {content_id} 0 R >>"
+            )
+            .as_bytes(),
+        );
+
+        let content = format!(
+            "{} {} {} rg 0 0 {width} {height} re f",
+            f32::from(red) / 255.0,
+            f32::from(green) / 255.0,
+            f32::from(blue) / 255.0
+        );
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            content_id,
+            format!(
+                "<< /Length {} >>\nstream\n{content}\nendstream",
+                content.len()
+            )
+            .as_bytes(),
+        );
+    }
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn center_pixel(pixels: &[u8], width: u32, height: u32) -> [u8; 4] {
+    let offset = ((height as usize / 2) * width as usize + width as usize / 2) * 4;
+    pixels[offset..offset + 4].try_into().unwrap()
+}
+
+#[test]
+fn renders_selected_pages_in_caller_order_with_duplicates() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[255, 0, 0], [0, 0, 255]]);
+    let rendered = render_pages_mem(&pdf, &[1, 0, 1], RenderOptions::new().dpi(72.0))
+        .expect("render selected pages");
+
+    assert_eq!(
+        rendered.iter().map(|page| page.page).collect::<Vec<_>>(),
+        [1, 0, 1]
+    );
+    for page in &rendered {
+        assert_eq!((page.width, page.height), (100, 80));
+        assert_eq!(page.pixels.len(), 100 * 80 * 4);
+        assert!(page.pixels.chunks_exact(4).all(|pixel| pixel[3] == 255));
+    }
+    assert_eq!(center_pixel(&rendered[0].pixels, 100, 80), [0, 0, 255, 255]);
+    assert_eq!(center_pixel(&rendered[1].pixels, 100, 80), [255, 0, 0, 255]);
+    assert_eq!(rendered[0], rendered[2]);
+}
+
+#[test]
+fn renders_an_image_xobject_to_opaque_color_pixels() {
+    let pdf = render_fixture::synthetic_image_pdf();
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render image page");
+    let mut pixels = rendered[0].pixels.chunks_exact(4);
+
+    assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+    assert!(rendered[0].warnings.is_empty());
+    assert!(pixels.clone().all(|pixel| pixel[3] == 255));
+    assert!(
+        pixels.clone().any(|pixel| pixel[0] > 180 && pixel[2] < 80),
+        "red checker cells were not decoded"
+    );
+    assert!(
+        pixels.any(|pixel| pixel[2] > 180 && pixel[0] < 80),
+        "blue checker cells were not decoded"
+    );
+}
+
+#[test]
+fn exposes_image_decode_failures_instead_of_silently_returning_pixels() {
+    let pdf = render_fixture::synthetic_broken_image_pdf();
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render image page");
+
+    assert_eq!(rendered[0].warnings, [RenderWarning::ImageDecodeFailure]);
+}
+
+#[test]
+fn uses_bounded_200_dpi_default() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+    let rendered = render_pages_mem(&pdf, &[0], RenderOptions::new()).expect("render page");
+
+    assert_eq!(DEFAULT_RENDER_DPI, 200.0);
+    assert_eq!((rendered[0].width, rendered[0].height), (277, 222));
+    assert_eq!(
+        rendered[0].pixels.len(),
+        rendered[0].width as usize * rendered[0].height as usize * 4
+    );
+}
+
+#[test]
+fn applies_crop_box_and_page_rotation() {
+    let pdf = make_solid_page_pdf_with_page_options(
+        100.0,
+        80.0,
+        &[[0, 255, 0]],
+        "/CropBox [0 0 40 30] /Rotate 90",
+    );
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render page");
+
+    assert_eq!((rendered[0].width, rendered[0].height), (30, 40));
+    assert_eq!(center_pixel(&rendered[0].pixels, 30, 40), [0, 255, 0, 255]);
+}
+
+#[test]
+fn rejects_invalid_dpi_values() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    for dpi in [0.0, -1.0, f32::NAN, f32::INFINITY, MAX_RENDER_DPI + 1.0] {
+        assert!(matches!(
+            render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(dpi)),
+            Err(RenderError::InvalidDpi { .. })
+        ));
+    }
+}
+
+#[test]
+fn rejects_invalid_pdf_bytes() {
+    assert_eq!(
+        render_pages_mem(b"not a PDF", &[0], RenderOptions::new()),
+        Err(RenderError::Parse)
+    );
+}
+
+#[test]
+fn rejects_out_of_range_pages_before_rendering() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[0, 1], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PageOutOfRange {
+            page: 1,
+            page_count: 1,
+        })
+    );
+}
+
+#[test]
+fn accepts_an_empty_selection_after_parsing() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[], RenderOptions::new()).unwrap(),
+        []
+    );
+    assert_eq!(
+        render_pages_mem(b"not a PDF", &[], RenderOptions::new()),
+        Err(RenderError::Parse)
+    );
+}
+
+#[test]
+fn rejects_dimension_and_pixel_limits_before_allocation() {
+    let too_wide = make_solid_page_pdf(17_000.0, 1.0, &[[0, 0, 0]]);
+    assert!(matches!(
+        render_pages_mem(&too_wide, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PageDimensionsTooLarge { page: 0, .. })
+    ));
+
+    let too_many_pixels = make_solid_page_pdf(6_000.0, 5_000.0, &[[0, 0, 0]]);
+    assert!(matches!(
+        render_pages_mem(&too_many_pixels, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PagePixelsTooLarge {
+            page: 0,
+            pixels: 30_000_000,
+            max: MAX_RENDER_PIXELS_PER_PAGE,
+        })
+    ));
+}
+
+#[test]
+fn rejects_total_output_limit_before_allocation() {
+    let pdf = make_solid_page_pdf(6_000.0, 4_000.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[0, 0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::OutputTooLarge {
+            bytes: 192_000_000,
+            max: MAX_RENDER_OUTPUT_BYTES,
+        })
+    );
+}
+
+#[test]
+fn rejects_excessive_page_entry_count() {
+    let pdf = make_solid_page_pdf(1.0, 1.0, &[[0, 0, 0]]);
+    let pages = vec![0; MAX_RENDER_PAGES_PER_REQUEST + 1];
+
+    assert_eq!(
+        render_pages_mem(&pdf, &pages, RenderOptions::new().dpi(72.0)),
+        Err(RenderError::TooManyPages {
+            requested: MAX_RENDER_PAGES_PER_REQUEST + 1,
+            max: MAX_RENDER_PAGES_PER_REQUEST,
+        })
+    );
+}
+
+#[test]
+fn render_options_debug_redacts_password() {
+    let debug = format!("{:?}", RenderOptions::new().password("secret123"));
+
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains("secret123"));
+}
+
+#[test]
+fn decrypts_with_the_supplied_password() {
+    let pdf = include_bytes!("fixtures/encrypted-secret123.pdf");
+
+    assert_eq!(
+        render_pages_mem(pdf, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::Encrypted)
+    );
+    assert_eq!(
+        render_pages_mem(pdf, &[0], RenderOptions::new().dpi(72.0).password("wrong")),
+        Err(RenderError::Encrypted)
+    );
+
+    let rendered = render_pages_mem(
+        pdf,
+        &[0],
+        RenderOptions::new().dpi(72.0).password("secret123"),
+    )
+    .expect("render encrypted PDF with its password");
+    assert_eq!(rendered.len(), 1);
+    assert!(!rendered[0].pixels.is_empty());
+}

--- a/tests/support/render_fixture.rs
+++ b/tests/support/render_fixture.rs
@@ -1,0 +1,87 @@
+/// Build a small, deterministic PDF whose only page contains an RGB image
+/// XObject. Keeping this generated avoids adding a separately licensed binary
+/// fixture and lets native and WebAssembly tests exercise the same bytes.
+pub fn synthetic_image_pdf() -> Vec<u8> {
+    let mut image = Vec::with_capacity(4 * 4 * 3);
+    for y in 0..4 {
+        for x in 0..4 {
+            image.extend_from_slice(if (x + y) % 2 == 0 {
+                &[255, 0, 0]
+            } else {
+                &[0, 0, 255]
+            });
+        }
+    }
+
+    synthetic_image_pdf_with_data(&image, "")
+}
+
+/// Build an image-backed PDF whose declared JPEG data cannot be decoded.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn synthetic_broken_image_pdf() -> Vec<u8> {
+    synthetic_image_pdf_with_data(b"not a JPEG stream", "/Filter /DCTDecode")
+}
+
+fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
+        assert_eq!(id, offsets.len());
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
+          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+
+    let content = b"q 64 0 0 64 0 0 cm /Im0 Do Q";
+    let mut content_stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    content_stream.extend_from_slice(content);
+    content_stream.extend_from_slice(b"\nendstream");
+    add_object(&mut pdf, &mut offsets, 4, &content_stream);
+
+    let mut image_stream = format!(
+        "<< /Type /XObject /Subtype /Image /Width 4 /Height 4 \
+         /ColorSpace /DeviceRGB /BitsPerComponent 8 {image_options} /Length {} >>\nstream\n",
+        image.len()
+    )
+    .into_bytes();
+    image_stream.extend_from_slice(image);
+    image_stream.extend_from_slice(b"\nendstream");
+    add_object(&mut pdf, &mut offsets, 5, &image_stream);
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}

--- a/tests/support/render_fixture.rs
+++ b/tests/support/render_fixture.rs
@@ -1,3 +1,35 @@
+/// Build a PDF from a sequence of already-formatted object bodies, each
+/// becoming object `index + 1`. Shares the header, `N 0 obj`/`endobj`
+/// framing, and xref/trailer generation used by every fixture builder in
+/// this crate's tests.
+pub fn build_pdf_from_objects(object_bodies: &[Vec<u8>]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    for body in object_bodies {
+        let id = offsets.len();
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
 /// Build a small, deterministic PDF whose only page contains an RGB image
 /// XObject. Keeping this generated avoids adding a separately licensed binary
 /// fixture and lets native and WebAssembly tests exercise the same bytes.
@@ -23,42 +55,10 @@ pub fn synthetic_broken_image_pdf() -> Vec<u8> {
 }
 
 fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
-    let mut pdf = b"%PDF-1.4\n".to_vec();
-    let mut offsets = vec![0_usize];
-
-    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
-        assert_eq!(id, offsets.len());
-        offsets.push(pdf.len());
-        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
-        pdf.extend_from_slice(body);
-        pdf.extend_from_slice(b"\nendobj\n");
-    }
-
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        1,
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-    );
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        2,
-        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-    );
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        3,
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
-          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
-    );
-
     let content = b"q 64 0 0 64 0 0 cm /Im0 Do Q";
     let mut content_stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
     content_stream.extend_from_slice(content);
     content_stream.extend_from_slice(b"\nendstream");
-    add_object(&mut pdf, &mut offsets, 4, &content_stream);
 
     let mut image_stream = format!(
         "<< /Type /XObject /Subtype /Image /Width 4 /Height 4 \
@@ -68,20 +68,14 @@ fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
     .into_bytes();
     image_stream.extend_from_slice(image);
     image_stream.extend_from_slice(b"\nendstream");
-    add_object(&mut pdf, &mut offsets, 5, &image_stream);
 
-    let xref_start = pdf.len();
-    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
-    pdf.extend_from_slice(b"0000000000 65535 f \n");
-    for offset in offsets.iter().skip(1) {
-        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-    }
-    pdf.extend_from_slice(
-        format!(
-            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
-            offsets.len()
-        )
-        .as_bytes(),
-    );
-    pdf
+    build_pdf_from_objects(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
+          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        content_stream,
+        image_stream,
+    ])
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -29,6 +29,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +156,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cast"
@@ -201,6 +269,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -388,6 +465,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +508,21 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -452,10 +574,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "skrifa",
+ "smallvec",
+ "vello_common 0.0.9",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hayro"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4caa128ab87fd48ffb7490617cf93f77f606820dffbc9fd9ef6ab0ed077f56d"
+dependencies = [
+ "bytemuck",
+ "hayro-interpret",
+ "image",
+ "kurbo",
+ "pic-scale",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
+
+[[package]]
+name = "hayro-cmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
+dependencies = [
+ "brotli",
+ "hayro-postscript",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2613d0406898995042d0794c4245b2f2fba1246490c8ac593769bba6551129d"
+dependencies = [
+ "bitflags 2.13.1",
+ "hayro-cmap",
+ "hayro-syntax",
+ "kurbo",
+ "moxcms",
+ "phf",
+ "rustc-hash",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "yoke",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69374b3668dd45aeb3d3145cda68f2c7b4f223aaa2511e67d076f1c7d741388d"
+dependencies = [
+ "fearless_simd",
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
+name = "hayro-postscript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+
+[[package]]
+name = "hayro-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edeafd70aa2db743de8ede8637d07ec87db05efe69cde371d03f1b185fcef27"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000",
+ "memchr",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -479,6 +720,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -586,6 +840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +862,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "log"
@@ -671,6 +943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,7 +1008,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 name = "pdf-inspector"
 version = "1.14.1"
 dependencies = [
+ "bytemuck",
  "env_logger",
+ "hayro",
  "include_dir",
  "log",
  "lopdf",
@@ -752,10 +1036,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pic-scale"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c80d88d5c31215ceec2862abb2504860c715b8e2545a5ab15b62a3d097f30d"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -786,6 +1157,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quote"
@@ -846,6 +1223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1260,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
@@ -967,10 +1360,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stringprep"
@@ -992,6 +1413,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1103,6 +1535,53 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vello_common"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3361bff7f7d82c0c496b92048db83846691f0e844cc28dee92b1c824291b55ee"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8ded630e8316bb94a55881256506d1f3b9947b5f66db8a7d32ca7ba02decd0"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown",
+ "png",
+ "vello_common 0.0.8",
+]
 
 [[package]]
 name = "version_check"
@@ -1298,7 +1777,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -24,6 +24,10 @@ wasm-bindgen = "0.2"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
+[features]
+default = []
+render = ["pdf-inspector/render"]
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,6 +5,10 @@ use pdf_inspector::{
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+#[cfg(all(test, target_arch = "wasm32", feature = "render"))]
+#[path = "../../tests/support/render_fixture.rs"]
+mod render_fixture;
+
 #[wasm_bindgen(typescript_custom_section)]
 const TYPESCRIPT_TYPES: &str = r#"
 export type PdfType = "TextBased" | "Scanned" | "ImageBased" | "Mixed";
@@ -391,6 +395,39 @@ mod tests {
 
         assert_eq!(pdf_type, "TextBased");
         assert!(!markdown.is_empty());
+    }
+
+    #[cfg(feature = "render")]
+    #[wasm_bindgen_test]
+    fn renders_a_selected_page_with_the_optional_core_feature() {
+        let pdf = crate::render_fixture::synthetic_image_pdf();
+        let rendered = pdf_inspector::render_pages_mem(
+            &pdf,
+            &[0],
+            pdf_inspector::RenderOptions::new().dpi(72.0),
+        )
+        .expect("render selected page");
+
+        assert_eq!(rendered.len(), 1);
+        assert_eq!(rendered[0].page, 0);
+        assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+        assert!(rendered[0].warnings.is_empty());
+        assert_eq!(
+            rendered[0].pixels.len(),
+            rendered[0].width as usize * rendered[0].height as usize * 4
+        );
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .all(|pixel| pixel[3] == 255));
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .any(|pixel| pixel[0] > 180 && pixel[2] < 80));
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .any(|pixel| pixel[2] > 180 && pixel[0] < 80));
     }
 
     #[wasm_bindgen_test]

--- a/wasm/tests/render_browser.rs
+++ b/wasm/tests/render_browser.rs
@@ -1,0 +1,33 @@
+#![cfg(all(target_arch = "wasm32", feature = "render"))]
+
+use wasm_bindgen_test::*;
+
+#[path = "../../tests/support/render_fixture.rs"]
+mod render_fixture;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn renders_an_image_xobject_in_a_browser() {
+    let pdf = render_fixture::synthetic_image_pdf();
+    let rendered =
+        pdf_inspector::render_pages_mem(&pdf, &[0], pdf_inspector::RenderOptions::new().dpi(72.0))
+            .expect("render image page");
+
+    assert_eq!(rendered.len(), 1);
+    assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+    assert!(rendered[0].warnings.is_empty());
+    assert_eq!(rendered[0].pixels.len(), 64 * 64 * 4);
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .all(|pixel| pixel[3] == 255));
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .any(|pixel| pixel[0] > 180 && pixel[2] < 80));
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .any(|pixel| pixel[2] > 180 && pixel[0] < 80));
+}


### PR DESCRIPTION
Hi! This is my first contribution here, and honestly one of my first real pieces of Rust; I come from other ecosystems, so if something below is nonsense or I misused a pattern you consider obvious, __please be patient and point it out__, I genuinely want to learn from the review.

## Why

`pages_needing_ocr` and the per page `needs_ocr` flag tell callers which pages need OCR, but nothing in the package hands them the pixels of those pages. Any library that depends on this package for its PDF handling and needs to act on that flag is stuck: it knows page 3 needs OCR, it has no way to rasterize page 3, and working around it means dragging in a second PDF stack and parsing the same bytes twice. Since PDF ownership lives here by design (the issue templates even route PDF matters to this repo), IMO the rendering primitive belongs here too.

## What

A pluggable `render` feature with a single entry point:

```rust
pub fn render_pages_mem(pdf_bytes: &[u8], pages: &[u32], options: RenderOptions)
    -> Result<Vec<RenderedPage>, RenderError>;
```

Page indexes are zero based, results come back in caller order with duplicates preserved, as opaque row-major RGBA8 on a white background at 200 DPI by default (300 max).
Rendering goes through [Hayro 0.7.1](https://github.com/LaurenzV/hayro) (a pure Rust PDF interpreter, which seems very well done made) so wasm32 keeps working and the dependency graph stays free of native PDF runtimes.
Every limit is validated before the first page renders:
 - 16384 px per side
 - 25000000 px per page
 - 100000000 output bytes per call
 - 1024 page entries per request
 
When Hayro hits something it can't draw (a font kind it doesn't support, an image that fails to decode) you get a typed `RenderWarning` on that page instead of silently wrong pixels; I added a test with an intentionally broken JPEG to be sure this doesn't regress. Render errors have their own non-exhaustive enum, separate from the extraction ones, and no Hayro type is exposed in the public API.

With default features nothing changes: [hayro](https://crates.io/crates/hayro) and [bytemuck](https://crates.io/crates/bytemuck) sit behind `render = ["dep:bytemuck", "dep:hayro"]`.

## Numbers

Letter page, release profile, Rust 1.95, Apple M3 Pro.
With a median of 20 runs in separate processes, first warmup run discarded:

| DPI | Output    | Render time | Peak RSS  |
|-----|-----------|-------------|-----------|
| 150 | 1240×1753 | ~7.29 ms    | ~ 30.4 MB |
| 200 | 1653×2338 | ~8.55 ms    | ~36.5 MB  |
| 300 | 2480×3507 | ~11.99 ms   | ~59.8 MB  |

Cost on the stripped release binary: ~704 bytes when the feature is compiled but never called, ~4.75 MB once a caller actually renders; six Letter pages at 200 DPI fit one call before the output cap.

The input was `018-base64-image/base64image.pdf` from the pinned corpus (the only page is classified as needing OCR, so it felt like the right sample).
To reproduce (from the package root):
```bash
git clone https://github.com/py-pdf/sample-files.git ../sample-files
git -C ../sample-files checkout 89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf

PDF_INSPECTOR_SAMPLE_FILES=../sample-files cargo test --release --features render --test render_corpus_tests renders_pinned -- --ignored --nocapture
```

For the RSS column I wrapped the single runs with `/usr/bin/time -l`. The full protocol (and a more detailed table with p95, min–max and standard deviation) is in `docs/benchmarking.md`, which this PR adds to.

## Tests

For the tests I generate a small PDF in memory (a page with a single image XObject) and assert on the rendered content, not just on buffer sizes. There are 14 new renderer tests and they go through page selection, caller order and duplicates, crop and rotation, the DPI default, all the public limits, out of range indexes, empty selections and passwords. The 820 unit and 152 integration tests that were already there are untouched.

The same generated PDF is rendered in the wasm tests too, in release mode, both on Node and on headless Chrome.

I also wrote a suite that renders six files from [py-pdf/sample-files](https://github.com/py-pdf/sample-files), pinned at commit [89039b6](https://github.com/py-pdf/sample-files/tree/89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf) and verified by SHA-256. It is marked as ignored and runs only when `PDF_INSPECTOR_SAMPLE_FILES` poinst at that checkout.

The CI changes are in a separate commit. I added jobs for the render feature, one pinned at Rust 1.92.0 (the minimum the feature compiles with, I check it on native and wasm32) and one for the corpus.

## Known limitations

[Hayro is a young project](https://github.com/LaurenzV/hayro#readme) and some advanced graphic effects of the PDF spec are not implemented yet (transparency things like blend isolation, knockout groups and color-key masking), so a few PDFs will not look pixel-perfect compared to Acrobat or Preview. While testing the `py-pdf` samples I also noticed that annotation widgets are not drawn...

My limits protect the output buffers but not what happens inside Hayro of course... so a malicious PDF can declare a huge embedded image and make the decoder allocate a lot of memory before my caps even enter the picture, meaning that if you render PDFs you must not just trust them: it's better to do it in a separate process or in a Worker (I know it seems obvious, but could be very dangerous if not well-checked).

The wasm package compiles fine with the feature but **I did not expose a JS API for the renderer yet**.

I didn't run the pdf-evals suite, so the coverage here is only what is described in Tests.

## Important notes
- I'm not very confident with Rust gh actions. I extended the `ci.yml` using the existing jobs as a template, but please make a profound check of the workflow changes.
- I left the `LICENSE` files untouched. Hayro embeds `PDFium/Foxit` fallback fonts and [Adobe CMap resources](https://github.com/adobe-type-tools/cmap-resources), so before pushing any artifact with render enabled the third party notices would probably need to be added; **LICENSE probably should be updated as part of the review.**
- The [bytemuck](https://github.com/Lokathor/bytemuck) conversion from Hayro's pixmap into `Vec<u8>` is the part of the Rust code I'm least sure I got right. **Please take take a careful look there.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788603668&installation_model_id=11126&pr_number=280&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F280&signature=8ade73462236905c8e25ffb9b3e0a9cc1437aef4a1812b1bc50c533e18cd2fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional selected-page rasterization behind the `render` feature to return opaque RGBA8 buffers for OCR-targeted pages. Works on native and WebAssembly (CPU-only); no JS API exposed yet.

- New Features
  - `render_pages_mem(&[u8], &[u32], RenderOptions) -> Result<Vec<RenderedPage>, RenderError>` renders zero-based pages; caller order and duplicates preserved.
  - Output is row-major RGBA8 on white; default 200 DPI, 300 max. Optional password in `RenderOptions` for encrypted PDFs (`RenderError::Encrypted` on failure).
  - Typed per-page warnings: `UnsupportedFont`, `ImageDecodeFailure` (skip OCR on these).
  - Hard limits validated upfront: dimensions, pixels per page, total RGBA bytes, and page-entry count. Skip the call when no pages need OCR and batch large renders to control memory.
  - Unit tests, wasm runtime tests (Node + headless Chrome), and an ignored checksum-verified external corpus.

- Dependencies
  - Adds optional `hayro@0.7.1` and `bytemuck@1.25` behind `render`; default feature set remains `lopdf`-only. CI covers native and wasm with `render`, docs build, MSRV check (1.92), the pinned corpus job, and Node + Chrome runtime tests using a `wasm-bindgen-cli` version pinned to `wasm/Cargo.lock`.

<sup>Written for commit 5a36ecb2080262053748610b9c6468a01a380f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

