### PR TITLE
feat(text-quality): add distinct-n self-check to catch duplicated tex…

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -48,6 +48,7 @@ pub struct PdfResult {
     pub pages_with_tables: Vec<u32>,
     pub pages_with_columns: Vec<u32>,
     pub has_encoding_issues: bool,
+    pub distinct_n: Option<f64>,
 }
 
 /// OCR reasons for a single 1-indexed page.
@@ -150,6 +151,7 @@ fn to_napi_result(r: pdf_inspector::PdfProcessResult) -> PdfResult {
         pages_with_tables: r.layout.pages_with_tables,
         pages_with_columns: r.layout.pages_with_columns,
         has_encoding_issues: r.has_encoding_issues,
+        distinct_n: r.distinct_n.map(|v| v as f64),
     }
 }
 

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -19,6 +19,7 @@ class PdfResult:
     pages_with_tables: list[int]
     pages_with_columns: list[int]
     has_encoding_issues: bool
+    distinct_n: Optional[float]
 
 class PageOcrReasons:
     """OCR reasons for a single 1-indexed page."""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,8 @@ use lopdf::Document;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use text_quality::{
-    analyze_text_quality, detect_encoding_issues, is_cid_garbage, is_garbage_text,
-    region_items_have_decoding_issue,
+    analyze_text_quality, compute_distinct_n, detect_encoding_issues, is_cid_garbage,
+    is_garbage_text, region_items_have_decoding_issue,
 };
 use tounicode::FontCMaps;
 
@@ -118,6 +118,9 @@ pub const OCR_REASON_NO_TEXT: &str = "no_text";
 /// rather than real text operators, so it cannot be extracted as characters.
 pub const OCR_REASON_VECTOR_TEXT: &str = "vector_text";
 
+/// OCR reason emitted when extracted text layer contains severe repetition loops.
+pub const OCR_REASON_SUSPECTED_REPEATED_TEXT: &str = "suspected_repeated_text";
+
 // =========================================================================
 // Result type
 // =========================================================================
@@ -155,6 +158,8 @@ pub struct PdfProcessResult {
     /// `true` when broken font encodings are detected (garbled text,
     /// replacement characters). Clients should fall back to OCR.
     pub has_encoding_issues: bool,
+    /// Uniqueness ratio of line n-grams (0.0–1.0), or `None` if markdown was not generated.
+    pub distinct_n: Option<f32>,
 }
 
 // =========================================================================
@@ -3757,6 +3762,7 @@ fn process_document(
             confidence,
             layout: LayoutComplexity::default(),
             has_encoding_issues: false,
+            distinct_n: None,
         });
     }
 
@@ -3773,6 +3779,7 @@ fn process_document(
             confidence,
             layout: LayoutComplexity::default(),
             has_encoding_issues: false,
+            distinct_n: None,
         });
     }
 
@@ -4090,6 +4097,8 @@ fn process_document(
         markdown
     };
 
+    let distinct_n = markdown.as_ref().map(|md| compute_distinct_n(md, 3, 50));
+
     Ok(PdfProcessResult {
         pdf_type,
         markdown,
@@ -4107,6 +4116,7 @@ fn process_document(
         confidence,
         layout,
         has_encoding_issues,
+        distinct_n,
     })
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -51,6 +51,9 @@ pub struct PyPdfResult {
     /// Whether encoding issues were detected.
     #[pyo3(get)]
     pub has_encoding_issues: bool,
+    /// Uniqueness ratio of line n-grams (0.0-1.0), or None if not computed.
+    #[pyo3(get)]
+    pub distinct_n: Option<f32>,
 }
 
 #[pymethods]
@@ -313,6 +316,7 @@ fn to_py_result(r: crate::PdfProcessResult) -> PyPdfResult {
         pages_with_tables: r.layout.pages_with_tables,
         pages_with_columns: r.layout.pages_with_columns,
         has_encoding_issues: r.has_encoding_issues,
+        distinct_n: r.distinct_n,
     }
 }
 

--- a/src/text_quality.rs
+++ b/src/text_quality.rs
@@ -25,7 +25,9 @@
 //!   distribution is a permutation of natural language ([`CipherGarbleStats`]).
 
 use crate::types::TextItem;
-use crate::{add_ocr_reason, OCR_REASON_SUSPECTED_GARBLED_TEXT};
+use crate::{
+    add_ocr_reason, OCR_REASON_SUSPECTED_GARBLED_TEXT, OCR_REASON_SUSPECTED_REPEATED_TEXT,
+};
 use std::collections::BTreeMap;
 
 /// Detect broken font encodings in extracted markdown text.
@@ -233,12 +235,13 @@ pub(crate) struct TextQualityReport {
 }
 
 #[derive(Debug, Default)]
-struct PageTextQualityEvidence {
+struct PageTextQualityEvidence<'a> {
     chars: usize,
     replacement_chars: usize,
     replacement_spans: usize,
     longest_replacement_run: usize,
     cipher_garble: CipherGarbleStats,
+    items: Vec<&'a TextItem>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -257,6 +260,7 @@ pub(crate) fn analyze_text_quality(items: &[TextItem]) -> TextQualityReport {
         }
 
         let evidence = evidence_by_page.entry(item.page).or_default();
+        evidence.items.push(item);
         evidence.chars += item.text.chars().filter(|ch| !ch.is_whitespace()).count();
         evidence.cipher_garble.add_text(&item.text);
 
@@ -289,6 +293,17 @@ pub(crate) fn analyze_text_quality(items: &[TextItem]) -> TextQualityReport {
                 page,
                 OCR_REASON_SUSPECTED_GARBLED_TEXT,
             );
+        } else {
+            let line_strings = group_spans_into_lines(&evidence.items);
+            let line_refs: Vec<&str> = line_strings.iter().map(|s| s.as_str()).collect();
+            let res = compute_distinct_n_lines_details(&line_refs, 3, 50);
+            if res.total_ngrams >= 10 && res.score < 0.50 {
+                add_ocr_reason(
+                    &mut reasons_by_page,
+                    page,
+                    OCR_REASON_SUSPECTED_REPEATED_TEXT,
+                );
+            }
         }
     }
 
@@ -298,6 +313,55 @@ pub(crate) fn analyze_text_quality(items: &[TextItem]) -> TextQualityReport {
         pages_needing_ocr,
         reasons_by_page,
     }
+}
+
+fn group_spans_into_lines(items: &[&TextItem]) -> Vec<String> {
+    let valid_items: Vec<&&TextItem> = items
+        .iter()
+        .filter(|item| !item.text.trim().is_empty())
+        .collect();
+
+    if valid_items.is_empty() {
+        return Vec::new();
+    }
+
+    let mut sorted = valid_items;
+    sorted.sort_by(|a, b| {
+        b.y.partial_cmp(&a.y)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+    });
+
+    let mut lines = Vec::new();
+    let mut current_line = String::new();
+    let mut current_y = sorted[0].y;
+    let mut last_x: Option<f32> = None;
+
+    for item in sorted {
+        let is_new_y_band = (item.y - current_y).abs() > 3.0;
+        let is_wrapped_x =
+            last_x.is_some_and(|lx| item.x <= lx && (lx - item.x) > 10.0);
+
+        if is_new_y_band || is_wrapped_x {
+            if !current_line.is_empty() {
+                lines.push(current_line);
+                current_line = String::new();
+            }
+            current_y = item.y;
+        }
+
+        if !current_line.is_empty() {
+            current_line.push(' ');
+        }
+        current_line.push_str(item.text.trim());
+        last_x = Some(item.x);
+    }
+
+    if !current_line.is_empty() {
+        lines.push(current_line);
+    }
+
+    lines
 }
 
 pub(crate) fn region_items_have_decoding_issue(items: &[TextItem]) -> bool {
@@ -517,4 +581,226 @@ pub(crate) fn is_cid_garbage(text: &str) -> bool {
     // page to OCR.
     let ascii_letters = text.chars().filter(|c| c.is_ascii_alphabetic()).count();
     total >= 20 && high_latin * 5 >= total * 2 && ascii_letters * 3 < total
+}
+
+/// Compute the distinct-n ratio over a sequence of text lines/spans.
+///
+/// Returns the ratio of unique line n-grams to total line n-grams within a
+/// sliding window.
+///
+/// Normalization:
+/// - Empty/whitespace-only lines are ignored.
+/// - Lines are trimmed and case-folded (lowercase) for comparison.
+///
+/// If `total_ngrams == 0`, returns `1.0`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DistinctNResult {
+    pub(crate) score: f32,
+    pub(crate) total_ngrams: usize,
+}
+
+pub(crate) fn compute_distinct_n(text: &str, n: usize, window_size: usize) -> f32 {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    compute_distinct_n_lines(&lines, n, window_size)
+}
+
+pub(crate) fn compute_distinct_n_lines(lines: &[&str], n: usize, window_size: usize) -> f32 {
+    compute_distinct_n_lines_details(lines, n, window_size).score
+}
+
+pub(crate) fn compute_distinct_n_lines_details(
+    lines: &[&str],
+    n: usize,
+    window_size: usize,
+) -> DistinctNResult {
+    if n == 0 || lines.len() < n {
+        return DistinctNResult {
+            score: 1.0,
+            total_ngrams: 0,
+        };
+    }
+
+    let norm_lines: Vec<String> = lines.iter().map(|l| l.to_lowercase()).collect();
+    let win_size = if window_size == 0 {
+        norm_lines.len()
+    } else {
+        window_size
+    };
+    let mut total_ngrams = 0usize;
+    let mut unique_ngrams = 0usize;
+
+    let mut window_start = 0;
+    while window_start < norm_lines.len() {
+        let window_end = (window_start + win_size).min(norm_lines.len());
+        let window_slice = &norm_lines[window_start..window_end];
+
+        if window_slice.len() >= n {
+            let mut seen = std::collections::HashSet::new();
+            for window in window_slice.windows(n) {
+                total_ngrams += 1;
+                if seen.insert(window) {
+                    unique_ngrams += 1;
+                }
+            }
+        }
+
+        if window_end >= norm_lines.len() {
+            break;
+        }
+        let step = (win_size / 2).max(1);
+        window_start += step;
+    }
+
+    let score = if total_ngrams == 0 {
+        1.0
+    } else {
+        (unique_ngrams as f64 / total_ngrams as f64) as f32
+    };
+
+    DistinctNResult {
+        score,
+        total_ngrams,
+    }
+}
+
+#[cfg(test)]
+mod distinct_n_tests {
+    use super::*;
+    use crate::types::{ItemType, TextItem};
+
+    #[test]
+    fn test_compute_distinct_n_unique_text() {
+        let text = "Line one of document\nLine two of document\nLine three of document\nLine four of document\nLine five of document";
+        let score = compute_distinct_n(text, 3, 50);
+        assert!((score - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_compute_distinct_n_repeated_text() {
+        let text = "Repeated line A\nRepeated line B\nRepeated line C\n".repeat(10);
+        let score = compute_distinct_n(&text, 3, 50);
+        assert!(score < 0.30, "Expected low distinct_n score, got {}", score);
+    }
+
+    #[test]
+    fn test_analyze_text_quality_flags_repeated_text() {
+        let mut items = Vec::new();
+        for i in 0..12 {
+            let y_pos = 500.0 - (i as f32 * 20.0);
+            let line_text = if i % 2 == 0 {
+                "Repeated paragraph line A"
+            } else {
+                "Repeated paragraph line B"
+            };
+            items.push(TextItem {
+                text: line_text.into(),
+                x: 10.0,
+                y: y_pos,
+                width: 100.0,
+                height: 12.0,
+                font: "Helvetica".into(),
+                font_size: 12.0,
+                page: 1,
+                is_bold: false,
+                is_italic: false,
+                is_underline: false,
+                is_strikeout: false,
+                item_type: ItemType::Text,
+                mcid: None,
+            });
+        }
+
+        let report = analyze_text_quality(&items);
+        assert!(report.has_encoding_issues);
+        assert!(report.pages_needing_ocr.contains(&1));
+        let reasons = report.reasons_by_page.get(&1).unwrap();
+        assert!(reasons.contains(&OCR_REASON_SUSPECTED_REPEATED_TEXT.to_string()));
+    }
+
+    #[test]
+    fn test_compute_distinct_n_window_size_one() {
+        let text = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+        // Ensure small window_size=1 does not infinite loop or panic
+        let score = compute_distinct_n(text, 1, 1);
+        assert!(score >= 0.0 && score <= 1.0);
+    }
+
+    #[test]
+    fn test_group_spans_into_lines() {
+        let item1 = TextItem {
+            text: "Hello ".into(),
+            x: 10.0,
+            y: 100.0,
+            width: 30.0,
+            height: 10.0,
+            font: "Helvetica".into(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+        let item_empty = TextItem {
+            text: "   ".into(),
+            x: 40.0,
+            y: 100.0,
+            width: 10.0,
+            height: 10.0,
+            font: "Helvetica".into(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+        let item2 = TextItem {
+            text: "World".into(),
+            x: 50.0,
+            y: 100.0,
+            width: 30.0,
+            height: 10.0,
+            font: "Helvetica".into(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+        let item3 = TextItem {
+            text: "Next line".into(),
+            x: 10.0,
+            y: 80.0,
+            width: 50.0,
+            height: 10.0,
+            font: "Helvetica".into(),
+            font_size: 10.0,
+            page: 1,
+            is_bold: false,
+            is_italic: false,
+            is_underline: false,
+            is_strikeout: false,
+            item_type: ItemType::Text,
+            mcid: None,
+        };
+
+        let items = vec![&item1, &item_empty, &item2, &item3];
+        let lines = group_spans_into_lines(&items);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "Hello World");
+        assert_eq!(lines[1], "Next line");
+    }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -49,6 +49,7 @@ export interface PdfProcessResult {
   confidence: number;
   layout: LayoutComplexity;
   hasEncodingIssues: boolean;
+  distinctN?: number;
 }
 
 export interface PdfClassification {
@@ -130,6 +131,7 @@ struct WasmPdfProcessResult {
     confidence: f64,
     layout: WasmLayoutComplexity,
     has_encoding_issues: bool,
+    distinct_n: Option<f32>,
 }
 
 impl From<PdfProcessResult> for WasmPdfProcessResult {
@@ -149,6 +151,7 @@ impl From<PdfProcessResult> for WasmPdfProcessResult {
             confidence: value.confidence as f64,
             layout: value.layout.into(),
             has_encoding_issues: value.has_encoding_issues,
+            distinct_n: value.distinct_n,
         }
     }
 }


### PR DESCRIPTION
## Problem / Context

PDF text extraction can sometimes produce well-encoded text (valid Unicode, high confidence, no `U+FFFD`) that is **emitted more than once**. Common causes include:
- Form XObjects invoked multiple times or recursively
- Text drawn twice with small offsets for faux-bolding
- Invisible OCR text layers over image layers that also carry text
- Tiling patterns containing text

Currently, `pdf-inspector` has signals for absent text (`pagesNeedingOcr`, `no_text`) and wrongly encoded text (`hasEncodingIssues`, replacement runs), but lacks a metric to catch text emitted repeatedly.

Closes #220.

---

## Solution

This PR introduces the **`distinct-n` metric** and per-page repetition detection:

1. **Windowed Line-based N-Gram Metric (`src/text_quality.rs`)**:
   - Calculates the ratio of unique line n-grams to total line n-grams ($N=3$) within a local sliding window ($W=50$).
   - Sized to structural units (lines) and windowed locally so that recurring running headers, footers, or legitimate multi-page phrases do not trigger false positives.

2. **Per-Page Text Quality Check**:
   - `analyze_text_quality` evaluates line-level distinctness on each page.
   - Pages with $\ge 10$ line n-grams and `distinct_n < 0.50` automatically emit the new `OCR_REASON_SUSPECTED_REPEATED_TEXT` (`"suspected_repeated_text"`), routing the page to `pages_needing_ocr` and setting `has_encoding_issues = true`.

3. **Multi-Language API Field**:
   - **Rust Core**: Added `distinct_n: Option<f32>` to `PdfProcessResult` & constant `pub const OCR_REASON_SUSPECTED_REPEATED_TEXT: &str = "suspected_repeated_text";`.
   - **Python**: Exposed `distinct_n: Optional[float]` in `PyPdfResult` and `.pyi` stubs.
   - **Node.js / NAPI**: Exposed `distinct_n: Option<f64>` on `PdfResult`.
   - **Browser WASM**: Exposed `distinctN?: number` on WASM `PdfProcessResult` TypeScript definitions and serialization.

---

## Verification & Testing

- **Library Unit Tests**: Added unit tests in `src/text_quality.rs` (`distinct_n_tests`). All **838 tests passed** (`cargo test --lib`).
- **Clippy**: `cargo clippy --lib -- -D warnings` completed with **0 warnings / 0 errors**.
- **WASM Package Check**: `cargo check --manifest-path wasm/Cargo.toml` compiled cleanly.
- **Developer Scripts**: `python -m unittest discover -s scripts/tests` passed all 13 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a windowed distinct-n self-check to catch duplicated PDF text and route affected pages to OCR. Also computes and exposes a document-level `distinct_n` ratio across Rust, Python, Node/NAPI, and WASM bindings.

- **New Features**
  - Per-page repetition detection using a line-based n-gram distinct-n metric (N=3, window=50).
  - Pages with ≥10 line n-grams and `distinct_n < 0.50` emit `"suspected_repeated_text"`, are added to `pages_needing_ocr`, and set `has_encoding_issues = true`.
  - New API field: `distinct_n` on `PdfProcessResult` (`Option<f32>` in Rust; `Optional[float]` in Python; `Option<f64>` in Node/NAPI; `distinctN?: number` in WASM), computed from document markdown (None if markdown is unavailable).
  - Added constant `OCR_REASON_SUSPECTED_REPEATED_TEXT`.

- **Bug Fixes**
  - Faster, safer distinct-n with reduced allocations and a half-window step (min 1) to handle small-window cases.
  - More accurate line grouping using Y-band and X-wrap detection; skips whitespace-only spans to reduce false positives.

<sup>Written for commit fda5eaaf0b35f2a21a21620d09459c1164241c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

