### PR TITLE
fix(layout): scale the page-number bands by the page's real height

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -964,13 +964,35 @@ const PAGE_NUMBER_Y_TOLERANCE: f32 = 3.0;
 const PAGE_NUMBER_CONTEXT_GAP_EM: f32 = 1.5;
 const PAGE_NUMBER_BOTTOM_Y: f32 = 100.0;
 const PAGE_NUMBER_TOP_Y: f32 = 720.0;
+/// The page height the absolute band constants above were calibrated for
+/// (US Letter). Pages whose visible box differs scale the bands by their
+/// real height, so an A4 page (841.89pt) does not treat the top ~122pt —
+/// eight lines of body text — as the folio zone (issue #283).
+const PAGE_NUMBER_BAND_REFERENCE_HEIGHT: f32 = 792.0;
+
+/// Vertical folio bands for a page: y above `top` or below `bottom` counts
+/// as page-edge. Derived from the page's visible box when known, keeping
+/// the exact historical thresholds on US-Letter-sized pages; without
+/// geometry the absolute constants apply unchanged.
+fn page_number_bands(bounds: Option<&(f32, f32)>) -> (f32, f32) {
+    match bounds {
+        Some(&(y0, y1)) if y1 - y0 > 72.0 => {
+            let scale = (y1 - y0) / PAGE_NUMBER_BAND_REFERENCE_HEIGHT;
+            (
+                y0 + PAGE_NUMBER_BOTTOM_Y * scale,
+                y0 + PAGE_NUMBER_TOP_Y * scale,
+            )
+        }
+        _ => (PAGE_NUMBER_BOTTOM_Y, PAGE_NUMBER_TOP_Y),
+    }
+}
 const SPREAD_MIN_CONTENT_WIDTH_EM: f32 = 40.0;
 const SPREAD_EDGE_FRACTION: f32 = 0.25;
 const ADJACENT_PAGE_MIN_CONTENT_WIDTH_EM: f32 = 26.0;
 
 type ContextualCandidateOccurrence = (u32, f32, Vec<(usize, u32)>);
 
-fn page_number_value(item: &TextItem) -> Option<u32> {
+fn page_number_value(item: &TextItem, page_bounds: &HashMap<u32, (f32, f32)>) -> Option<u32> {
     if !matches!(
         item.item_type,
         crate::types::ItemType::Text | crate::types::ItemType::FormField
@@ -984,10 +1006,11 @@ fn page_number_value(item: &TextItem) -> Option<u32> {
         return None;
     }
 
-    // Must be at top or bottom of page.
-    // US Letter = 792pt, A4 = 841pt. Page numbers are typically in the
-    // top ~5% or bottom ~12% of the page.
-    if item.y <= PAGE_NUMBER_TOP_Y && item.y >= PAGE_NUMBER_BOTTOM_Y {
+    // Must be at the top or bottom of the page. The bands scale with the
+    // page's real height so taller pages (A4 and up) keep the same physical
+    // margins as US Letter instead of swallowing body text.
+    let (bottom, top) = page_number_bands(page_bounds.get(&item.page));
+    if item.y <= top && item.y >= bottom {
         return None;
     }
 
@@ -1602,8 +1625,15 @@ fn page_number_context_masks(
 /// item attached to neighboring content on the same baseline is therefore kept.
 /// Complete page-number expressions such as `Page 42` remain removable even
 /// though their numeric item has lexical context.
-fn page_number_removal_mask(items: &[TextItem], document_page_count: usize) -> Vec<bool> {
-    let candidate_values: Vec<Option<u32>> = items.iter().map(page_number_value).collect();
+fn page_number_removal_mask(
+    items: &[TextItem],
+    document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
+) -> Vec<bool> {
+    let candidate_values: Vec<Option<u32>> = items
+        .iter()
+        .map(|item| page_number_value(item, page_bounds))
+        .collect();
     let (contextual, explicit_folio) =
         page_number_context_masks(items, &candidate_values, document_page_count);
 
@@ -1621,8 +1651,12 @@ fn page_number_removal_mask(items: &[TextItem], document_page_count: usize) -> V
 pub(super) fn needs_document_page_number_context(
     items: &[TextItem],
     document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> bool {
-    let candidate_values: Vec<Option<u32>> = items.iter().map(page_number_value).collect();
+    let candidate_values: Vec<Option<u32>> = items
+        .iter()
+        .map(|item| page_number_value(item, page_bounds))
+        .collect();
     let (contextual, explicit_folio) =
         page_number_context_masks(items, &candidate_values, document_page_count);
 
@@ -1640,7 +1674,7 @@ pub(crate) fn filter_markdown_page_numbers(
     items: Vec<TextItem>,
     document_page_count: u32,
 ) -> Vec<TextItem> {
-    filter_markdown_page_numbers_with_removed_pages(items, document_page_count).0
+    filter_markdown_page_numbers_with_removed_pages(items, document_page_count, &HashMap::new()).0
 }
 
 /// Filter Markdown folios while retaining the pages where items were removed.
@@ -1651,8 +1685,9 @@ pub(crate) fn filter_markdown_page_numbers(
 pub(crate) fn filter_markdown_page_numbers_with_removed_pages(
     items: Vec<TextItem>,
     document_page_count: u32,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> (Vec<TextItem>, HashSet<u32>, Vec<bool>) {
-    let remove = page_number_removal_mask(&items, document_page_count as usize);
+    let remove = page_number_removal_mask(&items, document_page_count as usize, page_bounds);
     let mut removed_pages = HashSet::new();
     let items = items
         .into_iter()
@@ -1977,7 +2012,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
             .map(|item| item.page as usize)
             .max()
             .unwrap_or(0);
-        let remove = page_number_removal_mask(&items, observed_page_count);
+        let remove = page_number_removal_mask(&items, observed_page_count, &HashMap::new());
         items
             .into_iter()
             .zip(remove)
@@ -2001,7 +2036,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
         // from changing the page's inferred layout.
         let column_detection_items: Vec<TextItem> = page_items
             .iter()
-            .filter(|item| page_number_value(item).is_none())
+            .filter(|item| page_number_value(item, &HashMap::new()).is_none())
             .cloned()
             .collect();
         let column_detection_items = column_detection_items.as_slice();
@@ -2058,7 +2093,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
                 let col_input: Vec<TextItem> = page_items
                     .iter()
                     .filter(|it| {
-                        if page_number_value(it).is_some() {
+                        if page_number_value(it, &HashMap::new()).is_some() {
                             return false;
                         }
                         let cx = it.x + it.width / 2.0;
@@ -2481,6 +2516,61 @@ mod tests {
             y -= 14.0;
         }
         items
+    }
+
+    #[test]
+    fn page_number_bands_scale_with_page_height() {
+        // US Letter keeps the exact historical thresholds.
+        assert_eq!(page_number_bands(Some(&(0.0, 792.0))), (100.0, 720.0));
+        // A4 scales both bands so the physical margins match Letter's.
+        let (bottom, top) = page_number_bands(Some(&(0.0, 841.89)));
+        assert!((bottom - 106.3).abs() < 0.1, "bottom band: {bottom}");
+        assert!((top - 765.35).abs() < 0.1, "top band: {top}");
+        // A box with a nonzero origin shifts the bands with it.
+        let (bottom, top) = page_number_bands(Some(&(100.0, 892.0)));
+        assert!((bottom - 200.0).abs() < 0.1, "offset bottom: {bottom}");
+        assert!((top - 820.0).abs() < 0.1, "offset top: {top}");
+        // Missing or degenerate geometry keeps the absolute constants.
+        assert_eq!(page_number_bands(None), (100.0, 720.0));
+        assert_eq!(page_number_bands(Some(&(0.0, 10.0))), (100.0, 720.0));
+    }
+
+    #[test]
+    fn a4_body_digits_above_the_letter_band_are_not_candidates() {
+        // Issue #283: on A4 (841.89pt) y=740 is body territory (~12% from
+        // the top), but the US-Letter constant treated it as the folio zone
+        // and deleted table row indices.
+        let a4: HashMap<u32, (f32, f32)> = HashMap::from([(1, (0.0, 841.89))]);
+        let index = make_item(1, 208.0, 740.0, "14");
+        assert_eq!(page_number_value(&index, &a4), None, "A4 y=740 is body");
+        // The same item without geometry keeps today's behavior.
+        assert_eq!(page_number_value(&index, &HashMap::new()), Some(14));
+        // A digit in A4's real top margin is still a candidate.
+        let folio = make_item(1, 297.0, 810.0, "7");
+        assert_eq!(page_number_value(&folio, &a4), Some(7));
+        // And the bottom band scales the same way: A4 y=103 is inside the
+        // scaled bottom band (106.3), so it stays a candidate.
+        let bottom = make_item(1, 297.0, 103.0, "9");
+        assert_eq!(page_number_value(&bottom, &a4), Some(9));
+    }
+
+    #[test]
+    fn letter_pages_keep_their_historical_bands() {
+        let letter: HashMap<u32, (f32, f32)> = HashMap::from([(1, (0.0, 792.0))]);
+        for (y, expect) in [
+            (740.0, Some(14)),
+            (719.0, None),
+            (99.0, Some(14)),
+            (101.0, None),
+        ] {
+            let item = make_item(1, 208.0, y, "14");
+            assert_eq!(page_number_value(&item, &letter), expect, "y={y}");
+            assert_eq!(
+                page_number_value(&item, &HashMap::new()),
+                expect,
+                "no-geometry y={y}"
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1354,6 +1354,7 @@ fn page_number_context_masks(
     items: &[TextItem],
     candidate_values: &[Option<u32>],
     document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> (Vec<bool>, Vec<bool>) {
     let mut contextual = vec![false; items.len()];
     let mut explicit_folio = vec![false; items.len()];
@@ -1502,9 +1503,12 @@ fn page_number_context_masks(
                             group.first() == Some(index) || group.last() == Some(index)
                         })
                         .collect();
+                    // The deep-margin gate uses the same scaled bands as
+                    // candidacy, so contextual folios on tall pages are
+                    // judged against their page's real margins.
                     let in_deep_margin = candidates.iter().all(|(index, _)| {
-                        items[*index].y < PAGE_NUMBER_BOTTOM_Y
-                            || items[*index].y > PAGE_NUMBER_TOP_Y
+                        let (bottom, top) = page_number_bands(page_bounds.get(&items[*index].page));
+                        items[*index].y < bottom || items[*index].y > top
                     });
                     if in_deep_margin
                         && !recurrence_candidates.is_empty()
@@ -1635,7 +1639,7 @@ fn page_number_removal_mask(
         .map(|item| page_number_value(item, page_bounds))
         .collect();
     let (contextual, explicit_folio) =
-        page_number_context_masks(items, &candidate_values, document_page_count);
+        page_number_context_masks(items, &candidate_values, document_page_count, page_bounds);
 
     candidate_values
         .iter()
@@ -1658,7 +1662,7 @@ pub(super) fn needs_document_page_number_context(
         .map(|item| page_number_value(item, page_bounds))
         .collect();
     let (contextual, explicit_folio) =
-        page_number_context_masks(items, &candidate_values, document_page_count);
+        page_number_context_masks(items, &candidate_values, document_page_count, page_bounds);
 
     candidate_values
         .iter()
@@ -2552,6 +2556,41 @@ mod tests {
         // scaled bottom band (106.3), so it stays a candidate.
         let bottom = make_item(1, 297.0, 103.0, "9");
         assert_eq!(page_number_value(&bottom, &a4), Some(9));
+    }
+
+    #[test]
+    fn contextual_deep_margin_gate_uses_the_scaled_bands() {
+        // A recurring "42 Company report" footer at A4 y=103 sits inside the
+        // scaled bottom band (106.3) but outside the Letter constant (100).
+        // The repeated-folio gate must judge it with the same scaled bands
+        // as candidacy, so the advancing footer number is still recognized.
+        let a4: HashMap<u32, (f32, f32)> = HashMap::from([
+            (1, (0.0, 841.89)),
+            (2, (0.0, 841.89)),
+            (3, (0.0, 841.89)),
+            (4, (0.0, 841.89)),
+            (5, (0.0, 841.89)),
+        ]);
+        let mut items = Vec::new();
+        for page in 1..=5u32 {
+            items.push(make_item(page, 72.0, 103.0, &format!("{}", 41 + page)));
+            items.push(make_item(page, 90.0, 103.0, "Company report"));
+            items.push(make_item(page, 72.0, 500.0, "Body content that stays"));
+        }
+        let mask = page_number_removal_mask(&items, 5, &a4);
+        for page in 0..5usize {
+            assert!(
+                mask[page * 3],
+                "advancing footer folio on page {} strips",
+                page + 1
+            );
+            assert!(!mask[page * 3 + 2], "body content survives");
+        }
+        // Without geometry the y=103 candidates are body (above the absolute
+        // 100pt band), so nothing strips - the gate stays consistent with
+        // candidacy in both modes.
+        let mask = page_number_removal_mask(&items, 5, &HashMap::new());
+        assert!(mask.iter().all(|&removed| !removed));
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -204,7 +204,11 @@ fn extract_positioned_text_with_folio_context_impl(
         include_invisible,
         None,
     )?;
-    if !layout::needs_document_page_number_context(&selected_items, doc.get_pages().len()) {
+    if !layout::needs_document_page_number_context(
+        &selected_items,
+        doc.get_pages().len(),
+        &page_vertical_bounds(doc),
+    ) {
         return Ok((
             (selected_items, selected_rects, selected_lines),
             page_thresholds,
@@ -1162,6 +1166,18 @@ pub(crate) fn get_number(obj: &Object) -> Option<f32> {
         Object::Real(r) => Some(*r),
         _ => None,
     }
+}
+
+/// Vertical extent (y0, y1) of each page's visible box, for scaling the
+/// page-number bands to the page's real height. Pages without a resolvable
+/// box are absent, which keeps the calibrated absolute bands for them.
+pub(crate) fn page_vertical_bounds(doc: &Document) -> HashMap<u32, (f32, f32)> {
+    doc.get_pages()
+        .into_iter()
+        .filter_map(|(page_num, page_id)| {
+            get_page_box(doc, page_id).map(|(_, y0, _, y1)| (page_num, (y0, y1)))
+        })
+        .collect()
 }
 
 /// Visible page box: CropBox if present, else MediaBox, walking page-tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,11 @@ pub fn extract_pages_markdown_mem(
     // Per-page Markdown receives the original items plus these decisions so
     // table detection can retain legitimate numeric cells.
     let (filtered_items, removed_page_number_pages, page_number_removal_mask) =
-        extractor::filter_markdown_page_numbers_with_removed_pages(all_items.clone(), page_count);
+        extractor::filter_markdown_page_numbers_with_removed_pages(
+            all_items.clone(),
+            page_count,
+            &extractor::page_vertical_bounds(&doc),
+        );
 
     // Tables need the original numeric cells; columns use folio-cleaned
     // evidence so removed page numbers cannot create false layout metadata.
@@ -3952,6 +3956,7 @@ fn process_document(
                 items,
                 page_count,
                 options.page_filter.as_ref(),
+                &extractor::page_vertical_bounds(&doc),
             );
 
             let text_quality = analyze_text_quality(&items);
@@ -5753,9 +5758,14 @@ fn select_items_with_document_folio_context(
     all_items: Vec<types::TextItem>,
     page_count: u32,
     page_filter: Option<&HashSet<u32>>,
+    page_bounds: &std::collections::HashMap<u32, (f32, f32)>,
 ) -> FolioFilteredItems {
     let (all_layout_items, all_removed_pages, all_removal_mask) =
-        extractor::filter_markdown_page_numbers_with_removed_pages(all_items.clone(), page_count);
+        extractor::filter_markdown_page_numbers_with_removed_pages(
+            all_items.clone(),
+            page_count,
+            page_bounds,
+        );
     let selected_page = |page: u32| page_filter.is_none_or(|filter| filter.contains(&page));
 
     let (items, removal_mask) = all_items
@@ -6127,8 +6137,11 @@ mod tests {
             test_item("1", 25.0, 20.0, 12.0, 10.0),
             test_item("2", 520.0, 60.0, 12.0, 10.0),
         ];
-        let (filtered, _, _) =
-            extractor::filter_markdown_page_numbers_with_removed_pages(items.clone(), 1);
+        let (filtered, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
+            items.clone(),
+            1,
+            &std::collections::HashMap::new(),
+        );
         assert!(filtered.is_empty());
 
         let filtered = compute_layout_complexity(&items, &filtered, &[], &[]);
@@ -6220,16 +6233,23 @@ mod tests {
             .filter(|item| item.page == 1)
             .cloned()
             .collect();
-        let (page_local_layout, _, _) =
-            extractor::filter_markdown_page_numbers_with_removed_pages(page_one_items.clone(), 4);
+        let (page_local_layout, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
+            page_one_items.clone(),
+            4,
+            &std::collections::HashMap::new(),
+        );
         let page_local = compute_layout_complexity(&page_one_items, &page_local_layout, &[], &[]);
         assert!(
             page_local.pages_with_columns.contains(&1),
             "fixture must reproduce page-local folio column evidence"
         );
 
-        let selected =
-            select_items_with_document_folio_context(items, 4, Some(&HashSet::from([1])));
+        let selected = select_items_with_document_folio_context(
+            items,
+            4,
+            Some(&HashSet::from([1])),
+            &std::collections::HashMap::new(),
+        );
         assert_eq!(
             selected
                 .removal_mask

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1815,6 +1815,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         crate::extractor::filter_markdown_page_numbers_with_removed_pages(
             non_table_items.into_iter().map(|(_, item)| item).collect(),
             document_page_count,
+            &std::collections::HashMap::new(),
         )
         .0
     };


### PR DESCRIPTION
Fixes #283 — building directly on @IngLP's excellent diagnosis.

## What

`page_number_value` gated folio candidates on absolute Y constants calibrated
for US Letter (`PAGE_NUMBER_TOP_Y = 720.0` of a 792pt page — the top inch).
On taller pages the band grows past the intended physical margin: on A4
(841.89pt) it covers the top **~122pt, roughly eight lines of body text**, so
short digit-only tokens there — table row indices, year column headers, risk
scale steps — were silently deleted as folios while the output stayed
structurally valid.

This PR scales both bands by the page's visible-box height (CropBox, else
MediaBox, via the existing `get_page_box`), threading a per-page `(y0, y1)`
map from the document into the folio filters:

- **US Letter keeps the exact historical thresholds** (scale = 1.0) — no
  behavior change for the calibrated case, so the existing corpus semantics
  are preserved.
- A4's top band becomes y > 765.35 (the same physical inch), bottom
  y < 106.3; boxes with a nonzero origin shift with it.
- Pages without resolvable geometry — and the item-only grouping path that
  has no document access — keep the absolute constants, so behavior degrades
  to exactly today's, never something new.

## One note on the repro

The issue's synthetic repro (18pt column gap) is already rescued on current
`main` by the baseline-context grouping, but the underlying miscalibration
still fires whenever the digit's neighbor sits beyond the 1.5-em context gap
— which is precisely the reported real-world shape (an index column beside a
percentage column):

```
A4, rows at y=740/725:  "14 | 87.00%"  →  "87.00%"     (index deleted, main)
                                       →  "14 | 87.00%" (this PR)
```

Verified with generated single-page PDFs on both paper sizes:

| Case | main | this PR |
|---|---|---|
| A4, `14` + far column at y=740 (body) | index **deleted** | kept |
| A4, lone `7` at y=810 (real top margin) | stripped | stripped |
| Letter, `14` + far column at y=740 (folio zone) | stripped | stripped (unchanged) |

## Tests

- `page_number_bands_scale_with_page_height` — Letter identity, A4 scaling,
  nonzero-origin boxes, missing/degenerate geometry fallback.
- `a4_body_digits_above_the_letter_band_are_not_candidates` — the issue's
  case; also pins that A4's real top margin still yields candidates and that
  the bottom band scales symmetrically.
- `letter_pages_keep_their_historical_bands` — boundary values (99/101,
  719/740) identical with and without geometry.
- Full suite: 822 lib tests + 152 + integration all pass; `cargo fmt`,
  `clippy -D warnings`, wasm target check/clippy, and the developer-script
  tests are green. No existing test needed its expectations changed —
  Letter-calibrated behavior is untouched by construction.

## Not included (possible follow-ups from the issue)

- The same-baseline-neighbor hardening (suggested fix 2) — the context
  grouping already covers gaps up to 1.5em; widening it is a behavior change
  for Letter documents too, so it deserves its own discussion.
- Exposing the removal as an option on `PdfOptions`/bindings — orthogonal
  API surface, better decided by maintainers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788633172&installation_model_id=11126&pr_number=287&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F287&signature=cd4121185ed18094e8e0c46e9b0b06861f6e14b78300638b8c53cb3f560591eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale page-number detection bands by each page’s real height so taller pages (like A4) keep the same physical margins, and apply the same bands to contextual folio checks. This prevents accidental removal of digit-only body text near the top/bottom; US Letter behavior is unchanged and pages without geometry fall back to existing constants.

- **Bug Fixes**
  - Scale top/bottom folio bands using per-page visible-box height; A4 now uses inch-equivalent thresholds.
  - Use the same scaled bands in the deep-margin recurrence gate so repeated folios on tall pages are recognized; fall back to absolute constants when geometry is missing or in item-only paths.
  - Thread per-page `(y0, y1)` into folio filters and selection; add tests for Letter identity, A4 scaling, nonzero origins, missing geometry, and the contextual-gate consistency.

<sup>Written for commit 73d77efa2c3b3887a08fec7491b2a9eef3eef1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

