### PR TITLE
Harden hex_to_unicode_string against malformed ToUnicode destinations

### DIFF
--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -594,7 +594,7 @@ fn hex_to_unicode_string(hex: &str) -> Option<String> {
 
     let bytes: Option<Vec<u8>> = (0..hex.len())
         .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+        .map(|i| u8::from_str_radix(hex.get(i..i + 2)?, 16).ok())
         .collect();
     let bytes = bytes?;
 
@@ -2604,6 +2604,24 @@ endcmap
         assert_eq!(cmap.lookup(0x0003), Some(" ".to_string()));
         assert_eq!(cmap.lookup(0x0024), Some("A".to_string()));
         assert_eq!(cmap.lookup(0x0025), Some("B".to_string()));
+    }
+
+    #[test]
+    fn test_hex_to_unicode_non_ascii_no_panic() {
+        // A destination containing a multi-byte char makes the byte length even
+        // while a byte offset can land inside a char. Slicing must not panic;
+        // it should be rejected gracefully.
+        assert_eq!(hex_to_unicode_string("XéY"), None);
+        assert_eq!(hex_to_unicode_string("\u{fffd}0"), None);
+    }
+
+    #[test]
+    fn test_parse_bfchar_non_ascii_destination_no_panic() {
+        // Crafted /ToUnicode CMap: a non-hex, non-ASCII destination previously
+        // triggered a char-boundary panic in hex_to_unicode_string.
+        let cmap_content = "beginbfchar <0041> <XéY> endbfchar";
+        // Must not panic; the malformed entry is simply skipped.
+        let _ = ToUnicodeCMap::parse(cmap_content.as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`hex_to_unicode_string` in `src/tounicode.rs` sliced the destination string with `&hex[i..i + 2]` after only checking that the string's byte length is even. An even byte length does not guarantee the offset falls on a UTF-8 char boundary, so a malformed `/ToUnicode` CMap destination containing non-ASCII bytes (which reach the parser via `String::from_utf8_lossy` and the verbatim `parse_bfchar`/`parse_bfrange` copy loops) could cause a byte-index slice that lands inside a multi-byte character. Slicing a `str` at a non-boundary index aborts the current parse via a runtime panic.

This is triggerable purely from untrusted input on the main text-extraction path, so a single malformed document could take down a direct Rust caller, the `wasm` build, and the `pdf2md` / `detect-pdf` binaries.

## Fix

Replace the panicking index with `hex.get(i..i + 2)?`. `get` returns `None` for an out-of-range or non-boundary index, which folds cleanly into the existing `Option` flow — the malformed entry is simply skipped instead of aborting.

```rust
.map(|i| u8::from_str_radix(hex.get(i..i + 2)?, 16).ok())
```

## Tests

Added two regression tests in the `tounicode` test module:

- `test_hex_to_unicode_non_ascii_no_panic` — direct unit test covering a multi-byte char and a replacement-char byte.
- `test_parse_bfchar_non_ascii_destination_no_panic` — end-to-end parse of a malformed CMap; the bad entry is skipped without aborting.

Both fail (abort) before the fix and pass after. All existing `tounicode` tests continue to pass.

Note: this is the same class of issue as the earlier glyph-name boundary fix (a byte-length check used to justify a byte-offset slice of a `str` that can hold non-ASCII text).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fb4d1ce-bf23-424b-9a01-0edd6df7e329?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fb4d1ce-bf23-424b-9a01-0edd6df7e329&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents UTF-8 char-boundary panics in `hex_to_unicode_string` when a `/ToUnicode` CMap has non-ASCII destinations. Malformed entries are now skipped instead of crashing text extraction, the `wasm` build, or the `pdf2md`/`detect-pdf` binaries.

- **Bug Fixes**
  - Replace `&hex[i..i + 2]` with `hex.get(i..i + 2)?` to guard non-boundary/out-of-range slices and skip bad entries.
  - Add regression tests for non-ASCII destinations to ensure no panic and correct skipping behavior.

<sup>Written for commit a825884e5ea351c4a19459110cd73ac56146d99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

