### PR TITLE
fix(tables): don't merge rows that only lack a marker-column glyph

### DIFF
--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -259,6 +259,21 @@ fn clean_table_cells(cells: &[Vec<String>]) -> (Vec<Vec<String>>, Vec<String>) {
     let mut cleaned: Vec<Vec<String>> = Vec::new();
     let mut footnotes: Vec<String> = Vec::new();
 
+    // Columns holding only one- or two-character markers (bullets, ticks,
+    // single-letter flags) never carry wrapped prose, so a row missing one is
+    // a complete record whose flag happens to be absent — not overflow from
+    // the row above. The continuation test below discounts them.
+    let marker_columns = marker_column_flags(cells);
+    let has_marker_columns = marker_columns.iter().any(|is_marker| *is_marker);
+    let substantive_filled = |row: &[String]| {
+        row.iter()
+            .enumerate()
+            .filter(|(idx, cell)| {
+                !cell.trim().is_empty() && !marker_columns.get(*idx).copied().unwrap_or(false)
+            })
+            .count()
+    };
+
     for row in cells {
         // Check if this row is empty
         if row.iter().all(|c| c.trim().is_empty()) {
@@ -403,10 +418,21 @@ fn clean_table_cells(cells: &[Vec<String>]) -> (Vec<Vec<String>>, Vec<String>) {
         let continues_wrapped_first_column_label = !first_cell.is_empty()
             && starts_with_lowercase_alpha(first_cell)
             && ends_like_incomplete_phrase(prev_first_cell);
+        // Overflow text always brings less prose than the row it wrapped from.
+        // When the row carries just as much once marker columns are discounted,
+        // nothing wrapped: it is a full record missing only a flag glyph.
+        // A row starting mid-phrase is wrapped text on its own evidence, so the
+        // marker test only speaks for rows without that signal.
+        let loses_only_markers = has_marker_columns
+            && !continues_wrapped_first_column_label
+            && cleaned
+                .last()
+                .is_some_and(|prev| substantive_filled(prev) <= substantive_filled(row));
         let is_wrapped_continuation = cleaned.len() > 1
             && filled_cells <= max_filled_for_merge
             && (prev_filled > filled_cells
                 || (continues_wrapped_first_column_label && prev_filled >= filled_cells))
+            && !loses_only_markers
             && !looks_like_data_row
             && !looks_like_spanning_first_column_row
             && !looks_like_hierarchical_subrow
@@ -436,6 +462,32 @@ fn clean_table_cells(cells: &[Vec<String>]) -> (Vec<Vec<String>>, Vec<String>) {
     }
 
     (cleaned, footnotes)
+}
+
+/// Flag columns whose non-empty values are all at most two characters.
+///
+/// Statement-style tables carry flag columns (a purchase indicator bullet, a
+/// tick, a one-letter code) that some rows leave blank. Those columns hold no
+/// prose, so their absence is not evidence that a row wrapped.
+fn marker_column_flags(cells: &[Vec<String>]) -> Vec<bool> {
+    let width = cells.iter().map(|row| row.len()).max().unwrap_or(0);
+    (0..width)
+        .map(|col| {
+            let mut populated = 0usize;
+            for row in cells {
+                let Some(cell) = row.get(col) else { continue };
+                let trimmed = cell.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if trimmed.chars().count() > 2 {
+                    return false;
+                }
+                populated += 1;
+            }
+            populated > 0
+        })
+        .collect()
 }
 
 /// Check if a cell value indicates a footnote row
@@ -702,6 +754,46 @@ mod tests {
         assert_eq!(cleaned[2][1], "Storage setup");
         assert_eq!(cleaned[3][1], "Label workspace");
         assert_eq!(cleaned[4][1], "Model training");
+    }
+
+    #[test]
+    fn test_clean_table_cells_missing_marker_glyph_keeps_row_separate() {
+        // A bank statement whose purchase-indicator column is a single bullet
+        // glyph, drawn invisibly (Tr 3) on some rows and so absent from the
+        // extracted text. Those rows are complete transactions, not text
+        // wrapped from the row above, and must not be merged away.
+        let cells = vec![
+            vec![
+                "DATE & TIME".into(),
+                "TRANSACTION DESCRIPTION".into(),
+                "AMOUNT".into(),
+                "PI".into(),
+            ],
+            vec![
+                "26/06/2026 00:00".into(),
+                "10% Swiggy CashBack".into(),
+                "+ C 26.20".into(),
+                "l".into(),
+            ],
+            vec![
+                "06/07/2026 14:16".into(),
+                "BPPY CC PAYMENT DP016187141619hpYGk".into(),
+                "+ C 8,889.00".into(),
+                String::new(),
+            ],
+            vec![
+                "13/07/2026 12:04".into(),
+                "PYU*Instamart GroceryBangalore".into(),
+                "C 479.00".into(),
+                "l".into(),
+            ],
+        ];
+        let (cleaned, _) = clean_table_cells(&cells);
+
+        assert_eq!(cleaned.len(), 4, "no transaction row may be merged away");
+        assert_eq!(cleaned[2][0], "06/07/2026 14:16");
+        assert_eq!(cleaned[2][2], "+ C 8,889.00");
+        assert_eq!(cleaned[2][3], "", "the absent marker stays absent");
     }
 
     #[test]

--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -464,20 +464,27 @@ fn clean_table_cells(cells: &[Vec<String>]) -> (Vec<Vec<String>>, Vec<String>) {
     (cleaned, footnotes)
 }
 
-/// Flag columns whose non-empty values are all at most two characters.
+/// Flag columns that hold a one- or two-character marker on some rows and
+/// nothing on others.
 ///
 /// Statement-style tables carry flag columns (a purchase indicator bullet, a
 /// tick, a one-letter code) that some rows leave blank. Those columns hold no
 /// prose, so their absence is not evidence that a row wrapped.
+///
+/// The header is skipped when classifying: a column labelled `Indicator` or
+/// `Status` still holds markers, and only its values decide. A column every
+/// row fills cannot be what makes a row look short, so requiring a blank keeps
+/// the exemption off tables where it has nothing to say.
 fn marker_column_flags(cells: &[Vec<String>]) -> Vec<bool> {
     let width = cells.iter().map(|row| row.len()).max().unwrap_or(0);
     (0..width)
         .map(|col| {
             let mut populated = 0usize;
-            for row in cells {
-                let Some(cell) = row.get(col) else { continue };
-                let trimmed = cell.trim();
+            let mut blank = 0usize;
+            for row in cells.iter().skip(1) {
+                let trimmed = row.get(col).map(|cell| cell.trim()).unwrap_or("");
                 if trimmed.is_empty() {
+                    blank += 1;
                     continue;
                 }
                 if trimmed.chars().count() > 2 {
@@ -485,7 +492,7 @@ fn marker_column_flags(cells: &[Vec<String>]) -> Vec<bool> {
                 }
                 populated += 1;
             }
-            populated > 0
+            populated > 0 && blank > 0
         })
         .collect()
 }
@@ -794,6 +801,64 @@ mod tests {
         assert_eq!(cleaned[2][0], "06/07/2026 14:16");
         assert_eq!(cleaned[2][2], "+ C 8,889.00");
         assert_eq!(cleaned[2][3], "", "the absent marker stays absent");
+    }
+
+    #[test]
+    fn test_clean_table_cells_marker_column_detected_under_descriptive_header() {
+        // The column label says nothing about what the column holds; only the
+        // values do. A spelled-out header must not hide a marker column.
+        let cells = vec![
+            vec![
+                "DATE & TIME".into(),
+                "TRANSACTION DESCRIPTION".into(),
+                "AMOUNT".into(),
+                "Indicator".into(),
+            ],
+            vec![
+                "26/06/2026 00:00".into(),
+                "10% Swiggy CashBack".into(),
+                "+ C 26.20".into(),
+                "l".into(),
+            ],
+            vec![
+                "06/07/2026 14:16".into(),
+                "BPPY CC PAYMENT DP016187141619hpYGk".into(),
+                "+ C 8,889.00".into(),
+                String::new(),
+            ],
+        ];
+        let (cleaned, _) = clean_table_cells(&cells);
+
+        assert_eq!(cleaned.len(), 3, "no transaction row may be merged away");
+        assert_eq!(cleaned[2][0], "06/07/2026 14:16");
+    }
+
+    #[test]
+    fn test_clean_table_cells_wrapped_overflow_still_merges_beside_marker_column() {
+        // The exemption must not blanket-disable continuation merging for any
+        // table that happens to contain a short column. Real overflow carries
+        // less prose than the row it wrapped from, and still merges.
+        let cells = vec![
+            vec!["Ref".into(), "Description".into(), "Amount".into()],
+            vec![
+                "A1".into(),
+                "Delivery charge for the northern".into(),
+                "120.00".into(),
+            ],
+            vec![
+                String::new(),
+                "region raised in transit".into(),
+                String::new(),
+            ],
+            vec!["B2".into(), "Handling fee".into(), "80.00".into()],
+        ];
+        let (cleaned, _) = clean_table_cells(&cells);
+
+        assert_eq!(cleaned.len(), 3, "wrapped overflow should still merge");
+        assert_eq!(
+            cleaned[1][1],
+            "Delivery charge for the northern region raised in transit"
+        );
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4052,3 +4052,56 @@ fn test_extract_pages_markdown_agrees_with_classify_on_scan_with_native_header()
         page.markdown
     );
 }
+
+/// A borderless statement table whose last column is a single marker glyph that
+/// some rows draw invisibly (`Tr 3`, e.g. a flag toggled off in the template).
+/// Invisible text is correctly excluded from extraction, so those rows arrive
+/// with one fewer filled cell — which must not be read as wrapped overflow text
+/// and merged into the row above, silently dropping a record.
+#[test]
+fn rows_missing_an_invisible_marker_glyph_stay_separate() {
+    let mut content = String::from("BT /F1 7 Tf\n");
+    let rows = [
+        ("21/06 22:29", "BUNDL TECHNOLOGIES", "67.00", true),
+        ("24/06 17:04", "RAZ SwiggyBangalore", "262.00", true),
+        ("26/06 00:00", "10% CashBack Credit", "26.20", false),
+        ("06/07 14:16", "BPPY CC PAYMENT DP016187", "8889.00", false),
+        ("13/07 12:04", "PYU Instamart Grocery", "479.00", true),
+    ];
+    content.push_str("1 0 0 1 60 260 Tm (DATE & TIME) Tj\n");
+    content.push_str("1 0 0 1 160 260 Tm (TRANSACTION DESCRIPTION) Tj\n");
+    content.push_str("1 0 0 1 400 260 Tm (AMOUNT) Tj\n");
+    content.push_str("1 0 0 1 470 260 Tm (PI) Tj\n");
+    for (idx, (date, description, amount, marker_visible)) in rows.iter().enumerate() {
+        let y = 240 - (idx as i32) * 14;
+        content.push_str(&format!("1 0 0 1 60 {y} Tm ({date}) Tj\n"));
+        content.push_str(&format!("1 0 0 1 160 {y} Tm ({description}) Tj\n"));
+        content.push_str(&format!("1 0 0 1 400 {y} Tm ({amount}) Tj\n"));
+        // The marker is emitted on every row; only its rendering mode differs.
+        content.push_str(if *marker_visible { "0 Tr\n" } else { "3 Tr\n" });
+        content.push_str(&format!("1 0 0 1 470 {y} Tm (l) Tj\n"));
+        content.push_str("0 Tr\n");
+    }
+    content.push_str("ET\n");
+
+    let pdf = make_text_pdf(&content, "0 0 595 300");
+    let markdown = process_pdf_mem(&pdf)
+        .expect("fixture should convert")
+        .markdown
+        .expect("fixture should produce markdown");
+
+    for (date, description, amount, _) in rows.iter() {
+        assert!(
+            markdown.contains(description),
+            "row {date} ({amount}) lost its description:\n{markdown}"
+        );
+    }
+    // Each row must occupy its own line; a merge would put two dates together.
+    for line in markdown.lines() {
+        let dates_on_line = rows.iter().filter(|(date, ..)| line.contains(date)).count();
+        assert!(
+            dates_on_line <= 1,
+            "two transactions were merged onto one row:\n{line}\n\nfull output:\n{markdown}"
+        );
+    }
+}


### PR DESCRIPTION
## Symptom

A borderless statement table lost 3 of its 9 transaction rows. Each lost row was concatenated into its neighbour — two dates, two descriptions and two amounts in one cell:

```
|26/06/2026| 00:00 06/07/2026| 14:16|10% Swiggy CashBack BPPY CC PAYMENT ...|+ C 26.20 + C 8,889.00|l|
```

No error, no warning. The rows are simply gone, which makes this a silent data-loss bug for anyone parsing financial or log tables.

## Root cause

`clean_table_cells` in `src/tables/format.rs` classifies a row as wrapped overflow text when it has fewer filled cells than the header:

```rust
let max_filled_for_merge = if header_filled >= 5 { header_filled / 2 }
                           else { header_filled.saturating_sub(1) };
let is_wrapped_continuation = cleaned.len() > 1
    && filled_cells <= max_filled_for_merge
    && (prev_filled > filled_cells || ...)
```

The table is 4 columns — `DATE & TIME | TRANSACTION DESCRIPTION | AMOUNT | PI` — where `PI` is a single bullet glyph. So `header_filled = 4`, `max_filled_for_merge = 3`, and:

- rows carrying the bullet → `filled_cells = 4` → kept
- rows without it → `filled_cells = 3` → `3 <= 3` and `prev_filled (4) > 3` → **merged away**

The existing `looks_like_data_row` guard doesn't catch it: it requires `avg_cell_len <= 10.0`, and these rows average 14.5 characters.

Crucially, the glyph is missing for a legitimate reason. The template emits it on *every* row but sets **text rendering mode 3** (invisible) where the flag is off:

```
Operation { operator: "Tr", operands: [3] }
Operation { operator: "Tj", operands: [(l)] }
```

`extractor/content_stream.rs:496` correctly skips invisible text — that's how OCR overlays are excluded. So extraction is right and the row genuinely arrives one cell short while being a complete record. Confirmed by patching the three glyphs to visible: the merge disappears and all 9 rows come back.

## Fix

Discount columns whose non-empty values are all at most two characters when comparing how much a row carries against the row above. Such columns hold markers (bullets, ticks, one-letter codes), not prose, so their absence is not evidence that anything wrapped.

Rows starting mid-phrase are exempted (`continues_wrapped_first_column_label`) — they carry their own positive evidence of wrapping, and the existing hierarchy test depends on that path.

Narrowly scoped: only the wrapped-continuation branch changes, and only for tables that actually have a marker column. Tables without one are untouched.

## Relationship to #232

Same function, different trigger, non-overlapping fix. #232 addresses currency-prefixed cells failing `looks_like_data_row`'s numeric check and fires through the *classic* continuation path (empty first column). This is the *wrapped* continuation path with a fully-populated first column. I built #232's branch and ran this repro against it — still 6 rows, so it does not cover this case. The two changes touch different predicates and should merge cleanly.

## Testing

- `test_clean_table_cells_missing_marker_glyph_keeps_row_separate` — unit test on the cell shape
- `rows_missing_an_invisible_marker_glyph_stay_separate` — integration test building a PDF that draws the marker with `Tr 3` on some rows, exercising the real extraction path. Verified it **fails without the fix** and passes with it
- Full suite green: 820 lib + 153 integration + 2 doc tests, 0 failures
- `cargo fmt --check` clean; `cargo clippy --all-targets` reports nothing on the changed regions (pre-existing warnings elsewhere untouched)

Verified end-to-end on the original document: 9/9 rows recovered, and the debit and credit columns now reconcile exactly against the totals printed on the statement (1,538.00 and 9,009.40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788622719&installation_model_id=11126&pr_number=282&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F282&signature=6ce0ee6434368d792e7e59b6e9a064fd261183ba557badbbbe4416bb5bfdc2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false row merges in tables with a short “marker” column by ignoring that column during wrap detection. Rows that only miss a glyph (including when drawn invisible with `Tr 3`) stay separate, preventing silent data loss.

- **Bug Fixes**
  - Classify marker columns from data rows only (skip header) and require a gap: non-empty values ≤2 chars with at least one blank; exclude them from continuation checks.
  - Keep merging when the first column clearly continues mid-phrase; only marker-only differences are ignored, and real wrapped overflow still merges.
  - Added unit and integration tests, including a header-labeled marker column and a PDF using `Tr 3`, to confirm rows remain separate.

<sup>Written for commit f8c33f48e12d3efeb488d98ea1926b751b4d518b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

