### PR TITLE
fix(markdown): collapse exact duplicate text overlays

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1133,6 +1133,61 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         return String::new();
     }
 
+    // Keep positioned extraction faithful to the source operations. Semantic
+    // Markdown needs only one copy of the same text painted at identical
+    // coordinates.
+    #[derive(Eq, Hash, PartialEq)]
+    struct OverlayKey {
+        page: u32,
+        is_form_field: bool,
+        text: String,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        font: String,
+        font_size: u32,
+        is_bold: bool,
+        is_italic: bool,
+        is_underline: bool,
+        is_strikeout: bool,
+    }
+
+    let mut seen_overlays = HashSet::new();
+    let overlay_keep_mask: Vec<bool> = items
+        .iter()
+        .map(|item| match item.item_type {
+            ItemType::Text | ItemType::FormField => seen_overlays.insert(OverlayKey {
+                page: item.page,
+                is_form_field: matches!(item.item_type, ItemType::FormField),
+                text: item.text.clone(),
+                x: item.x.to_bits(),
+                y: item.y.to_bits(),
+                width: item.width.to_bits(),
+                height: item.height.to_bits(),
+                font: item.font.clone(),
+                font_size: item.font_size.to_bits(),
+                is_bold: item.is_bold,
+                is_italic: item.is_italic,
+                is_underline: item.is_underline,
+                is_strikeout: item.is_strikeout,
+            }),
+            _ => true,
+        })
+        .collect();
+    let deduplicated_page_number_mask = prefiltered_page_number_mask.map(|mask| {
+        mask.iter()
+            .zip(&overlay_keep_mask)
+            .filter_map(|(remove, keep)| keep.then_some(*remove))
+            .collect::<Vec<_>>()
+    });
+    let items = items
+        .into_iter()
+        .zip(&overlay_keep_mask)
+        .filter_map(|(item, keep)| keep.then_some(item))
+        .collect::<Vec<_>>();
+    let prefiltered_page_number_mask = deduplicated_page_number_mask.as_deref();
+
     // Table detection must retain the original collection because short
     // numeric table cells can be indistinguishable from folios until
     // structural context is available. A precomputed mask carries the

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1151,6 +1151,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         is_italic: bool,
         is_underline: bool,
         is_strikeout: bool,
+        mcid: Option<i64>,
     }
 
     let mut seen_overlays = HashSet::new();
@@ -1171,6 +1172,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                 is_italic: item.is_italic,
                 is_underline: item.is_underline,
                 is_strikeout: item.is_strikeout,
+                mcid: item.mcid,
             }),
             _ => true,
         })
@@ -2136,6 +2138,42 @@ mod tests {
         let mut it = make_item(x, y, page);
         it.width = width;
         it
+    }
+
+    #[test]
+    fn exact_overlays_with_distinct_mcids_are_not_collapsed() {
+        let mut first = make_item(100.0, 700.0, 1);
+        first.text = "Tagged overlay".into();
+        first.width = 80.0;
+        first.mcid = Some(10);
+
+        let mut second = first.clone();
+        second.mcid = Some(11);
+
+        let struct_roles = HashMap::from([(
+            1,
+            HashMap::from([
+                (10, crate::structure_tree::StructRole::H1),
+                (11, crate::structure_tree::StructRole::H2),
+            ]),
+        )]);
+        let markdown = to_markdown_from_items_with_rects_and_lines(
+            vec![first, second],
+            MarkdownOptions::default(),
+            &[],
+            &[],
+            MarkdownDocumentContext {
+                page_thresholds: &HashMap::new(),
+                struct_roles: Some(&struct_roles),
+                struct_tables: &[],
+                page_count: 1,
+                prefiltered_page_number_pages: None,
+                prefiltered_page_number_mask: None,
+                precomputed_chart_regions: None,
+            },
+        );
+
+        assert_eq!(markdown.matches("Tagged overlay").count(), 2, "{markdown}");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -239,6 +239,31 @@ fn make_minimal_text_pdf() -> Vec<u8> {
     )
 }
 
+#[test]
+fn exact_duplicate_overlay_is_emitted_once_in_markdown() {
+    let content = "BT /F1 10 Tf 1 0 0 1 40 692 Tm (Purchase $19.95) Tj 1 0 0 1 40 692 Tm (Purchase $19.95) Tj 1 0 0 1 40 650 Tm (Purchase $19.95) Tj ET";
+    let pdf = make_text_pdf(content, "0 0 612 792");
+
+    let result = extract_pages_markdown_mem(&pdf, None).expect("overlay PDF should parse");
+    let markdown = &result.pages[0].markdown;
+    assert_eq!(
+        markdown.matches("Purchase $19.95").count(),
+        2,
+        "an exact overlay must collapse without removing text at another position: {markdown}"
+    );
+
+    let positioned = extract_text_with_positions_mem(&pdf)
+        .expect("positioned extraction should keep source operations");
+    assert_eq!(
+        positioned
+            .iter()
+            .filter(|item| item.text.contains("Purchase $19.95"))
+            .count(),
+        3,
+        "the positioned API must keep all source paint operations"
+    );
+}
+
 fn make_digit_run_repro_pdf() -> Vec<u8> {
     let content = r#"BT
 /F1 12 Tf


### PR DESCRIPTION
## Summary

- collapse exact duplicate text and form-field paint operations before Markdown conversion
- keep text at different positions, fonts, sizes, or semantic styles
- preserve every source operation in `extract_text_with_positions`
- keep the precomputed page-number mask aligned after the filter

## Regression proof

`exact_duplicate_overlay_is_emitted_once_in_markdown` failed on `436af97` before the fix.

The synthetic PDF paints `Purchase $19.95` twice at one position and once at another position. The unfixed Markdown contained three copies. The expected semantic Markdown contains two.

After the fix:

- Markdown contains two copies, one for each position
- positioned extraction contains all three source operations

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --offline -- -D warnings`
- [x] `cargo test --offline` — 992 passed
- [x] `cargo build --release --offline`
- [x] manual generated duplicate-overlay fixture through `pdf2md`

The test fixture is generated and contains no external document content.
