### PR TITLE
Preserve page-prefixed Markdown content

### DIFF
--- a/src/markdown/postprocess.rs
+++ b/src/markdown/postprocess.rs
@@ -464,6 +464,7 @@ mod tests {
         assert!(!is_page_number_line("Hello World"));
         assert!(!is_page_number_line("Chapter 1"));
         assert!(!is_page_number_line("Total: 500"));
+        assert!(!is_page_number_line("PAGE0-PARA2-END-MARKER-0"));
     }
 
     #[test]
@@ -505,6 +506,14 @@ mod tests {
         assert!(!result.contains("Page 42 explains the result"));
         assert!(result.contains("Content"));
         assert!(result.contains("End"));
+    }
+
+    #[test]
+    fn test_remove_page_numbers_preserves_page_prefixed_content() {
+        let input = "PAGE0-PARA2-START substantive report text PAGE0-PARA2-END-MARKER-0";
+        let result = remove_page_numbers(input);
+
+        assert_eq!(result, input);
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -70,10 +70,17 @@ pub(crate) fn is_page_number_line(text: &str) -> bool {
 
     let lowercase = text.trim().to_ascii_lowercase();
     lowercase.strip_prefix("page").is_some_and(|rest| {
-        rest.trim_start()
-            .chars()
-            .next()
+        let mut characters = rest.trim_start().chars().peekable();
+        let mut has_page_number = false;
+        while characters
+            .peek()
             .is_some_and(|character| character.is_ascii_digit())
+        {
+            has_page_number = true;
+            characters.next();
+        }
+
+        has_page_number && characters.next().is_none_or(char::is_whitespace)
     })
 }
 


### PR DESCRIPTION
Fixes #251

The reported `PAGE0-PARA...` content is removed by the page-number cleanup
predicate. It previously treated any line beginning with `page` and a digit as
a page-number line, even when the digit was immediately followed by substantive
text.

Consume the full numeric run and require it to end the line or be followed by
whitespace. This preserves `PAGE0-PARA2-...` report content while retaining the
existing cleanup behavior for forms such as `Page123` and `Page 42 ...`.

Validation:

- `cargo test page_number`: 32 passed
- exact synthetic PDF: all five page-prefixed markers survive in Markdown; no OCR
- all 820 library tests passed
- integration result matches clean `main`: 142 passed, 10 fixture/snapshot failures
- `cargo clippy --all-targets` and release build passed with upstream warnings only
- direct Rustfmt checks for both changed files and `git diff --check` passed

Repository-wide `cargo fmt` currently overflows the stack in unchanged
`src/lib.rs`; the two changed files pass direct Rustfmt validation.

AI assistance: OpenAI Codex helped isolate the predicate with a semantic control,
draft the fix and tests, and prepare this description. I reviewed the complete
diff and validation evidence and take responsibility for the contribution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629355&installation_model_id=11126&pr_number=284&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F284&signature=07262d9e0d83d5055c367f90a764afd07a051b76b48fc067f91322d4fba3e15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented loss of page-prefixed Markdown content by tightening page number detection. Lines like "PAGE0-PARA2-..." are preserved, while real page numbers (e.g., "Page 42", "Page123") are still removed.

- **Bug Fixes**
  - Updated is_page_number_line to consume the full digit run after "page" and require end-of-line or whitespace afterward.
  - Added tests to ensure remove_page_numbers keeps PAGE0-PARA2 markers and ignores false positives.

<sup>Written for commit 26e27fbcea4b399e5ac90bfb155d111cacf46556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

