### PR TITLE
feat: expose OCR routing thresholds in DetectionConfig

### DIFF
--- a/NOTES-267.md
+++ b/NOTES-267.md
@@ -1,0 +1,26 @@
+\# Notes: issue #267 — OCR confidence threshold
+
+
+
+Investigated `src/detector.rs`. Current routing is driven by:
+
+\- `min\_text\_ops\_per\_page` (default 3)
+
+\- `text\_page\_ratio\_threshold` (default 0.6)
+
+
+
+`confidence` itself is not currently compared to any threshold anywhere.
+
+
+
+Direction pending confirmation from maintainer:
+
+1\. Expose existing thresholds as tunable config, or
+
+2\. Add new post-classification confidence gate.
+
+
+
+Implementation to follow once confirmed.
+


### PR DESCRIPTION
Refs #267

   Draft PR to claim the issue while direction is confirmed with the maintainer.

   I looked into the current classification logic in `src/detector.rs` and posted
   findings on the issue: the reported `confidence` score isn't currently used to
   make routing decisions — routing is driven by `min_text_ops_per_page` and
   `text_page_ratio_threshold` in `DetectionConfig`, plus a few non-configurable
   heuristics. Waiting on confirmation of whether to (1) expose those existing
   thresholds, or (2) add a new post-classification confidence gate, before
   implementing.

   No code changes yet — will push commits once direction is confirmed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/pdf-inspector/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707289&installation_model_id=11126&pr_number=300&repository=firecrawl%2Fpdf-inspector&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Fpdf-inspector%2Fpull%2F300&signature=01e7f8e86024640d743ad792737f1175ab182f657442c7c9e6c490468e5e7437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents current OCR routing and the planned exposure of thresholds in `DetectionConfig`. No behavior change; adds `NOTES-267.md` to align with #267 and unblock implementation.

- Confirms routing uses `min_text_ops_per_page` (default 3) and `text_page_ratio_threshold` (default 0.6); `confidence` is not used.
- Requests maintainer decision: expose these thresholds in `DetectionConfig` or add a post-classification confidence gate.
- No code changes; review is documentation-only.

<sup>Written for commit 3f639bcb8afd0447be73d723373aea61b0c6f9a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

