### PR TITLE
fix(parser): recover malformed PDF containers and invisible OCR text

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1426,6 +1426,13 @@ fn scan_content_for_text_operators(
             }
         }
 
+        let follows_text_string = i > 0 && matches!(content[i - 1], b')' | b'>');
+        if matches!(b, b'\'' | b'"') && (is_word_start(i) || follows_text_string) && is_word_end(i)
+        {
+            text_ops += 1;
+            collect_text_chars_before(content, i, unique_chars);
+        }
+
         // Note: We do NOT count 'Do' operators here because Do invokes any
         // XObject — including Form XObjects that contain text.  Actual image
         // detection is handled by scan_xobjects_in_resources (checks Subtype)
@@ -2012,6 +2019,18 @@ mod tests {
             scan_content_for_text_operators(content3, &mut uchars, &mut HashSet::new());
         assert_eq!(ops3, 0);
         assert_eq!(imgs3, 0);
+    }
+
+    #[test]
+    fn test_scan_content_quote_operators_without_operand_whitespace() {
+        let mut uchars = HashSet::new();
+        let content = b"BT /F1 12 Tf (Single)' 0 0 (Double)\" ET";
+        let (ops, _, _, _) =
+            scan_content_for_text_operators(content, &mut uchars, &mut HashSet::new());
+
+        assert_eq!(ops, 2);
+        assert!(uchars.contains(&b'S'));
+        assert!(uchars.contains(&b'D'));
     }
 
     #[test]

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -137,8 +137,8 @@ fn rise_adjusted(tm: &[f32; 6], rise: f32) -> [f32; 6] {
     ]
 }
 
-/// Returns `(page_extraction, has_gid_fonts)` where `has_gid_fonts` indicates
-/// the page uses fonts with unresolvable gid-encoded glyphs.
+/// Returns extraction results plus page-level font, rotation, and invisible
+/// text metadata.
 pub(crate) fn extract_page_text_items(
     doc: &Document,
     page_id: ObjectId,
@@ -146,7 +146,7 @@ pub(crate) fn extract_page_text_items(
     font_cmaps: &FontCMaps,
     include_invisible: bool,
     style_cache: &mut FontStyleCache,
-) -> Result<(PageExtraction, bool, bool), PdfError> {
+) -> Result<(PageExtraction, bool, bool, bool), PdfError> {
     use lopdf::content::Content;
 
     let mut items = Vec::new();
@@ -154,6 +154,7 @@ pub(crate) fn extract_page_text_items(
     let mut clip_rects: Vec<PdfRect> = Vec::new();
     let mut lines: Vec<PdfLine> = Vec::new();
     let mut underline_lines: Vec<UnderlineLine> = Vec::new();
+    let mut has_invisible_text = false;
 
     // Path construction state for m/l/h → S/s line extraction
     let mut path_subpath_start: Option<(f32, f32)> = None;
@@ -252,17 +253,38 @@ pub(crate) fn extract_page_text_items(
     // Content::decode parser, causing it to skip operators like ET and Q.
     let content_data = strip_pdf_comments(&content_data);
 
-    let content = Content::decode(&content_data).map_err(|e| PdfError::Parse(e.to_string()))?;
-
     const MAX_OPERATIONS: usize = 1_000_000;
-    if content.operations.len() > MAX_OPERATIONS {
+    let content = Content::decode(&content_data).map_err(|e| PdfError::Parse(e.to_string()))?;
+    let mut operations = Vec::with_capacity(content.operations.len());
+    for op in content.operations {
+        if op.operator == "\"" && op.operands.len() >= 3 {
+            operations.push(lopdf::content::Operation::new(
+                "Tw",
+                vec![op.operands[0].clone()],
+            ));
+            operations.push(lopdf::content::Operation::new(
+                "Tc",
+                vec![op.operands[1].clone()],
+            ));
+            operations.push(lopdf::content::Operation::new(
+                "'",
+                vec![op.operands[2].clone()],
+            ));
+        } else {
+            operations.push(op);
+        }
+        if operations.len() > MAX_OPERATIONS {
+            break;
+        }
+    }
+    if operations.len() > MAX_OPERATIONS {
         log::warn!(
             "page {}: skipping extraction — {} operations exceeds limit ({})",
             page_num,
-            content.operations.len(),
+            operations.len(),
             MAX_OPERATIONS
         );
-        return Ok(((Vec::new(), Vec::new(), Vec::new()), false, false));
+        return Ok(((Vec::new(), Vec::new(), Vec::new()), false, false, false));
     }
 
     // Graphics state tracking
@@ -320,7 +342,7 @@ pub(crate) fn extract_page_text_items(
         stack.iter().rev().find_map(|e| e.mcid)
     }
 
-    for op in &content.operations {
+    for op in &operations {
         trace!("{} {:?}", op.operator, op.operands);
         match op.operator.as_str() {
             "q" => {
@@ -375,7 +397,6 @@ pub(crate) fn extract_page_text_items(
                 in_text_block = true;
                 text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
                 line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
-                text_rendering_mode = 0;
             }
             "ET" => {
                 // End text block
@@ -462,6 +483,11 @@ pub(crate) fn extract_page_text_items(
             "Tj" => {
                 // Show text string
                 if in_text_block && !op.operands.is_empty() {
+                    if text_rendering_mode == 3
+                        && get_operand_bytes(&op.operands[0]).is_some_and(|raw| !raw.is_empty())
+                    {
+                        has_invisible_text = true;
+                    }
                     // Advance text matrix regardless of visibility
                     let w_ts_opt = font_widths.get(&current_font).and_then(|fi| {
                         get_operand_bytes(&op.operands[0]).map(|raw| {
@@ -564,6 +590,13 @@ pub(crate) fn extract_page_text_items(
                 // Show text with positioning — split at column-sized gaps
                 if in_text_block && !op.operands.is_empty() {
                     if let Ok(array) = op.operands[0].as_array() {
+                        if text_rendering_mode == 3
+                            && array.iter().any(|element| {
+                                get_operand_bytes(element).is_some_and(|raw| !raw.is_empty())
+                            })
+                        {
+                            has_invisible_text = true;
+                        }
                         let font_info = font_widths.get(&current_font);
                         let is_invisible = (text_rendering_mode == 3 && !include_invisible)
                             || suppress_glyph_extraction;
@@ -742,6 +775,15 @@ pub(crate) fn extract_page_text_items(
             }
             "'" => {
                 // Move to next line and show text (equivalent to T* then Tj)
+                if text_rendering_mode == 3
+                    && op
+                        .operands
+                        .first()
+                        .and_then(get_operand_bytes)
+                        .is_some_and(|raw| !raw.is_empty())
+                {
+                    has_invisible_text = true;
+                }
                 let tl = if text_leading != 0.0 {
                     text_leading
                 } else {
@@ -1300,7 +1342,12 @@ pub(crate) fn extract_page_text_items(
 
     let items = super::merge_text_items(items);
     let items = super::merge_subscript_items(items);
-    Ok(((items, rects, lines), has_gid_fonts, coords_rotated))
+    Ok((
+        (items, rects, lines),
+        has_gid_fonts,
+        coords_rotated,
+        has_invisible_text,
+    ))
 }
 
 /// Counts of text operators with horizontal vs rotated combined matrices.
@@ -1498,7 +1545,7 @@ mod tests {
 
         let (doc, page_id) = simple_doc_with_content(content);
         let font_cmaps = FontCMaps::from_doc(&doc);
-        let ((items, _, _), _, _) = extract_page_text_items(
+        let ((items, _, _), _, _, _) = extract_page_text_items(
             &doc,
             page_id,
             1,
@@ -1736,7 +1783,7 @@ BT /F1 12 Tf 0 1 -1 0 240 100 Tm (WORLD) Tj ET
             &mut FontStyleCache::new(),
         )
         .unwrap();
-        let ((items, rects, lines), _has_gid, _coords_rotated) = result;
+        let ((items, rects, lines), _has_gid, _coords_rotated, _has_invisible_text) = result;
         assert!(items.is_empty());
         assert!(rects.is_empty());
         assert!(lines.is_empty());
@@ -1817,7 +1864,7 @@ BT 30 700 Tm <41> Tj ET";
         doc.trailer.set("Root", Object::Reference(catalog_id));
 
         let font_cmaps = FontCMaps::from_doc(&doc);
-        let ((items, _, _), _, _) = extract_page_text_items(
+        let ((items, _, _), _, _, _) = extract_page_text_items(
             &doc,
             page_id,
             1,

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -113,7 +113,7 @@ pub(crate) fn extract_text_with_positions_and_rects_with_password<P: AsRef<Path>
     crate::validate_pdf_file(&path)?;
     let (doc, _) = crate::load_document_from_path_with_password(&path, password)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
-    let (extraction, _thresholds, _gid_pages) =
+    let (extraction, _thresholds, _gid_pages, _invisible_pages) =
         extract_positioned_text_from_doc(&doc, &font_cmaps, page_filter)?;
     Ok(extraction)
 }
@@ -140,7 +140,7 @@ pub(crate) fn extract_text_with_positions_mem_and_rects(
     crate::validate_pdf_bytes(buffer)?;
     let (doc, _) = crate::load_document_from_mem(buffer)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
-    let (extraction, _thresholds, _gid_pages) =
+    let (extraction, _thresholds, _gid_pages, _invisible_pages) =
         extract_positioned_text_from_doc(&doc, &font_cmaps, page_filter)?;
     Ok(extraction)
 }
@@ -159,7 +159,7 @@ pub(crate) fn extract_positioned_text_from_doc(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     extract_positioned_text_impl(doc, font_cmaps, page_filter, false, None)
 }
 
@@ -170,7 +170,7 @@ pub(crate) fn extract_positioned_text_with_folio_context(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     extract_positioned_text_with_folio_context_impl(doc, font_cmaps, page_filter, false)
 }
 
@@ -179,7 +179,7 @@ pub(crate) fn extract_positioned_text_include_invisible_with_folio_context(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     extract_positioned_text_with_folio_context_impl(doc, font_cmaps, page_filter, true)
 }
 
@@ -188,7 +188,7 @@ fn extract_positioned_text_with_folio_context_impl(
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
     include_invisible: bool,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     let Some(required_pages) = page_filter else {
         return extract_positioned_text_impl(doc, font_cmaps, None, include_invisible, None);
     };
@@ -197,6 +197,7 @@ fn extract_positioned_text_with_folio_context_impl(
         (mut selected_items, mut selected_rects, mut selected_lines),
         mut page_thresholds,
         mut gid_encoded_pages,
+        mut invisible_text_pages,
     ) = extract_positioned_text_impl(
         doc,
         font_cmaps,
@@ -209,6 +210,7 @@ fn extract_positioned_text_with_folio_context_impl(
             (selected_items, selected_rects, selected_lines),
             page_thresholds,
             gid_encoded_pages,
+            invisible_text_pages,
         ));
     }
 
@@ -218,23 +220,29 @@ fn extract_positioned_text_with_folio_context_impl(
         .copied()
         .filter(|page| !required_pages.contains(page))
         .collect();
-    let ((context_items, context_rects, context_lines), context_thresholds, context_gid_pages) =
-        extract_positioned_text_impl(
-            doc,
-            font_cmaps,
-            Some(&context_pages),
-            include_invisible,
-            Some(required_pages),
-        )?;
+    let (
+        (context_items, context_rects, context_lines),
+        context_thresholds,
+        context_gid_pages,
+        context_invisible_pages,
+    ) = extract_positioned_text_impl(
+        doc,
+        font_cmaps,
+        Some(&context_pages),
+        include_invisible,
+        Some(required_pages),
+    )?;
     selected_items.extend(context_items);
     selected_rects.extend(context_rects);
     selected_lines.extend(context_lines);
     page_thresholds.extend(context_thresholds);
     gid_encoded_pages.extend(context_gid_pages);
+    invisible_text_pages.extend(context_invisible_pages);
     Ok((
         (selected_items, selected_rects, selected_lines),
         page_thresholds,
         gid_encoded_pages,
+        invisible_text_pages,
     ))
 }
 
@@ -244,7 +252,7 @@ pub(crate) fn extract_positioned_text_for_document_analysis(
     doc: &Document,
     font_cmaps: &FontCMaps,
     required_pages: &HashSet<u32>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     extract_positioned_text_impl(doc, font_cmaps, None, false, Some(required_pages))
 }
 
@@ -254,13 +262,14 @@ fn extract_positioned_text_impl(
     page_filter: Option<&HashSet<u32>>,
     include_invisible: bool,
     required_pages: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>), PdfError> {
+) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, HashSet<u32>), PdfError> {
     let pages = doc.get_pages();
     let mut all_items = Vec::new();
     let mut all_rects = Vec::new();
     let mut all_lines = Vec::new();
     let mut page_thresholds: PageThresholds = HashMap::new();
     let mut gid_encoded_pages: HashSet<u32> = HashSet::new();
+    let mut invisible_text_pages: HashSet<u32> = HashSet::new();
     // Embedded-font style flags are document-scoped: the same font program
     // is shared across pages, so parse it once, not once per page.
     let mut style_cache = FontStyleCache::new();
@@ -283,17 +292,20 @@ fn extract_positioned_text_impl(
             include_invisible,
             &mut style_cache,
         );
-        let ((mut items, mut rects, mut lines), has_gid_fonts, coords_rotated) = match page_result {
-            Ok(extraction) => extraction,
-            Err(error) if required_pages.is_some_and(|required| !required.contains(page_num)) => {
-                debug!(
-                    "page {}: skipping context-only extraction error: {}",
-                    page_num, error
-                );
-                continue;
-            }
-            Err(error) => return Err(error),
-        };
+        let ((mut items, mut rects, mut lines), has_gid_fonts, coords_rotated, has_invisible_text) =
+            match page_result {
+                Ok(extraction) => extraction,
+                Err(error)
+                    if required_pages.is_some_and(|required| !required.contains(page_num)) =>
+                {
+                    debug!(
+                        "page {}: skipping context-only extraction error: {}",
+                        page_num, error
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
         // Clip to the visible page box: single-page extracts and imposed
         // spreads keep neighboring pages' content in the stream, positioned
         // outside the CropBox. Extracting it interleaves invisible text into
@@ -371,6 +383,9 @@ fn extract_positioned_text_impl(
         if has_gid_fonts {
             gid_encoded_pages.insert(*page_num);
         }
+        if has_invisible_text {
+            invisible_text_pages.insert(*page_num);
+        }
         let threshold = crate::text_utils::fix_letterspaced_items(&mut items);
         if threshold > 0.10 {
             page_thresholds.insert(*page_num, threshold);
@@ -432,6 +447,7 @@ fn extract_positioned_text_impl(
         (all_items, all_rects, all_lines),
         page_thresholds,
         gid_encoded_pages,
+        invisible_text_pages,
     ))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3552,6 +3552,7 @@ fn decrypt_document_bytes(buf: &[u8], password: Option<&str>) -> Result<Document
 fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
     let mut candidates = Vec::new();
 
+    add_repair_candidate(&mut candidates, repair_inline_xref_header(buf), buf);
     add_repair_candidate(&mut candidates, append_missing_eof_marker(buf), buf);
     add_repair_candidate(&mut candidates, recover_startxref_pointer(buf), buf);
 
@@ -3686,6 +3687,52 @@ fn add_repair_candidate(
     candidates.push(candidate);
 }
 
+fn repair_inline_xref_header(buf: &[u8]) -> Option<Vec<u8>> {
+    let eof_pos = find_last_subslice(buf, b"%%EOF")?;
+    let tail_start = eof_pos.saturating_sub(1024);
+    let startxref_pos = find_last_subslice(&buf[tail_start..eof_pos], b"startxref")? + tail_start;
+
+    let mut cursor = startxref_pos + b"startxref".len();
+    while buf.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+        cursor += 1;
+    }
+
+    let mut xref_offset = 0usize;
+    let digits_start = cursor;
+    while let Some(digit) = buf.get(cursor).filter(|byte| byte.is_ascii_digit()) {
+        xref_offset = xref_offset
+            .checked_mul(10)?
+            .checked_add((*digit - b'0') as usize)?;
+        cursor += 1;
+    }
+    if cursor == digits_start {
+        return None;
+    }
+
+    let separator = xref_offset.checked_add(b"xref".len())?;
+    if buf.get(xref_offset..separator)? != b"xref"
+        || buf.get(separator) != Some(&b' ')
+        || !buf
+            .get(separator + 1)
+            .is_some_and(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut repaired = buf.to_vec();
+    repaired[separator] = b'\n';
+    Some(repaired)
+}
+
+fn find_last_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .rposition(|window| window == needle)
+}
+
 fn append_missing_eof_marker(buf: &[u8]) -> Option<Vec<u8>> {
     if contains_recent_eof_marker(buf) {
         return None;
@@ -3788,15 +3835,19 @@ fn process_document(
             options.page_filter.as_ref(),
         );
 
-        // For Mixed/template PDFs: if normal extraction produces garbage text
-        // (mostly non-alphanumeric), retry with invisible (Tr=3) text included.
-        // This unlocks OCR text layers behind scanned images.
-        if pdf_type == PdfType::Mixed {
+        // Retry an empty text-based result with invisible (Tr=3) text included.
+        // Some OCR-backed PDFs contain only an invisible text layer but are
+        // classified as TextBased because they have many text operators.
+        // Mixed/template PDFs additionally retry garbage visible text.
+        if matches!(pdf_type, PdfType::TextBased | PdfType::Mixed) {
             if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
                 let sample: String = items
                     .iter()
                     .filter(|item| {
-                        options
+                        matches!(
+                            item.item_type,
+                            types::ItemType::Text | types::ItemType::FormField
+                        ) && options
                             .page_filter
                             .as_ref()
                             .is_none_or(|filter| filter.contains(&item.page))
@@ -3804,7 +3855,9 @@ fn process_document(
                     .take(200)
                     .map(|item| item.text.as_str())
                     .collect();
-                if is_garbage_text(&sample) || sample.trim().is_empty() {
+                if sample.trim().is_empty()
+                    || (pdf_type == PdfType::Mixed && is_garbage_text(&sample))
+                {
                     extractor::extract_positioned_text_include_invisible_with_folio_context(
                         &doc,
                         &font_cmaps,
@@ -3813,13 +3866,15 @@ fn process_document(
                 } else {
                     result
                 }
-            } else {
+            } else if pdf_type == PdfType::Mixed {
                 // Normal extraction failed — try invisible as fallback
                 extractor::extract_positioned_text_include_invisible_with_folio_context(
                     &doc,
                     &font_cmaps,
                     options.page_filter.as_ref(),
                 )
+            } else {
+                result
             }
         } else {
             result
@@ -6094,6 +6149,42 @@ pub(crate) fn validate_pdf_file<P: AsRef<Path>>(path: P) -> Result<(), PdfError>
 mod tests {
     use super::*;
     use crate::types::ItemType;
+
+    fn minimal_pdf_with_inline_xref_header() -> Vec<u8> {
+        let mut pdf = b"%PDF-1.4\n".to_vec();
+        let catalog_offset = pdf.len();
+        pdf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+        let pages_offset = pdf.len();
+        pdf.extend_from_slice(b"2 0 obj\n<</Type /Pages /Count 0 /Kids []>>\nendobj\n");
+        let xref_offset = pdf.len();
+        pdf.extend_from_slice(
+            format!(
+                "xref 0 3\n\
+                 0000000000 65535 f \n\
+                 {catalog_offset:010} 00000 n \n\
+                 {pages_offset:010} 00000 n \n\
+                 trailer\n\
+                 <</Size 3 /Root 1 0 R>>\n\
+                 startxref\n\
+                 {xref_offset}\n\
+                 %%EOF\n"
+            )
+            .as_bytes(),
+        );
+        pdf
+    }
+
+    #[test]
+    fn loads_pdf_with_xref_section_on_keyword_line() {
+        let (doc, page_count) = load_document_from_mem(&minimal_pdf_with_inline_xref_header())
+            .expect("inline xref section header should be repaired");
+
+        assert_eq!(page_count, 0);
+        assert_eq!(
+            doc.trailer.get(b"Root").unwrap().as_reference().unwrap(),
+            (1, 0)
+        );
+    }
 
     fn test_item(text: &str, x: f32, y: f32, width: f32, height: f32) -> TextItem {
         TextItem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,7 +471,7 @@ pub fn extract_pages_markdown_mem(
             .filter_map(|page| page.checked_add(1))
             .collect()
     });
-    let ((all_items, all_rects, all_lines), page_thresholds, gid_pages) =
+    let ((all_items, all_rects, all_lines), page_thresholds, gid_pages, _invisible_pages) =
         if let Some(required_pages) = required_pages.as_ref() {
             extractor::extract_positioned_text_for_document_analysis(
                 &doc,
@@ -736,7 +736,7 @@ pub fn extract_text_in_regions_mem(
         page_heights.insert(*page_num, height);
 
         // Extract text items for this page
-        let ((mut items, _rects, _lines), has_gid, coords_rotated) =
+        let ((mut items, _rects, _lines), has_gid, coords_rotated, _has_invisible_text) =
             extractor::content_stream::extract_page_text_items(
                 &doc,
                 page_id,
@@ -901,7 +901,7 @@ pub fn extract_tables_in_regions_mem(
         let height = get_page_height(&doc, page_id).unwrap_or(792.0);
         page_heights.insert(*page_num, height);
 
-        let ((mut items, rects, lines), has_gid, coords_rotated) =
+        let ((mut items, rects, lines), has_gid, coords_rotated, _has_invisible_text) =
             extractor::content_stream::extract_page_text_items(
                 &doc,
                 page_id,
@@ -1212,7 +1212,7 @@ pub fn detect_vector_grid_in_region_mem(
     let needed_pages = HashSet::from([page_1idx]);
     let font_cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed_pages));
     let page_h = get_page_height(&doc, page_id).unwrap_or(792.0);
-    let ((mut items, rects, lines), _has_gid, coords_rotated) =
+    let ((mut items, rects, lines), _has_gid, coords_rotated, _has_invisible_text) =
         extractor::content_stream::extract_page_text_items(
             &doc,
             page_id,
@@ -1406,15 +1406,16 @@ mod vector_grid_tests {
         let &page_id = pages.get(&1).unwrap();
         let needed: HashSet<u32> = HashSet::from([1]);
         let cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed));
-        let ((items, rects, _lines), _has_gid, _rotated) = extract_page_text_items(
-            &doc,
-            page_id,
-            1,
-            &cmaps,
-            false,
-            &mut crate::extractor::FontStyleCache::new(),
-        )
-        .unwrap();
+        let ((items, rects, _lines), _has_gid, _rotated, _has_invisible_text) =
+            extract_page_text_items(
+                &doc,
+                page_id,
+                1,
+                &cmaps,
+                false,
+                &mut crate::extractor::FontStyleCache::new(),
+            )
+            .unwrap();
 
         let (rect_tables, _) = detect_tables_from_rects(&items, &rects, 1);
         assert_eq!(rect_tables.len(), 1, "expected one rect-detected table");
@@ -1448,15 +1449,16 @@ mod vector_grid_tests {
         let &page_id = pages.get(&page_num).unwrap();
         let needed: HashSet<u32> = HashSet::from([page_num]);
         let cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed));
-        let ((items, rects, _lines), _has_gid, _rotated) = extract_page_text_items(
-            &doc,
-            page_id,
-            page_num,
-            &cmaps,
-            false,
-            &mut crate::extractor::FontStyleCache::new(),
-        )
-        .unwrap();
+        let ((items, rects, _lines), _has_gid, _rotated, _has_invisible_text) =
+            extract_page_text_items(
+                &doc,
+                page_id,
+                page_num,
+                &cmaps,
+                false,
+                &mut crate::extractor::FontStyleCache::new(),
+            )
+            .unwrap();
 
         let (rect_tables, _) = detect_tables_from_rects(&items, &rects, page_num);
         rect_tables
@@ -2184,7 +2186,7 @@ pub fn extract_tables_with_structure_cells_mem(
         let height = get_page_height(&doc, page_id).unwrap_or(792.0);
         page_heights.insert(*page_num, height);
 
-        let ((mut items, _rects, _lines), _has_gid, coords_rotated) =
+        let ((mut items, _rects, _lines), _has_gid, coords_rotated, _has_invisible_text) =
             extractor::content_stream::extract_page_text_items(
                 &doc,
                 page_id,
@@ -2986,7 +2988,7 @@ fn detect_tsr_quality_issue(
     let mut needed: HashSet<u32> = HashSet::new();
     needed.insert(page_1idx);
     let font_cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed));
-    let ((mut items, _rects, _lines), _has_gid, coords_rotated) =
+    let ((mut items, _rects, _lines), _has_gid, coords_rotated, _has_invisible_text) =
         extractor::content_stream::extract_page_text_items(
             &doc,
             page_id,
@@ -3552,26 +3554,39 @@ fn decrypt_document_bytes(buf: &[u8], password: Option<&str>) -> Result<Document
 fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
     let mut candidates = Vec::new();
 
-    add_repair_candidate(&mut candidates, repair_inline_xref_header(buf), buf);
-    add_repair_candidate(&mut candidates, append_missing_eof_marker(buf), buf);
-    add_repair_candidate(&mut candidates, recover_startxref_pointer(buf), buf);
+    add_container_repair_pipeline(&mut candidates, buf, buf, false);
 
     let stripped = strip_leading_pdf_container_bytes(buf);
     if let Some(stripped_buf) = stripped.as_deref() {
-        add_repair_candidate(&mut candidates, Some(stripped_buf.to_vec()), buf);
-        add_repair_candidate(
-            &mut candidates,
-            append_missing_eof_marker(stripped_buf),
-            buf,
-        );
-        add_repair_candidate(
-            &mut candidates,
-            recover_startxref_pointer(stripped_buf),
-            buf,
-        );
+        add_container_repair_pipeline(&mut candidates, stripped_buf, buf, true);
     }
 
     candidates
+}
+
+fn add_container_repair_pipeline(
+    candidates: &mut Vec<Vec<u8>>,
+    seed: &[u8],
+    original: &[u8],
+    include_seed: bool,
+) {
+    let mut current = seed.to_vec();
+    if include_seed {
+        add_repair_candidate(candidates, Some(current.clone()), original);
+    }
+
+    for repair in [
+        append_missing_eof_marker as fn(&[u8]) -> Option<Vec<u8>>,
+        repair_inline_xref_header,
+        recover_startxref_pointer,
+        repair_inline_xref_header,
+    ] {
+        let Some(repaired) = repair(&current) else {
+            continue;
+        };
+        current = repaired;
+        add_repair_candidate(candidates, Some(current.clone()), original);
+    }
 }
 
 /// Some PDF writers emit a `startxref` pointer that doesn't actually point
@@ -3835,12 +3850,143 @@ fn process_document(
             options.page_filter.as_ref(),
         );
 
-        // Retry an empty text-based result with invisible (Tr=3) text included.
-        // Some OCR-backed PDFs contain only an invisible text layer but are
-        // classified as TextBased because they have many text operators.
-        // Mixed/template PDFs additionally retry garbage visible text.
-        if matches!(pdf_type, PdfType::TextBased | PdfType::Mixed) {
-            if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
+        let result = if matches!(pdf_type, PdfType::TextBased | PdfType::Mixed) {
+            result.map(
+                |(
+                    (mut items, mut rects, mut lines),
+                    mut page_thresholds,
+                    mut gid_encoded_pages,
+                    invisible_text_pages,
+                )| {
+                    let retry_pages: HashSet<u32> = invisible_text_pages
+                        .iter()
+                        .copied()
+                        .filter(|page| {
+                            options
+                                .page_filter
+                                .as_ref()
+                                .is_none_or(|filter| filter.contains(page))
+                        })
+                        .collect();
+
+                    if !retry_pages.is_empty() {
+                        match extractor::extract_positioned_text_include_invisible_with_folio_context(
+                            &doc,
+                            &font_cmaps,
+                            Some(&retry_pages),
+                        ) {
+                            Ok((
+                                (mut retry_items, retry_rects, retry_lines),
+                                retry_thresholds,
+                                retry_gid_pages,
+                                _,
+                            )) => {
+                                // OCR layers can repeat visible text at the same baseline.
+                                let mut overlay_keys = HashSet::new();
+                                retry_items.retain(|item| {
+                                    let kind = match &item.item_type {
+                                        types::ItemType::Text => 0u8,
+                                        types::ItemType::FormField => 1u8,
+                                        _ => return true,
+                                    };
+                                    let quantize = |value: f32| (value * 2.0).round() as i32;
+                                    overlay_keys.insert((
+                                        item.page,
+                                        kind,
+                                        item.text.clone(),
+                                        quantize(item.x),
+                                        quantize(item.y),
+                                        quantize(item.height),
+                                    ))
+                                });
+                                let text_chars = |page_items: &[TextItem], page: u32| {
+                                    page_items
+                                        .iter()
+                                        .filter(|item| {
+                                            item.page == page
+                                                && matches!(
+                                                    item.item_type,
+                                                    types::ItemType::Text
+                                                        | types::ItemType::FormField
+                                                )
+                                        })
+                                        .map(|item| {
+                                            item.text
+                                                .chars()
+                                                .filter(|ch| !ch.is_whitespace())
+                                                .count()
+                                        })
+                                        .sum::<usize>()
+                                };
+                                let pages_to_replace: HashSet<u32> = retry_pages
+                                    .iter()
+                                    .copied()
+                                    .filter(|page| {
+                                        let visible_chars = text_chars(&items, *page);
+                                        let all_chars = text_chars(&retry_items, *page);
+                                        visible_chars == 0
+                                            || all_chars >= visible_chars.saturating_mul(2)
+                                    })
+                                    .collect();
+
+                                if !pages_to_replace.is_empty() {
+                                    items.retain(|item| !pages_to_replace.contains(&item.page));
+                                    items.extend(
+                                        retry_items
+                                            .into_iter()
+                                            .filter(|item| pages_to_replace.contains(&item.page)),
+                                    );
+                                    rects.retain(|rect| !pages_to_replace.contains(&rect.page));
+                                    rects.extend(
+                                        retry_rects
+                                            .into_iter()
+                                            .filter(|rect| pages_to_replace.contains(&rect.page)),
+                                    );
+                                    lines.retain(|line| !pages_to_replace.contains(&line.page));
+                                    lines.extend(
+                                        retry_lines
+                                            .into_iter()
+                                            .filter(|line| pages_to_replace.contains(&line.page)),
+                                    );
+                                    page_thresholds
+                                        .retain(|page, _| !pages_to_replace.contains(page));
+                                    page_thresholds.extend(
+                                        retry_thresholds
+                                            .into_iter()
+                                            .filter(|(page, _)| pages_to_replace.contains(page)),
+                                    );
+                                    gid_encoded_pages.extend(
+                                        retry_gid_pages
+                                            .into_iter()
+                                            .filter(|page| pages_to_replace.contains(page)),
+                                    );
+                                }
+                            }
+                            Err(error) => {
+                                log::debug!(
+                                    "invisible-text page retry failed; keeping visible extraction: {}",
+                                    error
+                                );
+                            }
+                        }
+                    }
+
+                    (
+                        (items, rects, lines),
+                        page_thresholds,
+                        gid_encoded_pages,
+                        invisible_text_pages,
+                    )
+                },
+            )
+        } else {
+            result
+        };
+
+        // Mixed/template PDFs additionally retry wholly empty or garbage
+        // visible text, preserving the existing scanned-image fallback.
+        if pdf_type == PdfType::Mixed {
+            if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _, _)| e) {
                 let sample: String = items
                     .iter()
                     .filter(|item| {
@@ -3855,9 +4001,7 @@ fn process_document(
                     .take(200)
                     .map(|item| item.text.as_str())
                     .collect();
-                if sample.trim().is_empty()
-                    || (pdf_type == PdfType::Mixed && is_garbage_text(&sample))
-                {
+                if sample.trim().is_empty() || is_garbage_text(&sample) {
                     extractor::extract_positioned_text_include_invisible_with_folio_context(
                         &doc,
                         &font_cmaps,
@@ -3866,15 +4010,13 @@ fn process_document(
                 } else {
                     result
                 }
-            } else if pdf_type == PdfType::Mixed {
+            } else {
                 // Normal extraction failed — try invisible as fallback
                 extractor::extract_positioned_text_include_invisible_with_folio_context(
                     &doc,
                     &font_cmaps,
                     options.page_filter.as_ref(),
                 )
-            } else {
-                result
             }
         } else {
             result
@@ -3915,7 +4057,12 @@ fn process_document(
         text_quality_pages,
         text_quality_reasons_by_page,
     ) = match extracted {
-        Some(((items, rects, lines), page_thresholds, gid_encoded_pages)) => {
+        Some((
+            (items, rects, lines),
+            page_thresholds,
+            gid_encoded_pages,
+            _invisible_text_pages,
+        )) => {
             let mut ocr_reasons_by_page = BTreeMap::new();
 
             // For TextBased PDFs with pages flagged for OCR (Identity-H or
@@ -6178,6 +6325,58 @@ mod tests {
     fn loads_pdf_with_xref_section_on_keyword_line() {
         let (doc, page_count) = load_document_from_mem(&minimal_pdf_with_inline_xref_header())
             .expect("inline xref section header should be repaired");
+
+        assert_eq!(page_count, 0);
+        assert_eq!(
+            doc.trailer.get(b"Root").unwrap().as_reference().unwrap(),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn loads_inline_xref_pdf_with_leading_bom() {
+        let mut pdf = vec![0xEF, 0xBB, 0xBF];
+        pdf.extend_from_slice(&minimal_pdf_with_inline_xref_header());
+
+        let (doc, page_count) = load_document_from_mem(&pdf)
+            .expect("leading BOM and inline xref should both be repaired");
+
+        assert_eq!(page_count, 0);
+        assert_eq!(
+            doc.trailer.get(b"Root").unwrap().as_reference().unwrap(),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn loads_inline_xref_pdf_with_truncated_eof() {
+        let mut pdf = minimal_pdf_with_inline_xref_header();
+        assert!(pdf.ends_with(b"%%EOF\n"));
+        pdf.truncate(pdf.len() - 2);
+
+        let (doc, page_count) = load_document_from_mem(&pdf)
+            .expect("truncated EOF and inline xref should both be repaired");
+
+        assert_eq!(page_count, 0);
+        assert_eq!(
+            doc.trailer.get(b"Root").unwrap().as_reference().unwrap(),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn loads_inline_xref_pdf_with_corrupted_startxref() {
+        let mut pdf = minimal_pdf_with_inline_xref_header();
+        let marker = find_last_subslice(&pdf, b"startxref\n").unwrap() + b"startxref\n".len();
+        let end = pdf[marker..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .unwrap()
+            + marker;
+        pdf[marker..end].fill(b'9');
+
+        let (doc, page_count) = load_document_from_mem(&pdf)
+            .expect("corrupted startxref and inline xref should both be repaired");
 
         assert_eq!(page_count, 0);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3925,7 +3925,7 @@ fn process_document(
                                         let visible_chars = text_chars(&items, *page);
                                         let all_chars = text_chars(&retry_items, *page);
                                         visible_chars == 0
-                                            || all_chars >= visible_chars.saturating_mul(2)
+                                            || all_chars > visible_chars
                                     })
                                     .collect();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -81,6 +81,25 @@ fn make_text_pdf(content: &str, media_box: &str) -> Vec<u8> {
     pdf
 }
 
+#[test]
+fn text_based_pdf_falls_back_to_invisible_ocr_text() {
+    let pdf = make_text_pdf(
+        "BT /F1 12 Tf 3 Tr 100 700 Td (Hidden OCR text) Tj ET",
+        "0 0 612 792",
+    );
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .is_some_and(|markdown| markdown.contains("Hidden OCR text")),
+        "empty visible extraction should fall back to the invisible OCR layer"
+    );
+}
+
 fn make_recurring_contextual_folio_pdf() -> Vec<u8> {
     let mut pdf = b"%PDF-1.4\n".to_vec();
     let mut offsets = vec![0usize];
@@ -3721,7 +3740,7 @@ fn test_synthetic_type0_broken_tounicode_emits_fffd_not_latin1_mojibake() {
 /// `Do` operator (per PDF spec section 8.9.5 "Image Coordinate System").
 /// For an axis-aligned image at `(x, y)` with size `w × h`, that's
 /// `[w, 0, 0, h, x, y]`.
-fn make_pdf_with_image(image_ctm: [f32; 6]) -> Vec<u8> {
+fn make_pdf_with_image(image_ctm: [f32; 6], invisible_text: bool) -> Vec<u8> {
     let mut pdf = b"%PDF-1.4\n".to_vec();
     let mut offsets = vec![0usize];
 
@@ -3773,10 +3792,15 @@ fn make_pdf_with_image(image_ctm: [f32; 6]) -> Vec<u8> {
     // BT/ET around a small text item just so the page isn't classified as
     // image-only (which would route to a different code path). Then save
     // graphics state, apply the image CTM, invoke Im0, restore.
-    let content = format!(
-        "BT /F1 12 Tf 100 700 Td (Hi) Tj ET\nq {} {} {} {} {} {} cm /Im0 Do Q",
-        a, b, c, d, e, f
-    );
+    let text = if invisible_text {
+        format!(
+            "BT /F1 12 Tf 3 Tr 100 700 Td {} ET",
+            "(Hidden OCR text) Tj 0 -5 Td ".repeat(100)
+        )
+    } else {
+        "BT /F1 12 Tf 100 700 Td (Hi) Tj ET".to_string()
+    };
+    let content = format!("{text}\nq {a} {b} {c} {d} {e} {f} cm /Im0 Do Q");
     add_stream_object(&mut pdf, &mut offsets, 4, "", content.as_bytes());
     add_object(
         &mut pdf,
@@ -3815,11 +3839,27 @@ fn make_pdf_with_image(image_ctm: [f32; 6]) -> Vec<u8> {
 }
 
 #[test]
+fn image_placeholder_does_not_block_invisible_ocr_fallback() {
+    let pdf = make_pdf_with_image([200.0, 0.0, 0.0, 100.0, 50.0, 600.0], true);
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .is_some_and(|markdown| markdown.contains("Hidden OCR text")),
+        "image placeholders are not usable visible text"
+    );
+}
+
+#[test]
 fn test_extract_text_with_positions_emits_image_bboxes() {
     // Place a 200×100 image at (50, 600) in PDF user space (origin
     // bottom-left). The Do operator applies the CTM to a unit square,
     // so for an axis-aligned image, CTM = [w, 0, 0, h, x, y].
-    let pdf = make_pdf_with_image([200.0, 0.0, 0.0, 100.0, 50.0, 600.0]);
+    let pdf = make_pdf_with_image([200.0, 0.0, 0.0, 100.0, 50.0, 600.0], false);
     let items = extract_text_with_positions_mem(&pdf).expect("extract");
 
     let images: Vec<&TextItem> = items
@@ -3858,7 +3898,7 @@ fn test_image_xobject_bbox_handles_rotated_ctm() {
     //   (1,1) → (100, 400)
     //   (0,1) → (100, 300)
     // → AABB: x=100..200 (w=100), y=300..400 (h=100).
-    let pdf = make_pdf_with_image([0.0, 100.0, -100.0, 0.0, 200.0, 300.0]);
+    let pdf = make_pdf_with_image([0.0, 100.0, -100.0, 0.0, 200.0, 300.0], false);
     let items = extract_text_with_positions_mem(&pdf).expect("extract");
     let img = items
         .iter()
@@ -3876,7 +3916,7 @@ fn test_image_emission_does_not_change_default_markdown() {
     // emission MUST NOT make `extract_pages_markdown` start producing
     // `![Image: …]` placeholders for everyone. Existing callers that
     // upgrade should see no diff in their markdown.
-    let pdf = make_pdf_with_image([200.0, 0.0, 0.0, 100.0, 50.0, 600.0]);
+    let pdf = make_pdf_with_image([200.0, 0.0, 0.0, 100.0, 50.0, 600.0], false);
     let result = extract_pages_markdown_mem(&pdf, None).expect("extract");
     assert_eq!(result.pages.len(), 1);
     assert!(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -81,6 +81,88 @@ fn make_text_pdf(content: &str, media_box: &str) -> Vec<u8> {
     pdf
 }
 
+fn make_two_page_text_pdf(first_content: &str, second_content: &str) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        "<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 7 0 R >> >> /Contents 4 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        4,
+        &format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            first_content.len(),
+            first_content
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 7 0 R >> >> /Contents 6 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        6,
+        &format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            second_content.len(),
+            second_content
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        7,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
 #[test]
 fn text_based_pdf_falls_back_to_invisible_ocr_text() {
     let pdf = make_text_pdf(
@@ -97,6 +179,107 @@ fn text_based_pdf_falls_back_to_invisible_ocr_text() {
             .as_deref()
             .is_some_and(|markdown| markdown.contains("Hidden OCR text")),
         "empty visible extraction should fall back to the invisible OCR layer"
+    );
+}
+
+#[test]
+fn visible_header_does_not_block_invisible_ocr_body() {
+    let hidden_body = "(Hidden OCR body) Tj 0 -5 Td ".repeat(100);
+    let pdf = make_text_pdf(
+        &format!("BT /F1 12 Tf 100 740 Td (Visible header) Tj 3 Tr 0 -20 Td {hidden_body} ET"),
+        "0 0 612 792",
+    );
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+    let markdown = result.markdown.expect("PDF should produce markdown");
+
+    assert!(markdown.contains("Visible header"));
+    assert!(
+        markdown.contains("Hidden OCR body"),
+        "a visible header must not suppress the page's invisible OCR body"
+    );
+}
+
+#[test]
+fn visible_page_does_not_block_another_pages_invisible_ocr_text() {
+    let visible = "BT /F1 12 Tf 100 700 Td (Visible first page) Tj ET";
+    let hidden = format!(
+        "BT /F1 12 Tf 3 Tr 100 700 Td {} ET",
+        "(Hidden second page) Tj 0 -5 Td ".repeat(100)
+    );
+    let pdf = make_two_page_text_pdf(visible, &hidden);
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+    let markdown = result.markdown.expect("PDF should produce markdown");
+
+    assert!(markdown.contains("Visible first page"));
+    assert!(
+        markdown.contains("Hidden second page"),
+        "visible text on one page must not suppress another page's invisible OCR layer"
+    );
+}
+
+#[test]
+fn overlaid_invisible_copy_is_not_duplicated() {
+    let pdf = make_text_pdf(
+        "BT /F1 12 Tf 100 700 Td (Same text) Tj 3 Tr 0 0 Td (Same text) Tj ET",
+        "0 0 612 792",
+    );
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+    let markdown = result.markdown.expect("PDF should produce markdown");
+
+    assert_eq!(
+        markdown.matches("Same text").count(),
+        1,
+        "an overlaid invisible copy must not duplicate visible text: {markdown:?}"
+    );
+}
+
+#[test]
+fn text_rendering_mode_persists_across_bt() {
+    let pdf = make_text_pdf(
+        "3 Tr BT /F1 12 Tf 100 700 Td (Hidden across BT) Tj ET",
+        "0 0 612 792",
+    );
+
+    let visible_items = extract_text_with_positions_mem(&pdf).expect("extract visible text");
+    assert!(
+        visible_items
+            .iter()
+            .all(|item| !item.text.contains("Hidden across BT")),
+        "BT must not reset the text rendering mode"
+    );
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .is_some_and(|markdown| markdown.contains("Hidden across BT")),
+        "the invisible fallback should recover text whose Tr state predates BT"
+    );
+}
+
+#[test]
+fn double_quote_operator_invisible_text_is_recovered() {
+    let pdf = make_text_pdf(
+        "BT /F1 12 Tf 3 Tr 14 TL 0 0 (Hidden double quote) \" ET",
+        "0 0 612 792",
+    );
+
+    let result = process_pdf_mem(&pdf).expect("PDF should parse");
+
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .is_some_and(|markdown| markdown.contains("Hidden double quote")),
+        "the double-quote text-showing operator must participate in invisible fallback; \
+         pdf_type={:?}, markdown={:?}, ocr_pages={:?}",
+        result.pdf_type,
+        result.markdown,
+        result.pages_needing_ocr
     );
 }
 


### PR DESCRIPTION
## Summary

Improve PDF recovery and text extraction for malformed PDF containers and invisible OCR text layers.

## Changes

- Recover malformed classic xref headers such as `xref 0 N`.
- Compose container repairs for leading bytes, truncated `%%EOF`, invalid `startxref`, and malformed xref headers.
- Detect invisible text rendered with `Tr=3`.
- Retry invisible-text extraction per page instead of per document.
- Deduplicate visible text and overlapping invisible OCR copies.
- Keep text items, rectangles, and lines in the same coordinate space after retry.
- Preserve text rendering mode across `BT` operators.
- Support the PDF `"` text-showing operator.

## Why

Some PDF readers tolerate malformed container structures that `lopdf` rejects. In addition, some searchable PDFs store useful OCR text entirely or partially as invisible text.

These cases previously caused parse failures, empty output, missing page content, or duplicated text.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
  - 840 unit tests
  - 159 integration tests
  - 2 CLI tests
  - 2 doc tests
- `cargo build --release`
- Tested against 118 real-world PDFs:
  - 107 extracted successfully
  - 11 correctly requested OCR
  - 0 parse failures
- All 7 previously failing SpringBoot thesis PDFs now parse successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs malformed PDFs and restores invisible OCR text with a per-page fallback that replaces only pages that improve, reducing parse failures and missing content. Adds de-duplication to avoid duplicated text from overlaid OCR layers.

- **Bug Fixes**
  - Compose container repairs (BOM, truncated `%%EOF`, invalid `startxref`, inline `xref 0 N`) and apply on original and stripped buffers.
  - Preserve text rendering mode across `BT`; cap parsed operations; keep items/rects/lines in the same coordinate space after page retries.
  - Treat image placeholders as non-text so invisible OCR fallback can trigger.

- **New Features**
  - Detect invisible text (`Tr=3`) and retry extraction per page; replace only pages that benefit; de-duplicate overlaid invisible OCR copies.
  - Support the `"` text-showing operator by expanding to `Tw`, `Tc`, and `'`; detect `'`/`"` even without operand whitespace.

<sup>Written for commit cadc09be9ff5780cb5441da778921a6b093ad563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

