### PR TITLE
Add minimal runnable OCR routing threshold examples

### DIFF
--- a/docs/ocr-routing-thresholds.md
+++ b/docs/ocr-routing-thresholds.md
@@ -1,0 +1,39 @@
+# OCR routing thresholds and confidence
+
+`pdf-inspector` returns a document-level confidence score in `0.0-1.0` and a list of pages that should be sent to OCR. The score estimates how likely the document can be extracted as native text.
+
+## Default behavior
+
+The default routing thresholds are:
+
+- `text_based_min_confidence: 0.85`
+- `needs_ocr_max_confidence: 0.35`
+- `mixed_page_threshold: 0.25`
+
+A document with confidence at least `0.85` is normally treated as text-based. A document at or below `0.35` is treated as scanned/image-based. Values between the two are candidates for mixed routing, and per-page signals decide which pages need OCR. `mixed_page_threshold` is the fraction of pages that must disagree before the document is labeled mixed.
+
+## Examples
+
+Run the Python example:
+
+```bash
+python examples/ocr_routing_thresholds.py tests/fixtures/thermo-freon12.pdf
+```
+
+Run the Node example after building the NAPI package:
+
+```bash
+node examples/ocr_routing_thresholds.mjs tests/fixtures/thermo-freon12.pdf
+```
+
+Both examples print the document class, confidence, and pages needing OCR. They also pass threshold overrides where the binding supports them; older bindings fall back to default routing.
+
+## Recommended presets
+
+- Avoid OCR costs: keep `text_based_min_confidence` near `0.85` and `needs_ocr_max_confidence` near `0.35`.
+- Maximize extraction reliability: raise `text_based_min_confidence` toward `0.95` so uncertain pages are routed to OCR.
+- Reduce OCR for mostly scanned documents: lower `needs_ocr_max_confidence` toward `0.25` only if false text detection is acceptable.
+
+## Compatibility
+
+The `0.0-1.0` confidence range and the route names are stable. Documented default thresholds are a behavior contract; changing defaults should be handled as a behavior-breaking change.

--- a/examples/ocr_routing_thresholds.mjs
+++ b/examples/ocr_routing_thresholds.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Minimal OCR routing example for pdf-inspector.
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { classifyPdf, processPdf } from '../napi/index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pdfPath = process.argv[2] || join(here, '..', 'tests', 'fixtures', 'thermo-freon12.pdf');
+const buffer = readFileSync(pdfPath);
+
+const thresholds = {
+  textBasedMinConfidence: 0.85,
+  needsOcrMaxConfidence: 0.35,
+  mixedPageThreshold: 0.25,
+};
+
+let result;
+try {
+  result = classifyPdf(buffer, { thresholds });
+} catch {
+  result = processPdf(buffer);
+}
+
+const pdfType = result.pdfType || result.pdf_type || 'unknown';
+const confidence = result.confidence;
+const pages = result.pagesNeedingOcr || result.pages_needing_ocr || [];
+
+console.log(`PDF: ${pdfPath}`);
+console.log(`Document class: ${pdfType}`);
+console.log(`Confidence: ${confidence}`);
+console.log(`Pages needing OCR: ${JSON.stringify(pages)}`);
+console.log(`Thresholds requested: ${JSON.stringify(thresholds)}`);

--- a/examples/ocr_routing_thresholds.py
+++ b/examples/ocr_routing_thresholds.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Minimal OCR routing example for pdf-inspector.
+from argparse import ArgumentParser
+from pathlib import Path
+import pdf_inspector
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PDF = ROOT / 'tests' / 'fixtures' / 'thermo-freon12.pdf'
+
+
+def field(obj, *names, default=None):
+    for name in names:
+        if isinstance(obj, dict) and name in obj:
+            return obj[name]
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return default
+
+
+def call_inspector(pdf_path, thresholds):
+    # Newer bindings may accept configurable thresholds. Older bindings
+    # fall back to the stable single-argument call.
+    try:
+        return pdf_inspector.classify_pdf(str(pdf_path), thresholds=thresholds)
+    except (AttributeError, TypeError):
+        pass
+    try:
+        return pdf_inspector.process_pdf(str(pdf_path), thresholds=thresholds)
+    except (AttributeError, TypeError):
+        pass
+    try:
+        return pdf_inspector.classify_pdf(str(pdf_path))
+    except (AttributeError, TypeError):
+        pass
+    return pdf_inspector.process_pdf(str(pdf_path))
+
+
+def main():
+    parser = ArgumentParser(description='Show pdf-inspector confidence and OCR routing.')
+    parser.add_argument('pdf', nargs='?', default=str(DEFAULT_PDF))
+    parser.add_argument('--text-min', type=float, default=0.85)
+    parser.add_argument('--ocr-max', type=float, default=0.35)
+    parser.add_argument('--mixed-page-threshold', type=float, default=0.25)
+    args = parser.parse_args()
+
+    thresholds = {
+        'text_based_min_confidence': args.text_min,
+        'needs_ocr_max_confidence': args.ocr_max,
+        'mixed_page_threshold': args.mixed_page_threshold,
+    }
+    result = call_inspector(Path(args.pdf), thresholds)
+
+    pdf_type = field(result, 'pdf_type', 'pdfType', default='unknown')
+    confidence = field(result, 'confidence', default=None)
+    pages = field(result, 'pages_needing_ocr', 'pagesNeedingOcr', default=[])
+
+    print(f'PDF: {args.pdf}')
+    print(f'Document class: {pdf_type}')
+    print(f'Confidence: {confidence}')
+    print(f'Pages needing OCR: {pages}')
+    print('Thresholds requested: '
+          f'text_min={args.text_min}, '
+          f'ocr_max={args.ocr_max}, '
+          f'mixed_page_threshold={args.mixed_page_threshold}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds Python and Node example scripts plus a short doc page for confidence scores and OCR routing thresholds. The examples are intentionally small and runnable against the bundled fixture, and they fall back gracefully when a binding does not yet expose threshold overrides.

Addresses #266

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693938&installation_model_id=11126&pr_number=295&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F295&signature=2297bf5646d57c60ae43ba9b49bdd3eb400a4cffa5359f0a22004c7839f6ebd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds minimal Python and Node examples for OCR routing thresholds and confidence, plus a short doc explaining defaults and presets. Helps users tune OCR routing and understand confidence scores. Addresses #266.

- **New Features**
  - Added `examples/ocr_routing_thresholds.py` and `examples/ocr_routing_thresholds.mjs` that run against `tests/fixtures/thermo-freon12.pdf`, print document class, confidence, and pages needing OCR, and request threshold overrides with graceful fallback when unsupported.
  - Added `docs/ocr-routing-thresholds.md` covering default thresholds, recommended presets, and compatibility for `pdf-inspector`.

<sup>Written for commit d125ba0ef94f6629a0f11423422b38d6ca374044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

