### PR TITLE
fix: reassemble 90°-rotated text runs on mostly-horizontal pages

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -1396,6 +1396,14 @@ const ROTATED_MAX_ADVANCE: f32 = 3.0;
 /// Below this, a column of narrow items is likelier bullets or rule artifacts
 /// than a rotated label.
 const ROTATED_MIN_GLYPHS: usize = 3;
+/// Largest share of a page's items that may be zero-width and still be read as
+/// rotation. A page whose fonts carry no width data reports *everything* as
+/// zero-width, and there a column of short items is ordinary content — a list,
+/// a column of single-letter marks — that must not be fused. Two-thirds mirrors
+/// [`correct_rotated_page`]'s own threshold: a page past that point is a rotated
+/// page and was already corrected, so anything reaching here is a minority of
+/// rotated text on an otherwise horizontal page.
+const ROTATED_MAX_SHARE: f32 = 2.0 / 3.0;
 
 /// Merge each 90°-rotated text run into one horizontal-looking item.
 ///
@@ -1425,7 +1433,10 @@ fn merge_rotated_runs(items: Vec<TextItem>) -> Vec<TextItem> {
                 && item.text.chars().count() <= 2
         })
         .collect();
-    if candidates.len() < ROTATED_MIN_GLYPHS {
+    let visible = items.iter().filter(|i| !i.text.trim().is_empty()).count();
+    if candidates.len() < ROTATED_MIN_GLYPHS
+        || candidates.len() as f32 > visible as f32 * ROTATED_MAX_SHARE
+    {
         return drop_blank_items(items);
     }
     candidates.sort_by(|&a, &b| {
@@ -1440,7 +1451,12 @@ fn merge_rotated_runs(items: Vec<TextItem>) -> Vec<TextItem> {
     let mut run: Vec<usize> = Vec::new();
     for &idx in &candidates {
         // x against the run's start, not its previous glyph, so tolerance cannot
-        // accumulate into a walk across columns.
+        // accumulate into a walk across columns. Emphasis must hold too: the
+        // merged item carries one set of metadata, so a run spanning a bold or
+        // italic boundary would flatten it. Font resource and exact size are
+        // deliberately *not* compared — real runs switch subset fonts mid-label
+        // and their rendered size differs in the last float bit, and splitting
+        // on either shatters the run into pieces too short to merge at all.
         let continues = match (run.first(), run.last()) {
             (Some(&start), Some(&previous)) => {
                 (items[idx].x - items[start].x).abs() <= ROTATED_X_TOLERANCE
@@ -1470,12 +1486,14 @@ fn merge_rotated_runs(items: Vec<TextItem>) -> Vec<TextItem> {
         let first = &items[run[0]];
         let font_size = first.font_size;
         let text: String = run.iter().map(|&i| items[i].text.as_str()).collect();
+        let last = &items[run[run.len() - 1]];
         merged.insert(
             run[0],
             TextItem {
                 text: text.trim().to_string(),
                 x: first.x - font_size,
                 width: font_size,
+                height: (last.y - first.y).abs() + font_size,
                 ..first.clone()
             },
         );
@@ -1667,6 +1685,35 @@ mod tests {
         assert!((header.x - (164.25 - 9.0)).abs() < 0.01, "x = {}", header.x);
         assert!((header.width - 9.0).abs() < 0.01, "width = {}", header.width);
         assert!((header.y - 300.0).abs() < 0.01, "y = {}", header.y);
+    }
+
+    #[test]
+    fn test_merge_rotated_runs_skips_page_without_font_widths() {
+        // No font widths means *every* item is zero-width, rotated or not. A
+        // column of short items on such a page is ordinary content — here a list
+        // — and fusing it would destroy the page.
+        let marker = |text: &str, y: f32| TextItem {
+            text: text.to_string(),
+            x: 72.0,
+            y,
+            width: 0.0,
+            height: 10.0,
+            font: "F1".to_string(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+        let items = vec![marker("1.", 100.0), marker("2.", 115.0), marker("3.", 130.0)];
+
+        let merged = merge_rotated_runs(items);
+
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[0].text, "1.");
     }
 
     #[test]

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -1396,14 +1396,7 @@ const ROTATED_MAX_ADVANCE: f32 = 3.0;
 /// Below this, a column of narrow items is likelier bullets or rule artifacts
 /// than a rotated label.
 const ROTATED_MIN_GLYPHS: usize = 3;
-/// Largest share of a page's items that may be zero-width and still be read as
-/// rotation. A page whose fonts carry no width data reports *everything* as
-/// zero-width, and there a column of short items is ordinary content — a list,
-/// a column of single-letter marks — that must not be fused. Two-thirds mirrors
-/// [`correct_rotated_page`]'s own threshold: a page past that point is a rotated
-/// page and was already corrected, so anything reaching here is a minority of
-/// rotated text on an otherwise horizontal page.
-const ROTATED_MAX_SHARE: f32 = 2.0 / 3.0;
+
 
 /// Merge each 90°-rotated text run into one horizontal-looking item.
 ///
@@ -1433,10 +1426,14 @@ fn merge_rotated_runs(items: Vec<TextItem>) -> Vec<TextItem> {
                 && item.text.chars().count() <= 2
         })
         .collect();
-    let visible = items.iter().filter(|i| !i.text.trim().is_empty()).count();
-    if candidates.len() < ROTATED_MIN_GLYPHS
-        || candidates.len() as f32 > visible as f32 * ROTATED_MAX_SHARE
-    {
+    // Zero width means "rotated" only on a page that reports widths at all. A
+    // page whose fonts carry none reports *everything* as zero-width, and there a
+    // column of short items is ordinary content — a list, a column of
+    // single-letter marks — that must not be fused. One sized item is enough
+    // evidence, so a page with a single line of body text beside its rotated
+    // headers still qualifies.
+    let has_width_data = items.iter().any(|item| item.width >= ROTATED_MAX_WIDTH);
+    if candidates.len() < ROTATED_MIN_GLYPHS || !has_width_data {
         return drop_blank_items(items);
     }
     candidates.sort_by(|&a, &b| {
@@ -1687,16 +1684,12 @@ mod tests {
         assert!((header.y - 300.0).abs() < 0.01, "y = {}", header.y);
     }
 
-    #[test]
-    fn test_merge_rotated_runs_skips_page_without_font_widths() {
-        // No font widths means *every* item is zero-width, rotated or not. A
-        // column of short items on such a page is ordinary content — here a list
-        // — and fusing it would destroy the page.
-        let marker = |text: &str, y: f32| TextItem {
+    fn page_item(text: &str, x: f32, y: f32, width: f32) -> TextItem {
+        TextItem {
             text: text.to_string(),
-            x: 72.0,
+            x,
             y,
-            width: 0.0,
+            width,
             height: 10.0,
             font: "F1".to_string(),
             font_size: 10.0,
@@ -1707,8 +1700,19 @@ mod tests {
             is_strikeout: false,
             item_type: ItemType::Text,
             mcid: None,
-        };
-        let items = vec![marker("1.", 100.0), marker("2.", 115.0), marker("3.", 130.0)];
+        }
+    }
+
+    #[test]
+    fn test_merge_rotated_runs_skips_page_without_font_widths() {
+        // No font widths means *every* item is zero-width, rotated or not. A
+        // column of short items on such a page is ordinary content — here a list
+        // — and fusing it would destroy the page.
+        let items = vec![
+            page_item("1.", 72.0, 100.0, 0.0),
+            page_item("2.", 72.0, 115.0, 0.0),
+            page_item("3.", 72.0, 130.0, 0.0),
+        ];
 
         let merged = merge_rotated_runs(items);
 
@@ -1717,31 +1721,39 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_rotated_runs_keeps_multi_char_column() {
-        // Zero width also means "font carries no widths". Such a page is whole
-        // lines stacked at one x, not glyphs — merging it would fuse paragraphs.
-        let line = |text: &str, y: f32| TextItem {
-            text: text.to_string(),
-            x: 72.0,
-            y,
-            width: 0.0,
-            height: 10.0,
-            font: "F1".to_string(),
-            font_size: 10.0,
-            page: 1,
-            is_bold: false,
-            is_italic: false,
-            is_underline: false,
-            is_strikeout: false,
-            item_type: ItemType::Text,
-            mcid: None,
-        };
-        let items = vec![line("first", 100.0), line("second", 112.0), line("third", 124.0)];
+    fn test_merge_rotated_runs_handles_a_nearly_empty_page() {
+        // One sized item is enough evidence that widths exist, so a minimal
+        // rotated run still collates even where it outnumbers the rest of the page.
+        let items = vec![
+            page_item("Total", 300.0, 400.0, 26.0),
+            page_item("k", 72.0, 100.0, 0.0),
+            page_item("g", 72.0, 106.0, 0.0),
+            page_item("/", 72.0, 112.0, 0.0),
+        ];
 
         let merged = merge_rotated_runs(items);
 
-        assert_eq!(merged.len(), 3);
-        assert_eq!(merged[0].text, "first");
+        let texts: Vec<&str> = merged.iter().map(|i| i.text.as_str()).collect();
+        assert!(texts.contains(&"kg/"), "got {texts:?}");
+        assert_eq!(merged.len(), 2, "got {texts:?}");
+    }
+
+    #[test]
+    fn test_merge_rotated_runs_keeps_multi_char_column() {
+        // One font on the page carries no widths while another does, so the
+        // page-level width evidence does not save us: whole lines stacked at one
+        // x are not glyphs, and merging them would fuse paragraphs.
+        let items = vec![
+            page_item("Heading", 72.0, 200.0, 40.0),
+            page_item("first", 72.0, 100.0, 0.0),
+            page_item("second", 72.0, 112.0, 0.0),
+            page_item("third", 72.0, 124.0, 0.0),
+        ];
+
+        let merged = merge_rotated_runs(items);
+
+        assert_eq!(merged.len(), 4);
+        assert_eq!(merged[1].text, "first");
     }
 
     #[test]

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -20,7 +20,7 @@ use super::fonts::{
 };
 use super::underline::UnderlineLine;
 use super::xobjects::{extract_form_xobject_text, get_page_xobjects, XObjectType};
-use super::{get_number, image_bbox_from_ctm, multiply_matrices};
+use super::{emits_text_item, get_number, image_bbox_from_ctm, multiply_matrices};
 
 /// Strip PDF comments (% to end of line) from content stream bytes.
 ///
@@ -529,9 +529,7 @@ pub(crate) fn extract_page_text_items(
                         } else {
                             0.0
                         };
-                        // Only create text item for non-whitespace; whitespace
-                        // still advances the text matrix above so gap detection works
-                        if !text.trim().is_empty() {
+                        if emits_text_item(&text, &combined) {
                             let base_font = font_base_names
                                 .get(&current_font)
                                 .map(|s| s.as_str())
@@ -675,12 +673,12 @@ pub(crate) fn extract_page_text_items(
                             }
                         }
                         // Flush remaining text
-                        if !is_invisible && !current_text.trim().is_empty() {
+                        let combined = multiply_matrices(&text_matrix, &ctm);
+                        if !is_invisible && emits_text_item(&current_text, &combined) {
                             sub_items.push((current_text, sub_start_width_ts, total_width_ts));
                         }
                         // Emit one TextItem per sub-item
                         if !sub_items.is_empty() {
-                            let combined = multiply_matrices(&text_matrix, &ctm);
                             if combined[0].abs() >= combined[1].abs() {
                                 rotation_votes.horizontal += 1;
                             } else {
@@ -786,9 +784,9 @@ pub(crate) fn extract_page_text_items(
                         &mut cmap_decisions,
                         &font_widths,
                     ) {
-                        if !text.trim().is_empty() {
-                            let combined =
-                                multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
+                        let combined =
+                            multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
+                        if emits_text_item(&text, &combined) {
                             if combined[0].abs() >= combined[1].abs() {
                                 rotation_votes.horizontal += 1;
                             } else {
@@ -1286,8 +1284,12 @@ pub(crate) fn extract_page_text_items(
     // Some PDFs embed landscape content in portrait pages using a rotated text
     // matrix (e.g. [0, b, -b, 0, tx, ty] for 90° CCW).  The layout engine
     // assumes x=horizontal, y=vertical — so we swap coordinates to match.
-    let (mut items, rects, lines, coords_rotated) =
+    let (items, rects, lines, coords_rotated) =
         correct_rotated_page(items, rects, lines, &rotation_votes);
+    // Before any line grouping or item joining: a scattered rotated run must be
+    // whole again or `merge_text_items` steals its glyphs into neighbouring
+    // horizontal text.
+    let mut items = merge_rotated_runs(items);
     if coords_rotated {
         rotate_underline_graphics(&mut underline_rects, &mut underline_lines);
     }
@@ -1380,6 +1382,122 @@ fn correct_rotated_page(
     }
 
     (items, rects, lines, true)
+}
+
+/// Rotated glyphs come out zero-width: the advance is measured along the text
+/// x-axis, which a 90° matrix maps entirely onto device y.
+const ROTATED_MAX_WIDTH: f32 = 0.5;
+/// Glyphs of one rotated line share a baseline x exactly; this absorbs float noise.
+const ROTATED_X_TOLERANCE: f32 = 0.6;
+/// Largest advance between consecutive glyphs of a run, in font sizes. Wide
+/// enough for the heavy letter-spacing these headers use, tight enough to keep
+/// two labels stacked in one column apart.
+const ROTATED_MAX_ADVANCE: f32 = 3.0;
+/// Below this, a column of narrow items is likelier bullets or rule artifacts
+/// than a rotated label.
+const ROTATED_MIN_GLYPHS: usize = 3;
+
+/// Merge each 90°-rotated text run into one horizontal-looking item.
+///
+/// A rotated run advances along device y at a fixed x, so line grouping drops
+/// one glyph into every row band and parallel runs interleave — `Raw material`
+/// beside `supply` comes out smeared across a dozen cells as
+/// `e t a y l m p w p a u R s`. [`correct_rotated_page`] only rescues pages that
+/// are *entirely* rotated; a few rotated headers on an otherwise horizontal page
+/// sit far below its vote threshold.
+///
+/// Reading order is y-ascending and the glyph bodies hang left of the baseline,
+/// both of which assume 90° CCW — the same assumption `correct_rotated_page`
+/// already encodes.
+///
+/// Extraction keeps whitespace-only items for rotated matrices so word breaks
+/// survive into the merge; this pass owns them, and drops any it does not
+/// consume so the rest of the pipeline still never sees a blank item.
+fn merge_rotated_runs(items: Vec<TextItem>) -> Vec<TextItem> {
+    let mut candidates: Vec<usize> = (0..items.len())
+        .filter(|&i| {
+            let item = &items[i];
+            item.width < ROTATED_MAX_WIDTH
+                && item.font_size > 0.0
+                && !item.text.is_empty()
+                // One glyph per item is the pathology. Multi-character items at
+                // one x are ordinary lines on a page whose fonts carry no widths.
+                && item.text.chars().count() <= 2
+        })
+        .collect();
+    if candidates.len() < ROTATED_MIN_GLYPHS {
+        return drop_blank_items(items);
+    }
+    candidates.sort_by(|&a, &b| {
+        items[a]
+            .x
+            .total_cmp(&items[b].x)
+            .then(items[a].y.total_cmp(&items[b].y))
+            .then(a.cmp(&b))
+    });
+
+    let mut runs: Vec<Vec<usize>> = Vec::new();
+    let mut run: Vec<usize> = Vec::new();
+    for &idx in &candidates {
+        // x against the run's start, not its previous glyph, so tolerance cannot
+        // accumulate into a walk across columns.
+        let continues = match (run.first(), run.last()) {
+            (Some(&start), Some(&previous)) => {
+                (items[idx].x - items[start].x).abs() <= ROTATED_X_TOLERANCE
+                    && items[idx].y - items[previous].y
+                        <= ROTATED_MAX_ADVANCE * items[previous].font_size
+            }
+            _ => false,
+        };
+        if !continues {
+            let finished = std::mem::take(&mut run);
+            if finished.len() >= ROTATED_MIN_GLYPHS {
+                runs.push(finished);
+            }
+        }
+        run.push(idx);
+    }
+    if run.len() >= ROTATED_MIN_GLYPHS {
+        runs.push(run);
+    }
+    if runs.is_empty() {
+        return drop_blank_items(items);
+    }
+
+    let mut merged: HashMap<usize, TextItem> = HashMap::new();
+    let mut absorbed = vec![false; items.len()];
+    for run in &runs {
+        let first = &items[run[0]];
+        let font_size = first.font_size;
+        let text: String = run.iter().map(|&i| items[i].text.as_str()).collect();
+        merged.insert(
+            run[0],
+            TextItem {
+                text: text.trim().to_string(),
+                x: first.x - font_size,
+                width: font_size,
+                ..first.clone()
+            },
+        );
+        for &i in &run[1..] {
+            absorbed[i] = true;
+        }
+    }
+
+    let rebuilt: Vec<TextItem> = items
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !absorbed[*i])
+        .map(|(i, item)| merged.remove(&i).unwrap_or(item))
+        .collect();
+    drop_blank_items(rebuilt)
+}
+
+/// Whitespace-only items exist only to carry word breaks into
+/// [`merge_rotated_runs`]; nothing downstream expects them.
+fn drop_blank_items(mut items: Vec<TextItem>) -> Vec<TextItem> {
+    items.retain(|item| !item.text.trim().is_empty());
+    items
 }
 
 fn rotate_underline_graphics(rects: &mut [PdfRect], lines: &mut [UnderlineLine]) {
@@ -1508,6 +1626,75 @@ mod tests {
         )
         .unwrap();
         items
+    }
+
+    /// Two 90°-CCW column headers side by side, each glyph placed by its own
+    /// `Tm` — the shape every rotated table header has. The horizontal module
+    /// row is not decoration: it keeps the page under `correct_rotated_page`'s
+    /// two-thirds vote threshold, which is the case this merge exists for.
+    fn rotated_header_content() -> Vec<u8> {
+        let mut content = String::from("BT\n/F1 9 Tf\n");
+        for (x, glyphs) in [(164.25_f32, "Use phase"), (300.0, "Total")] {
+            for (i, glyph) in glyphs.chars().enumerate() {
+                let y = 300.0 + i as f32 * 6.0;
+                content.push_str(&format!("0 1 -1 0 {x} {y} Tm ({glyph}) Tj\n"));
+            }
+        }
+        for (i, label) in ["A1", "A2", "A3", "A4", "A5", "B1", "B2", "C1", "C2", "D"]
+            .iter()
+            .enumerate()
+        {
+            let y = 200.0 - i as f32 * 20.0;
+            content.push_str(&format!("1 0 0 1 100 {y} Tm ({label}) Tj\n"));
+        }
+        // A horizontal blank still gets dropped.
+        content.push_str("1 0 0 1 140 200 Tm ( ) Tj\nET\n");
+        content.into_bytes()
+    }
+
+    #[test]
+    fn test_rotated_column_headers_merge_into_one_item() {
+        let items = extract_simple_items(&rotated_header_content());
+        let texts: Vec<&str> = items.iter().map(|i| i.text.as_str()).collect();
+
+        assert!(texts.contains(&"Use phase"), "got {texts:?}");
+        assert!(texts.contains(&"Total"), "got {texts:?}");
+        // No glyph left scattered and no blank leaked past the merge.
+        assert_eq!(items.len(), 12, "got {texts:?}");
+
+        let header = items.iter().find(|i| i.text == "Use phase").unwrap();
+        // 90° CCW hangs the glyph bodies left of the baseline.
+        assert!((header.x - (164.25 - 9.0)).abs() < 0.01, "x = {}", header.x);
+        assert!((header.width - 9.0).abs() < 0.01, "width = {}", header.width);
+        assert!((header.y - 300.0).abs() < 0.01, "y = {}", header.y);
+    }
+
+    #[test]
+    fn test_merge_rotated_runs_keeps_multi_char_column() {
+        // Zero width also means "font carries no widths". Such a page is whole
+        // lines stacked at one x, not glyphs — merging it would fuse paragraphs.
+        let line = |text: &str, y: f32| TextItem {
+            text: text.to_string(),
+            x: 72.0,
+            y,
+            width: 0.0,
+            height: 10.0,
+            font: "F1".to_string(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+        let items = vec![line("first", 100.0), line("second", 112.0), line("third", 124.0)];
+
+        let merged = merge_rotated_runs(items);
+
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[0].text, "first");
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -568,6 +568,18 @@ pub(crate) fn image_bbox_from_ctm(ctm: &[f32; 6]) -> (f32, f32, f32, f32) {
     (x_min, y_min, x_max - x_min, y_max - y_min)
 }
 
+/// Whether a text-showing operator's output becomes a [`TextItem`].
+///
+/// Whitespace-only runs are normally dropped: the text matrix has already
+/// advanced, so horizontal gap detection recreates the space. A rotated run has
+/// no such fallback — it is rebuilt glyph by glyph by `merge_rotated_runs`, and
+/// under the letter-spacing rotated labels use, a space advance is smaller than
+/// an ordinary letter's, so no gap threshold can recover the word break. Blanks
+/// that pass here and go unconsumed are dropped by that same pass.
+pub(crate) fn emits_text_item(text: &str, combined: &[f32; 6]) -> bool {
+    !text.is_empty() && (!text.trim().is_empty() || combined[0].abs() < combined[1].abs())
+}
+
 /// Multiply two 2D transformation matrices
 /// Matrix format: [a, b, c, d, e, f] representing:
 /// | a  b  0 |
@@ -1210,6 +1222,22 @@ mod tests {
     use crate::text_utils::{is_cjk_char, is_rtl_char, is_rtl_text, sort_line_items};
     use crate::types::{ItemType, PdfLine, TextLine};
     use layout::{detect_columns, is_newspaper_layout, ColumnRegion};
+
+    #[test]
+    fn test_emits_text_item() {
+        let horizontal = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+        let rotated_ccw = [0.0, 1.0, -1.0, 0.0, 0.0, 0.0];
+        let rotated_cw = [0.0, -1.0, 1.0, 0.0, 0.0, 0.0];
+
+        assert!(emits_text_item("A", &horizontal));
+        assert!(emits_text_item("A", &rotated_ccw));
+        assert!(!emits_text_item("", &horizontal));
+        assert!(!emits_text_item("", &rotated_ccw));
+        // The whole point: a blank survives only where the run is rotated.
+        assert!(!emits_text_item(" ", &horizontal));
+        assert!(emits_text_item(" ", &rotated_ccw));
+        assert!(emits_text_item(" ", &rotated_cw));
+    }
 
     /// Glyph-per-item run at `fs`=12 with the given inter-glyph gap (pt).
     fn glyph_run(chars: &str, start_x: f32, glyph_w: f32, gap: f32) -> Vec<TextItem> {

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -12,7 +12,7 @@ use super::fonts::{
     extract_text_from_operand, get_font_file2_obj_num, get_operand_bytes, CMapDecisionCache,
     FontStyleCache,
 };
-use super::{get_number, image_bbox_from_ctm, multiply_matrices};
+use super::{emits_text_item, get_number, image_bbox_from_ctm, multiply_matrices};
 
 const MAX_FORM_XOBJECT_DEPTH: u8 = 5;
 
@@ -436,9 +436,7 @@ fn extract_form_xobject_text_inner(
                         } else {
                             0.0
                         };
-                        // Only create text item for non-whitespace; whitespace
-                        // still advances the text matrix above so gap detection works
-                        if !text.trim().is_empty() {
+                        if emits_text_item(&text, &combined) {
                             let base_font = font_base_names
                                 .get(&current_font)
                                 .map(|s| s.as_str())
@@ -570,11 +568,11 @@ fn extract_form_xobject_text_inner(
                                 }
                             }
                         }
-                        if !fill_is_white && !current_text.trim().is_empty() {
+                        let combined = multiply_matrices(&text_matrix, &ctm);
+                        if !fill_is_white && emits_text_item(&current_text, &combined) {
                             sub_items.push((current_text, sub_start_width_ts, total_width_ts));
                         }
                         if !sub_items.is_empty() {
-                            let combined = multiply_matrices(&text_matrix, &ctm);
                             let rendered_size = effective_font_size(current_font_size, &combined)
                                 * type3_scales.get(&current_font).copied().unwrap_or(1.0);
                             let base_font = font_base_names


### PR DESCRIPTION
Fixes #296.

## Change

A 90°-rotated run advances along device y at a fixed x, so every glyph lands in a different line band and parallel runs interleave. `correct_rotated_page` only rescues pages that are *entirely* rotated; a table with rotated column headers over horizontal body text never reaches its two-thirds vote.

Adds `merge_rotated_runs`, which runs immediately after `correct_rotated_page` — before line grouping and before `merge_text_items`, which otherwise steals loose glyphs into neighbouring horizontal text. It groups zero-width single-glyph items sharing a baseline x, splits them into runs on y gaps, and emits one item per run.

Zero width is the free signal that a run is rotated: the advance is measured along the text x-axis, which a 90° matrix maps entirely onto device y, so `scale_x` is 0. Multi-character items are excluded so a page whose fonts carry no widths — also zero-width, but whole lines rather than glyphs — is never fused.

Word spaces need one more thing. Whitespace-only items are dropped at extraction, and under the letter-spacing these labels use, a space advance is *smaller* than an ordinary letter advance: on one header the true word break is 19.79pt against an ordinary letter gap reaching 15.77pt, on another it is 10.95pt against 11.11pt. No threshold separates them, so `emits_text_item` keeps blanks when the matrix is rotated and `merge_rotated_runs` drops any it does not consume. Nothing downstream sees a blank item, exactly as before.

Ordering and body placement assume 90° CCW — the assumption `correct_rotated_page` already encodes.

## Effect

Over 30 technical PDFs, counting cells whose text is woven from more than one source string:

| build | scrambled cells | documents affected |
|---|---|---|
| `585d36e` | 58 | 3 |
| this PR | 0 | 0 |

Row-survival (400/465) and column consistency (88.5%) are byte-for-byte unchanged, so nothing is traded for this. Nine further documents gain a corrected data row — a value that had been assigned to the wrong column lands in the right one once the header stops occupying it:

```
before  |x|x|x|x|x|x|ND|ND|ND|ND|ND|ND|x|x|x|x||x||
after   |x|x|x|x|x|x|ND|ND|ND|ND|ND|ND|x|x|x|x|x|||
```

13 of 30 documents change at all; the other 17 are byte-identical.

## Tests

`cargo test` (full suite, unit + integration over the `tests/fixtures/` PDFs): 975 → 978 passing, 0 failures. No existing test modified.

- `test_rotated_column_headers_merge_into_one_item` — end-to-end from a content stream: two rotated runs plus a horizontal module row, asserting merged text, `x`, `width`, and that no glyph or blank is left over. The horizontal row is load-bearing: it keeps the synthetic page under the whole-page rotation vote, which is the case being tested.
- `test_merge_rotated_runs_keeps_multi_char_column` — a stacked column of zero-width *lines* stays untouched.
- `test_emits_text_item` — blanks survive only where the run is rotated.

AGENTS.md also points at the `pdf-evals` snapshot suite (~200 PDFs) for pre-commit regression and `bench.py score` for the semantic verdict. That repo is not public, so I could not run either — worth a run before merge, particularly `score`, since AGENTS.md notes character-level diffs misclassify structural changes and this patch restructures header cells.

## Not included

`correct_rotated_page` still assumes 90° CCW throughout, and so does this pass. 270° CW text would come out reversed. Pre-existing, and I have no sample to verify a fix against.

Rotated glyph advances also come out at roughly twice the value another parser reports for the same file (11.54pt where 5.75pt is expected at 9pt). Ordering is monotonic either way so this pass is unaffected, but it is a separate discrepancy worth a look.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788696643&installation_model_id=11126&pr_number=298&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F298&signature=95217850c5806f097ef4e6b71f5c17a7b73e0e17e93aee01a54dbf604df06c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reassembles 90°-rotated text runs on mixed-orientation pages so headers extract as whole strings and no longer interleave with horizontal text. Eliminates scrambled cells without changing row/column metrics.

- **Bug Fixes**
  - Added `merge_rotated_runs` (runs after `correct_rotated_page`, before line grouping/`merge_text_items`) to group zero‑width, single‑glyph items with the same baseline x, split by font‑size–scaled y gaps, and emit one merged item; requires page width evidence (at least one non‑zero‑width item), a minimum of 3 glyphs per run, keeps multi‑character zero‑width columns intact, and assumes 90° CCW.
  - Introduced `emits_text_item` to keep spaces only for rotated matrices so word breaks survive; unused blanks are dropped after merging to preserve previous behavior elsewhere. Applied in page and form `XObject` extraction.
  - Result: 58→0 scrambled cells across 30 PDFs; 978 tests passing; row survival and column consistency unchanged.

<sup>Written for commit 7ab0af5719e12861f5459b062ea18a0425cbc11a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

