### PR TITLE
Robustness: handle non-ASCII input in uniXXXX glyph name parsing

### DIFF
--- a/src/glyph_names.rs
+++ b/src/glyph_names.rs
@@ -4566,9 +4566,13 @@ pub fn glyph_to_char(name: &str) -> Option<char> {
         }
     }
 
-    // Try to parse uniXXXX format
-    if name.starts_with("uni") && name.len() >= 7 {
-        if let Ok(code) = u32::from_str_radix(&name[3..7], 16) {
+    // Try to parse uniXXXX format.
+    // Use `get` rather than a byte-length check + slice: `name` can contain
+    // non-ASCII bytes (e.g. U+FFFD from lossy UTF-8 decoding of an attacker
+    // controlled /Differences name), so byte index 7 may not be a char
+    // boundary and `&name[3..7]` would panic.
+    if let Some(hex) = name.strip_prefix("uni").and_then(|rest| rest.get(..4)) {
+        if let Ok(code) = u32::from_str_radix(hex, 16) {
             // Strip PUA F000 offset: uniF0XX → U+00XX (Windows Symbol encoding convention)
             let code = if (0xF000..=0xF0FF).contains(&code) {
                 code - 0xF000
@@ -4587,4 +4591,37 @@ pub fn glyph_to_char(name: &str) -> Option<char> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uni_hex_parsing() {
+        assert_eq!(glyph_to_char("uni0041"), Some('A'));
+        assert_eq!(glyph_to_char("uni00e9"), Some('\u{00e9}'));
+        // PUA F0xx symbol-encoding offset is stripped.
+        assert_eq!(glyph_to_char("uniF041"), Some('A'));
+    }
+
+    #[test]
+    fn u_hex_parsing() {
+        assert_eq!(glyph_to_char("u0041"), Some('A'));
+        assert_eq!(glyph_to_char("u1F600"), Some('\u{1F600}'));
+    }
+
+    #[test]
+    fn non_ascii_uni_name_does_not_panic() {
+        // A crafted /Differences name like `/uni#80#80#80#80` decodes via
+        // from_utf8_lossy into "uni" followed by four U+FFFD replacements.
+        // Byte index 7 lands mid-character, so a naive `&name[3..7]` slice
+        // would panic. It must be handled gracefully instead.
+        let crafted = format!("uni{0}{0}{0}{0}", '\u{FFFD}');
+        assert_eq!(glyph_to_char(&crafted), None);
+
+        // Assorted non-ASCII bytes right after the "uni" prefix.
+        assert_eq!(glyph_to_char("uni\u{FFFD}bc"), None);
+        assert_eq!(glyph_to_char("uni\u{00e9}00"), None);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `glyph_to_char` robust to non-ASCII input when parsing the `uniXXXX` glyph-name form in `src/glyph_names.rs`.

The previous code guarded the slice with a byte-length check:

```rust
if name.starts_with("uni") && name.len() >= 7 {
    if let Ok(code) = u32::from_str_radix(&name[3..7], 16) {
```

A byte-length check only proves the index is in bounds — not that it falls on a UTF-8 character boundary. `name` originates from `String::from_utf8_lossy` of a PDF Name object in a font's `/Encoding` `/Differences` array, so it can contain multi-byte `U+FFFD` replacement characters. When that happens, byte index 7 can land in the middle of a character, and slicing a `str` on a non-boundary index panics.

For example, a `/Differences` name of `/uni#80#80#80#80` decodes to `"uni"` followed by four `U+FFFD` replacements (3 bytes each). The resulting string is 15 bytes so both `starts_with("uni")` and `len() >= 7` pass, but index 7 sits inside the second replacement character, so `&name[3..7]` panics.

## Fix

Use a checked slice via `str::get`, which returns `None` on an out-of-range or non-boundary index and folds naturally into the existing `Option`/`Result` flow:

```rust
if let Some(hex) = name.strip_prefix("uni").and_then(|rest| rest.get(..4)) {
    if let Ok(code) = u32::from_str_radix(hex, 16) {
```

Behavior for valid inputs is unchanged; malformed/non-ASCII names now return `None` instead of panicking.

## Tests

Added a `#[cfg(test)]` module covering:
- Valid `uniXXXX` and `uXXXXX` parsing (including the PUA `F0xx` symbol-encoding offset).
- Non-ASCII/`U+FFFD`-containing names that previously triggered a mid-character slice, asserting they return `None` without panicking.

`cargo fmt`, `cargo clippy -- -D warnings` (lib), and `cargo test` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6489b084-dce4-4999-b4e9-af2d3fa5f3eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6489b084-dce4-4999-b4e9-af2d3fa5f3eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent panics in `glyph_to_char` by parsing `uniXXXX` glyph names with a checked slice, so non-ASCII input no longer slices mid-char. Invalid names now return None; valid cases (including the `F0xx` offset) are unchanged, with tests added.

<sup>Written for commit bfb33caa37b6f3be404b3dd92eac516f1419f75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

