### PR TITLE
fix(structure-tree): bound recursive /K parsing with cycle detection and a node budget

### DIFF
--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -267,9 +267,10 @@ impl StructTree {
         if walk.truncated {
             log::warn!(
                 "structure tree parsing was truncated (node budget of \
-                 {MAX_STRUCT_NODES} reached, a `/K` reference cycle, or the max \
-                 nesting depth of {MAX_DEPTH}); tagged roles/tables may be \
-                 incomplete (likely a very large or malformed tagged PDF)"
+                 {MAX_STRUCT_NODES} or traversal budget of {MAX_STRUCT_WORK} \
+                 reached, a `/K` reference cycle, or the max nesting depth of \
+                 {MAX_DEPTH}); tagged roles/tables may be incomplete (likely a \
+                 very large or malformed tagged PDF)"
             );
         }
 

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -9,7 +9,7 @@
 use log::debug;
 use lopdf::{Document, Object, ObjectId};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ─── Standard structure types ────────────────────────────────────────
 
@@ -252,8 +252,16 @@ impl StructTree {
         let role_map = parse_role_map(doc, struct_root);
         debug!("structure tree: {} role map entries", role_map.len());
 
+        // Seed the cycle guard with the struct-root's own object id so a `/K`
+        // that points back at the root is treated as a cycle, and bound total
+        // node materialization with a global budget.
+        let mut walk = StructWalk::new();
+        if let Ok(root_id) = struct_root_obj.as_reference() {
+            walk.active.insert(root_id);
+        }
+
         // Parse child elements from /K
-        let children = parse_kids(doc, struct_root, &role_map, None, 0);
+        let children = parse_kids(doc, struct_root, &role_map, None, 0, &mut walk);
         debug!("structure tree: {} top-level elements", children.len());
 
         if children.is_empty() {
@@ -479,6 +487,34 @@ fn parse_role_map(doc: &Document, struct_root: &lopdf::Dictionary) -> HashMap<St
 /// malformed PDFs).
 const MAX_DEPTH: usize = 64;
 
+/// Global cap on the number of structure-tree nodes materialized in a single
+/// parse. Real tagged trees are far smaller; a crafted PDF can alias one struct
+/// element into its own `/K` (e.g. `/K [n 0 R n 0 R]`) so the tree branches
+/// exponentially (2^depth) before the depth cap is reached, exhausting memory.
+/// This budget bounds total work and allocation regardless of tree shape.
+const MAX_STRUCT_NODES: usize = 500_000;
+
+/// Traversal state shared across the recursive structure-tree parse.
+///
+/// `budget` is a global allowance of nodes still permitted to be materialized;
+/// it caps total work even for aliased/DAG-shaped `/K` graphs of distinct
+/// objects. `active` holds the object IDs currently on the depth-first path so
+/// a struct element that references itself (or an ancestor) is not expanded
+/// into an unbounded/exponential subtree.
+struct StructWalk {
+    budget: usize,
+    active: HashSet<ObjectId>,
+}
+
+impl StructWalk {
+    fn new() -> Self {
+        Self {
+            budget: MAX_STRUCT_NODES,
+            active: HashSet::new(),
+        }
+    }
+}
+
 /// Parse child elements from a `/K` entry.
 fn parse_kids(
     doc: &Document,
@@ -486,8 +522,9 @@ fn parse_kids(
     role_map: &HashMap<String, String>,
     inherited_page: Option<ObjectId>,
     depth: usize,
+    walk: &mut StructWalk,
 ) -> Vec<StructElement> {
-    if depth >= MAX_DEPTH {
+    if depth >= MAX_DEPTH || walk.budget == 0 {
         return Vec::new();
     }
 
@@ -498,21 +535,50 @@ fn parse_kids(
     // /Pg on this element (inherited by children)
     let page_id = get_page_ref(doc, dict).or(inherited_page);
 
+    let mut children = Vec::new();
     match k_obj {
         Object::Array(arr) => {
-            let mut children = Vec::new();
             for item in arr {
-                let resolved = resolve_obj(doc, item);
-                parse_kid(doc, resolved, role_map, page_id, depth, &mut children);
+                process_kid_item(doc, item, role_map, page_id, depth, &mut children, walk);
             }
-            children
         }
         other => {
-            let resolved = resolve_obj(doc, other);
-            let mut children = Vec::new();
-            parse_kid(doc, resolved, role_map, page_id, depth, &mut children);
-            children
+            process_kid_item(doc, other, role_map, page_id, depth, &mut children, walk);
         }
+    }
+    children
+}
+
+/// Resolve one `/K` array item (following at most one level of indirection),
+/// guarding against reference cycles and the global node budget, then dispatch
+/// it via [`parse_kid`].
+fn process_kid_item(
+    doc: &Document,
+    item: &Object,
+    role_map: &HashMap<String, String>,
+    inherited_page: Option<ObjectId>,
+    depth: usize,
+    out: &mut Vec<StructElement>,
+    walk: &mut StructWalk,
+) {
+    if walk.budget == 0 || depth >= MAX_DEPTH {
+        return;
+    }
+    // If this child is an indirect reference, track its id on the active path so
+    // a self/ancestor reference is not expanded into an exponential subtree.
+    let ref_id = match item {
+        Object::Reference(id) => Some(*id),
+        _ => None,
+    };
+    if let Some(id) = ref_id {
+        if !walk.active.insert(id) {
+            return; // cycle: this object is already on the current path
+        }
+    }
+    let resolved = resolve_obj(doc, item);
+    parse_kid(doc, resolved, role_map, inherited_page, depth, out, walk);
+    if let Some(id) = ref_id {
+        walk.active.remove(&id);
     }
 }
 
@@ -524,10 +590,15 @@ fn parse_kid(
     inherited_page: Option<ObjectId>,
     depth: usize,
     out: &mut Vec<StructElement>,
+    walk: &mut StructWalk,
 ) {
     match obj {
         // Direct MCID integer — create a leaf wrapper
         Object::Integer(mcid) => {
+            if walk.budget == 0 {
+                return;
+            }
+            walk.budget -= 1;
             // This is a bare MCID at the struct-element level.
             // We attach it to the parent element, so we create a wrapper struct element.
             // Actually, bare MCIDs inside /K are content refs for the parent,
@@ -546,11 +617,11 @@ fn parse_kid(
             });
         }
         Object::Dictionary(d) => {
-            parse_struct_element_dict(doc, d, role_map, inherited_page, depth, out);
+            parse_struct_element_dict(doc, d, role_map, inherited_page, depth, out, walk);
         }
         Object::Stream(s) => {
             // Some PDFs wrap struct elements in streams (rare)
-            parse_struct_element_dict(doc, &s.dict, role_map, inherited_page, depth, out);
+            parse_struct_element_dict(doc, &s.dict, role_map, inherited_page, depth, out, walk);
         }
         _ => {}
     }
@@ -565,10 +636,14 @@ fn parse_struct_element_dict(
     inherited_page: Option<ObjectId>,
     depth: usize,
     out: &mut Vec<StructElement>,
+    walk: &mut StructWalk,
 ) {
-    if depth >= MAX_DEPTH {
+    if depth >= MAX_DEPTH || walk.budget == 0 {
         return;
     }
+    // Charge this node against the global budget so aliased/DAG-shaped `/K`
+    // graphs (which the per-path cycle guard alone cannot bound) still stop.
+    walk.budget -= 1;
     // Check if this is a marked-content reference dict (has /Type /MCR)
     if is_mcr_dict(dict) {
         if let Ok(Object::Integer(mcid)) = dict.get(b"MCID") {
@@ -628,6 +703,13 @@ fn parse_struct_element_dict(
             }
             Object::Array(arr) => {
                 for item in arr {
+                    if walk.budget == 0 {
+                        break;
+                    }
+                    let ref_id = match item {
+                        Object::Reference(id) => Some(*id),
+                        _ => None,
+                    };
                     let resolved = resolve_obj(doc, item);
                     match resolved {
                         Object::Integer(mcid) => {
@@ -648,24 +730,28 @@ fn parse_struct_element_dict(
                             } else if is_objr_dict(d) {
                                 // Skip object references
                             } else {
-                                parse_struct_element_dict(
+                                recurse_struct_child(
                                     doc,
+                                    ref_id,
                                     d,
                                     role_map,
                                     page_id,
-                                    depth + 1,
+                                    depth,
                                     &mut children,
+                                    walk,
                                 );
                             }
                         }
                         Object::Stream(s) => {
-                            parse_struct_element_dict(
+                            recurse_struct_child(
                                 doc,
+                                ref_id,
                                 &s.dict,
                                 role_map,
                                 page_id,
-                                depth + 1,
+                                depth,
                                 &mut children,
+                                walk,
                             );
                         }
                         _ => {}
@@ -682,7 +768,20 @@ fn parse_struct_element_dict(
                         });
                     }
                 } else {
-                    parse_struct_element_dict(doc, d, role_map, page_id, depth + 1, &mut children);
+                    let ref_id = match k_obj {
+                        Object::Reference(id) => Some(*id),
+                        _ => None,
+                    };
+                    recurse_struct_child(
+                        doc,
+                        ref_id,
+                        d,
+                        role_map,
+                        page_id,
+                        depth,
+                        &mut children,
+                        walk,
+                    );
                 }
             }
             _ => {}
@@ -697,6 +796,36 @@ fn parse_struct_element_dict(
         content_refs,
         children,
     });
+}
+
+/// Recurse into a child struct-element dictionary, guarding against reference
+/// cycles (via the active-path object-id set) and the global node budget.
+///
+/// `ref_id` is the object id of the child when it was reached through an
+/// indirect reference (`None` for an inline dictionary, which cannot alias).
+#[allow(clippy::too_many_arguments)]
+fn recurse_struct_child(
+    doc: &Document,
+    ref_id: Option<ObjectId>,
+    dict: &lopdf::Dictionary,
+    role_map: &HashMap<String, String>,
+    inherited_page: Option<ObjectId>,
+    depth: usize,
+    out: &mut Vec<StructElement>,
+    walk: &mut StructWalk,
+) {
+    if walk.budget == 0 {
+        return;
+    }
+    if let Some(id) = ref_id {
+        if !walk.active.insert(id) {
+            return; // cycle: this object is already on the current path
+        }
+    }
+    parse_struct_element_dict(doc, dict, role_map, inherited_page, depth + 1, out, walk);
+    if let Some(id) = ref_id {
+        walk.active.remove(&id);
+    }
 }
 
 /// Check if dict has `/Type /MCR`.
@@ -901,6 +1030,7 @@ fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lopdf::dictionary;
 
     #[test]
     fn non_heading_content_roles() {
@@ -1230,5 +1360,122 @@ mod tests {
         let page_ids = doc.get_pages();
         let role_map = tree.mcid_to_roles(&page_ids);
         assert!(!role_map.is_empty(), "Should have MCID→role mappings");
+    }
+
+    fn count_nodes(elems: &[StructElement]) -> usize {
+        elems.iter().map(|e| 1 + count_nodes(&e.children)).sum()
+    }
+
+    /// Wrap already-created struct elements under a `/StructTreeRoot` and
+    /// `/Catalog`, returning a document ready for [`StructTree::from_doc`].
+    /// `root_kid` is the top-level element the root's `/K` points at.
+    fn finalize_tagged_doc(mut doc: Document, root_kid: ObjectId) -> Document {
+        let root_id = doc.add_object(dictionary! {
+            "Type" => "StructTreeRoot",
+            "K" => vec![Object::Reference(root_kid)],
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "StructTreeRoot" => Object::Reference(root_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        doc
+    }
+
+    #[test]
+    fn struct_tree_self_alias_kids_terminates() {
+        // A struct element that lists itself twice in `/K` (`/K [n 0 R n 0 R]`)
+        // must not expand into an exponential tree.
+        let mut doc = Document::new();
+        let elem = doc.new_object_id();
+        doc.set_object(
+            elem,
+            dictionary! {
+                "Type" => "StructElem",
+                "S" => "Div",
+                "K" => vec![Object::Reference(elem), Object::Reference(elem)],
+            },
+        );
+        let doc = finalize_tagged_doc(doc, elem);
+
+        let tree = StructTree::from_doc(&doc).expect("tree should parse");
+        let n = count_nodes(&tree.children);
+        assert!(
+            n < 10,
+            "self-alias must not explode; materialized {n} nodes"
+        );
+    }
+
+    #[test]
+    fn struct_tree_mutual_alias_kids_terminates() {
+        // A → B → A cycle via `/K` must terminate.
+        let mut doc = Document::new();
+        let a = doc.new_object_id();
+        let b = doc.new_object_id();
+        doc.set_object(
+            a,
+            dictionary! {
+                "Type" => "StructElem",
+                "S" => "Div",
+                "K" => vec![Object::Reference(b), Object::Reference(b)],
+            },
+        );
+        doc.set_object(
+            b,
+            dictionary! {
+                "Type" => "StructElem",
+                "S" => "Div",
+                "K" => vec![Object::Reference(a), Object::Reference(a)],
+            },
+        );
+        let doc = finalize_tagged_doc(doc, a);
+
+        let tree = StructTree::from_doc(&doc).expect("tree should parse");
+        let n = count_nodes(&tree.children);
+        assert!(
+            n < 100,
+            "mutual alias must terminate small; materialized {n} nodes"
+        );
+    }
+
+    #[test]
+    fn struct_tree_aliased_dag_respects_node_budget() {
+        // Distinct elements, each aliased twice in the next level's `/K`, form a
+        // DAG that would expand to 2^depth nodes (the per-path cycle guard does
+        // not catch this since every id is on the path only once). The global
+        // node budget must cap total materialization.
+        let mut doc = Document::new();
+        let levels = 22; // 2^22 ≈ 4.2M unbounded, well past the budget
+        let ids: Vec<ObjectId> = (0..=levels).map(|_| doc.new_object_id()).collect();
+        for i in 0..levels {
+            doc.set_object(
+                ids[i],
+                dictionary! {
+                    "Type" => "StructElem",
+                    "S" => "Div",
+                    "K" => vec![Object::Reference(ids[i + 1]), Object::Reference(ids[i + 1])],
+                },
+            );
+        }
+        doc.set_object(
+            ids[levels],
+            dictionary! { "Type" => "StructElem", "S" => "P" },
+        );
+        let root_id = doc.add_object(dictionary! {
+            "Type" => "StructTreeRoot",
+            "K" => vec![Object::Reference(ids[0])],
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "StructTreeRoot" => Object::Reference(root_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let tree = StructTree::from_doc(&doc).expect("tree should parse");
+        let n = count_nodes(&tree.children);
+        assert!(
+            n <= MAX_STRUCT_NODES,
+            "node count {n} exceeded budget {MAX_STRUCT_NODES}"
+        );
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -513,11 +513,15 @@ const MAX_STRUCT_NODES: usize = 500_000;
 /// (or an ancestor) is not expanded into an unbounded/exponential subtree.
 /// `truncated` records whether any parse work was skipped — the budget was
 /// exhausted, a `/K` reference cycle was broken, or the depth cap was hit — so
-/// the caller can log it once rather than per skipped item.
+/// the caller can log it once rather than per skipped item. `stalled` is set
+/// when an atomic multi-unit reservation could not fit in the remaining budget;
+/// it makes [`exhausted`](Self::exhausted) report done so a wide `/K` array is
+/// not scanned to the end once no further leaf can be materialized.
 struct StructWalk {
     budget: usize,
     active: HashSet<ObjectId>,
     truncated: bool,
+    stalled: bool,
 }
 
 impl StructWalk {
@@ -526,6 +530,7 @@ impl StructWalk {
             budget: MAX_STRUCT_NODES,
             active: HashSet::new(),
             truncated: false,
+            stalled: false,
         }
     }
 
@@ -550,24 +555,28 @@ impl StructWalk {
 
     /// Atomically charge `n` units for a single item that materializes several
     /// budget-counted parts at once (a leaf wrapper node *plus* its content
-    /// reference). Charges nothing and flags truncation when fewer than `n`
-    /// units remain, so a partial reservation never wastes capacity that a later
-    /// smaller item could have used.
+    /// reference). Charges nothing when fewer than `n` units remain — so a
+    /// partial reservation never wastes capacity — and marks the walk `stalled`
+    /// so the enclosing loop stops instead of scanning the rest of a wide `/K`
+    /// array that can no longer fit any leaf.
     fn charge_n(&mut self, n: usize) -> bool {
         if self.budget < n {
             self.truncated = true;
+            self.stalled = true;
             return false;
         }
         self.budget -= n;
         true
     }
 
-    /// Whether the budget is spent. Use this at the guards that break/return to
-    /// skip remaining items: it records that truncation occurred (a guard only
-    /// fires while there is still an item pending), so callers that drop work
-    /// without going through [`charge`] still flag the truncation for logging.
+    /// Whether traversal should stop: the budget is spent, or a multi-unit
+    /// reservation could not fit (`stalled`) so no further leaf will materialize.
+    /// Use this at the guards that break/return to skip remaining items; it
+    /// records that truncation occurred (a guard only fires while an item is
+    /// still pending), so callers that drop work without going through
+    /// [`charge`](Self::charge) still flag the truncation for logging.
     fn exhausted(&mut self) -> bool {
-        if self.budget == 0 {
+        if self.budget == 0 || self.stalled {
             self.truncated = true;
             true
         } else {
@@ -1770,6 +1779,25 @@ mod tests {
         parse_struct_element_dict(&doc, &mcr, &role_map, None, 0, &mut out, &mut walk);
         assert!(out.is_empty(), "MCR dict must not partially materialize");
         assert_eq!(walk.budget, 1, "the leftover unit must be preserved");
+        assert!(walk.truncated);
+    }
+
+    #[test]
+    fn insufficient_reservation_stops_the_scan() {
+        // A one-unit budget is not "exhausted" for a one-unit item, but once a
+        // two-unit leaf reservation fails, the walk is stalled so enclosing `/K`
+        // loops stop instead of scanning the rest of a wide array.
+        let mut walk = StructWalk::new();
+        walk.budget = 1;
+        assert!(
+            !walk.exhausted(),
+            "one unit left must still allow a one-unit item"
+        );
+        assert!(!walk.charge_n(2), "cannot reserve two units from one");
+        assert!(
+            walk.exhausted(),
+            "an insufficient reservation must stop the loop"
+        );
         assert!(walk.truncated);
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -710,18 +710,23 @@ fn parse_struct_element_dict(
     // Check if this is a marked-content reference dict (has /Type /MCR)
     if is_mcr_dict(dict) {
         if let Ok(Object::Integer(mcid)) = dict.get(b"MCID") {
-            let page_id = get_page_ref(doc, dict).or(inherited_page);
-            out.push(StructElement {
-                role: StructRole::Span,
-                alt_text: None,
-                actual_text: None,
-                lang: None,
-                content_refs: vec![MarkedContentRef {
-                    mcid: *mcid,
-                    page_id,
-                }],
-                children: Vec::new(),
-            });
+            // The entry charge above covered the wrapper node; charge once more
+            // for the content reference so this matches the bare-MCID path
+            // (both materialize a Span node + one reference = two items).
+            if walk.charge() {
+                let page_id = get_page_ref(doc, dict).or(inherited_page);
+                out.push(StructElement {
+                    role: StructRole::Span,
+                    alt_text: None,
+                    actual_text: None,
+                    lang: None,
+                    content_refs: vec![MarkedContentRef {
+                        mcid: *mcid,
+                        page_id,
+                    }],
+                    children: Vec::new(),
+                });
+            }
         }
         return;
     }
@@ -1691,6 +1696,26 @@ mod tests {
             before - walk.budget,
             2,
             "bare MCID must charge for both the node and its content reference"
+        );
+    }
+
+    #[test]
+    fn mcr_dict_charges_node_and_reference() {
+        // A top-level MCR `/K` dict materializes the same wrapper node + content
+        // reference as a bare MCID, so it must charge the same two budget units
+        // (not one), keeping the per-item budgeting uniform.
+        let doc = Document::new();
+        let obj = Object::Dictionary(dictionary! { "Type" => "MCR", "MCID" => 3 });
+        let role_map = HashMap::new();
+        let mut out = Vec::new();
+        let mut walk = StructWalk::new();
+        let before = walk.budget;
+        parse_kid(&doc, &obj, &role_map, None, 0, &mut out, &mut walk);
+        assert_eq!(out.len(), 1, "MCR dict should materialize one wrapper node");
+        assert_eq!(
+            before - walk.budget,
+            2,
+            "MCR dict must charge for both the node and its content reference"
         );
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -548,6 +548,20 @@ impl StructWalk {
         true
     }
 
+    /// Atomically charge `n` units for a single item that materializes several
+    /// budget-counted parts at once (a leaf wrapper node *plus* its content
+    /// reference). Charges nothing and flags truncation when fewer than `n`
+    /// units remain, so a partial reservation never wastes capacity that a later
+    /// smaller item could have used.
+    fn charge_n(&mut self, n: usize) -> bool {
+        if self.budget < n {
+            self.truncated = true;
+            return false;
+        }
+        self.budget -= n;
+        true
+    }
+
     /// Whether the budget is spent. Use this at the guards that break/return to
     /// skip remaining items: it records that truncation occurred (a guard only
     /// fires while there is still an item pending), so callers that drop work
@@ -654,9 +668,9 @@ fn parse_kid(
     match obj {
         // Direct MCID integer — create a leaf wrapper
         Object::Integer(mcid) => {
-            // This materializes both a wrapper node and a marked-content
-            // reference, so charge two units to match the per-item budget.
-            if !walk.charge() || !walk.charge() {
+            // A wrapper node plus its content reference — two items — reserved
+            // atomically so we never consume one unit without emitting both.
+            if !walk.charge_n(2) {
                 return;
             }
             // This is a bare MCID at the struct-element level.
@@ -702,32 +716,36 @@ fn parse_struct_element_dict(
         walk.note_skipped();
         return;
     }
+
+    // A marked-content reference dict materializes a wrapper node + one content
+    // reference (two items). Reserve both atomically *before* the node charge so
+    // we never consume a unit without emitting the reference — which would also
+    // deny that unit to a later element that would have fit. This matches the
+    // bare-MCID path.
+    if is_mcr_dict(dict) {
+        if let Ok(Object::Integer(mcid)) = dict.get(b"MCID") {
+            if !walk.charge_n(2) {
+                return;
+            }
+            let page_id = get_page_ref(doc, dict).or(inherited_page);
+            out.push(StructElement {
+                role: StructRole::Span,
+                alt_text: None,
+                actual_text: None,
+                lang: None,
+                content_refs: vec![MarkedContentRef {
+                    mcid: *mcid,
+                    page_id,
+                }],
+                children: Vec::new(),
+            });
+        }
+        return;
+    }
+
     // Charge this node against the global budget so aliased/DAG-shaped `/K`
     // graphs (which the per-path cycle guard alone cannot bound) still stop.
     if !walk.charge() {
-        return;
-    }
-    // Check if this is a marked-content reference dict (has /Type /MCR)
-    if is_mcr_dict(dict) {
-        if let Ok(Object::Integer(mcid)) = dict.get(b"MCID") {
-            // The entry charge above covered the wrapper node; charge once more
-            // for the content reference so this matches the bare-MCID path
-            // (both materialize a Span node + one reference = two items).
-            if walk.charge() {
-                let page_id = get_page_ref(doc, dict).or(inherited_page);
-                out.push(StructElement {
-                    role: StructRole::Span,
-                    alt_text: None,
-                    actual_text: None,
-                    lang: None,
-                    content_refs: vec![MarkedContentRef {
-                        mcid: *mcid,
-                        page_id,
-                    }],
-                    children: Vec::new(),
-                });
-            }
-        }
         return;
     }
 
@@ -1717,5 +1735,41 @@ mod tests {
             2,
             "MCR dict must charge for both the node and its content reference"
         );
+    }
+
+    #[test]
+    fn leaf_wrappers_reserve_both_units_atomically() {
+        // With only one unit left, a two-item leaf wrapper (bare MCID or MCR
+        // dict) must consume nothing and flag truncation, leaving the unit for a
+        // later single-item element instead of half-charging.
+        let doc = Document::new();
+        let role_map = HashMap::new();
+
+        // Bare MCID via parse_kid.
+        let mut walk = StructWalk::new();
+        walk.budget = 1;
+        let mut out = Vec::new();
+        parse_kid(
+            &doc,
+            &Object::Integer(5),
+            &role_map,
+            None,
+            0,
+            &mut out,
+            &mut walk,
+        );
+        assert!(out.is_empty(), "bare MCID must not partially materialize");
+        assert_eq!(walk.budget, 1, "the leftover unit must be preserved");
+        assert!(walk.truncated);
+
+        // MCR dict via parse_struct_element_dict.
+        let mcr = dictionary! { "Type" => "MCR", "MCID" => 1 };
+        let mut walk = StructWalk::new();
+        walk.budget = 1;
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &mcr, &role_map, None, 0, &mut out, &mut walk);
+        assert!(out.is_empty(), "MCR dict must not partially materialize");
+        assert_eq!(walk.budget, 1, "the leftover unit must be preserved");
+        assert!(walk.truncated);
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -538,6 +538,19 @@ impl StructWalk {
         self.budget -= 1;
         true
     }
+
+    /// Whether the budget is spent. Use this at the guards that break/return to
+    /// skip remaining items: it records that truncation occurred (a guard only
+    /// fires while there is still an item pending), so callers that drop work
+    /// without going through [`charge`] still flag the truncation for logging.
+    fn exhausted(&mut self) -> bool {
+        if self.budget == 0 {
+            self.truncated = true;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 /// Parse child elements from a `/K` entry.
@@ -549,7 +562,7 @@ fn parse_kids(
     depth: usize,
     walk: &mut StructWalk,
 ) -> Vec<StructElement> {
-    if depth >= MAX_DEPTH || walk.budget == 0 {
+    if depth >= MAX_DEPTH || walk.exhausted() {
         return Vec::new();
     }
 
@@ -564,7 +577,7 @@ fn parse_kids(
     match k_obj {
         Object::Array(arr) => {
             for item in arr {
-                if walk.budget == 0 {
+                if walk.exhausted() {
                     break;
                 }
                 process_kid_item(doc, item, role_map, page_id, depth, &mut children, walk);
@@ -589,7 +602,7 @@ fn process_kid_item(
     out: &mut Vec<StructElement>,
     walk: &mut StructWalk,
 ) {
-    if walk.budget == 0 || depth >= MAX_DEPTH {
+    if walk.exhausted() || depth >= MAX_DEPTH {
         return;
     }
     // If this child is an indirect reference, track its id on the active path so
@@ -731,7 +744,7 @@ fn parse_struct_element_dict(
             }
             Object::Array(arr) => {
                 for item in arr {
-                    if walk.budget == 0 {
+                    if walk.exhausted() {
                         break;
                     }
                     // Only content-ref items (bare MCIDs / MCR dicts) are charged
@@ -853,7 +866,7 @@ fn recurse_struct_child(
     out: &mut Vec<StructElement>,
     walk: &mut StructWalk,
 ) {
-    if walk.budget == 0 {
+    if walk.exhausted() {
         return;
     }
     if let Some(id) = ref_id {
@@ -1557,5 +1570,50 @@ mod tests {
         // Stays exhausted/flagged on subsequent calls.
         assert!(!walk.charge());
         assert!(walk.truncated);
+    }
+
+    #[test]
+    fn exhausted_flags_truncation_after_budget_spent_by_charge() {
+        // The dominant truncation path: the budget is driven to 0 by a
+        // successful `charge()` (which does not set the flag), and remaining
+        // items are then dropped by an `exhausted()` guard — which must flag it.
+        let mut walk = StructWalk::new();
+        walk.budget = 1;
+        assert!(walk.charge());
+        assert!(
+            !walk.truncated,
+            "spending the last unit is not truncation yet"
+        );
+        assert!(walk.exhausted(), "budget is now spent");
+        assert!(
+            walk.truncated,
+            "the guard that skips work must flag truncation"
+        );
+    }
+
+    #[test]
+    fn wide_kids_array_flags_truncation_via_parser() {
+        // Reproduce the reviewer's scenario through the real parser: a `/K`
+        // array wider than the budget drives the budget to 0 via `charge()`,
+        // then the loop guard drops the rest — the truncation flag must be set
+        // (so `from_doc` logs it) rather than staying silently false.
+        let mut doc = Document::new();
+        let elem = doc.new_object_id();
+        let kids: Vec<Object> = (0..20i64).map(Object::Integer).collect();
+        doc.set_object(
+            elem,
+            dictionary! { "Type" => "StructElem", "S" => "P", "K" => kids },
+        );
+        let dict = doc.get_dictionary(elem).unwrap().clone();
+
+        let mut walk = StructWalk::new();
+        walk.budget = 5; // smaller than the 20-item `/K` array
+        let role_map = HashMap::new();
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &dict, &role_map, None, 0, &mut out, &mut walk);
+        assert!(
+            walk.truncated,
+            "a `/K` array wider than the budget must flag truncation"
+        );
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -266,9 +266,10 @@ impl StructTree {
 
         if walk.truncated {
             log::warn!(
-                "structure tree hit the {MAX_STRUCT_NODES}-node budget and was \
-                 truncated; tagged roles/tables may be incomplete (likely a very \
-                 large or malformed tagged PDF)"
+                "structure tree parsing was truncated (node budget of \
+                 {MAX_STRUCT_NODES} reached, a `/K` reference cycle, or the max \
+                 nesting depth of {MAX_DEPTH}); tagged roles/tables may be \
+                 incomplete (likely a very large or malformed tagged PDF)"
             );
         }
 
@@ -510,8 +511,9 @@ const MAX_STRUCT_NODES: usize = 500_000;
 /// single element with a very wide `/K` array. `active` holds the object IDs
 /// currently on the depth-first path so a struct element that references itself
 /// (or an ancestor) is not expanded into an unbounded/exponential subtree.
-/// `truncated` records whether the budget was ever exhausted so the caller can
-/// log it once rather than per skipped item.
+/// `truncated` records whether any parse work was skipped — the budget was
+/// exhausted, a `/K` reference cycle was broken, or the depth cap was hit — so
+/// the caller can log it once rather than per skipped item.
 struct StructWalk {
     budget: usize,
     active: HashSet<ObjectId>,
@@ -525,6 +527,13 @@ impl StructWalk {
             active: HashSet::new(),
             truncated: false,
         }
+    }
+
+    /// Record that some parse work was skipped for a non-budget reason (a `/K`
+    /// reference cycle or the depth cap), so the one-shot truncation warning
+    /// also covers malformed/over-deep trees, not just budget exhaustion.
+    fn note_skipped(&mut self) {
+        self.truncated = true;
     }
 
     /// Charge one unit against the budget for a materialized item (a struct
@@ -562,7 +571,11 @@ fn parse_kids(
     depth: usize,
     walk: &mut StructWalk,
 ) -> Vec<StructElement> {
-    if depth >= MAX_DEPTH || walk.exhausted() {
+    if depth >= MAX_DEPTH {
+        walk.note_skipped();
+        return Vec::new();
+    }
+    if walk.exhausted() {
         return Vec::new();
     }
 
@@ -602,7 +615,11 @@ fn process_kid_item(
     out: &mut Vec<StructElement>,
     walk: &mut StructWalk,
 ) {
-    if walk.exhausted() || depth >= MAX_DEPTH {
+    if walk.exhausted() {
+        return;
+    }
+    if depth >= MAX_DEPTH {
+        walk.note_skipped();
         return;
     }
     // If this child is an indirect reference, track its id on the active path so
@@ -613,6 +630,7 @@ fn process_kid_item(
     };
     if let Some(id) = ref_id {
         if !walk.active.insert(id) {
+            walk.note_skipped();
             return; // cycle: this object is already on the current path
         }
     }
@@ -636,7 +654,9 @@ fn parse_kid(
     match obj {
         // Direct MCID integer — create a leaf wrapper
         Object::Integer(mcid) => {
-            if !walk.charge() {
+            // This materializes both a wrapper node and a marked-content
+            // reference, so charge two units to match the per-item budget.
+            if !walk.charge() || !walk.charge() {
                 return;
             }
             // This is a bare MCID at the struct-element level.
@@ -678,9 +698,13 @@ fn parse_struct_element_dict(
     out: &mut Vec<StructElement>,
     walk: &mut StructWalk,
 ) {
+    if depth >= MAX_DEPTH {
+        walk.note_skipped();
+        return;
+    }
     // Charge this node against the global budget so aliased/DAG-shaped `/K`
     // graphs (which the per-path cycle guard alone cannot bound) still stop.
-    if depth >= MAX_DEPTH || !walk.charge() {
+    if !walk.charge() {
         return;
     }
     // Check if this is a marked-content reference dict (has /Type /MCR)
@@ -871,6 +895,7 @@ fn recurse_struct_child(
     }
     if let Some(id) = ref_id {
         if !walk.active.insert(id) {
+            walk.note_skipped();
             return; // cycle: this object is already on the current path
         }
     }
@@ -1614,6 +1639,58 @@ mod tests {
         assert!(
             walk.truncated,
             "a `/K` array wider than the budget must flag truncation"
+        );
+    }
+
+    #[test]
+    fn cycle_skip_flags_truncation() {
+        // A `/K` reference cycle is dropped rather than expanded; that skip must
+        // still flag truncation so the one-shot warning fires for malformed
+        // trees, not only for budget exhaustion.
+        let mut doc = Document::new();
+        let elem = doc.new_object_id();
+        doc.set_object(
+            elem,
+            dictionary! {
+                "Type" => "StructElem",
+                "S" => "Div",
+                "K" => vec![Object::Reference(elem), Object::Reference(elem)],
+            },
+        );
+        let dict = doc.get_dictionary(elem).unwrap().clone();
+
+        let mut walk = StructWalk::new();
+        walk.active.insert(elem); // simulate `elem` already on the DFS path
+        let role_map = HashMap::new();
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &dict, &role_map, None, 0, &mut out, &mut walk);
+        assert!(
+            walk.truncated,
+            "a cycle-skipped `/K` child must flag truncation"
+        );
+    }
+
+    #[test]
+    fn bare_mcid_charges_node_and_reference() {
+        // A bare MCID `/K` child becomes a wrapper node carrying one content
+        // reference — two materialized items — so it must charge two budget
+        // units, not one.
+        let doc = Document::new();
+        let obj = Object::Integer(7);
+        let role_map = HashMap::new();
+        let mut out = Vec::new();
+        let mut walk = StructWalk::new();
+        let before = walk.budget;
+        parse_kid(&doc, &obj, &role_map, None, 0, &mut out, &mut walk);
+        assert_eq!(
+            out.len(),
+            1,
+            "bare MCID should materialize one wrapper node"
+        );
+        assert_eq!(
+            before - walk.budget,
+            2,
+            "bare MCID must charge for both the node and its content reference"
         );
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -264,6 +264,14 @@ impl StructTree {
         let children = parse_kids(doc, struct_root, &role_map, None, 0, &mut walk);
         debug!("structure tree: {} top-level elements", children.len());
 
+        if walk.truncated {
+            log::warn!(
+                "structure tree hit the {MAX_STRUCT_NODES}-node budget and was \
+                 truncated; tagged roles/tables may be incomplete (likely a very \
+                 large or malformed tagged PDF)"
+            );
+        }
+
         if children.is_empty() {
             return None;
         }
@@ -502,9 +510,12 @@ const MAX_STRUCT_NODES: usize = 500_000;
 /// single element with a very wide `/K` array. `active` holds the object IDs
 /// currently on the depth-first path so a struct element that references itself
 /// (or an ancestor) is not expanded into an unbounded/exponential subtree.
+/// `truncated` records whether the budget was ever exhausted so the caller can
+/// log it once rather than per skipped item.
 struct StructWalk {
     budget: usize,
     active: HashSet<ObjectId>,
+    truncated: bool,
 }
 
 impl StructWalk {
@@ -512,6 +523,7 @@ impl StructWalk {
         Self {
             budget: MAX_STRUCT_NODES,
             active: HashSet::new(),
+            truncated: false,
         }
     }
 
@@ -520,6 +532,7 @@ impl StructWalk {
     /// underflowing — once the budget is exhausted, so callers skip the item.
     fn charge(&mut self) -> bool {
         if self.budget == 0 {
+            self.truncated = true;
             return false;
         }
         self.budget -= 1;
@@ -1531,5 +1544,18 @@ mod tests {
             "content_refs unbounded: {} > {MAX_STRUCT_NODES}",
             tree.mcid_count()
         );
+    }
+
+    #[test]
+    fn budget_charge_flags_truncation_once_exhausted() {
+        let mut walk = StructWalk::new();
+        walk.budget = 1;
+        assert!(walk.charge(), "should spend the last unit");
+        assert!(!walk.truncated, "not truncated while budget remained");
+        assert!(!walk.charge(), "budget exhausted");
+        assert!(walk.truncated, "exhaustion must set the truncation flag");
+        // Stays exhausted/flagged on subsequent calls.
+        assert!(!walk.charge());
+        assert!(walk.truncated);
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -539,6 +539,9 @@ fn parse_kids(
     match k_obj {
         Object::Array(arr) => {
             for item in arr {
+                if walk.budget == 0 {
+                    break;
+                }
                 process_kid_item(doc, item, role_map, page_id, depth, &mut children, walk);
             }
         }
@@ -706,6 +709,11 @@ fn parse_struct_element_dict(
                     if walk.budget == 0 {
                         break;
                     }
+                    // Charge every `/K` item against the budget *before* handling
+                    // it, so an array of bare MCIDs or MCR dicts (which append to
+                    // `content_refs` rather than recursing) cannot allocate
+                    // without bound.
+                    walk.budget -= 1;
                     let ref_id = match item {
                         Object::Reference(id) => Some(*id),
                         _ => None,
@@ -1476,6 +1484,34 @@ mod tests {
         assert!(
             n <= MAX_STRUCT_NODES,
             "node count {n} exceeded budget {MAX_STRUCT_NODES}"
+        );
+    }
+
+    #[test]
+    fn struct_tree_wide_mcid_array_respects_budget() {
+        // A single struct element with a `/K` array of bare MCIDs wider than the
+        // budget must not allocate `content_refs` without bound — each array item
+        // is charged, so materialized marked-content refs stay within the budget.
+        let mut doc = Document::new();
+        let elem = doc.new_object_id();
+        let kids: Vec<Object> = (0..(MAX_STRUCT_NODES as i64 + 100))
+            .map(Object::Integer)
+            .collect();
+        doc.set_object(
+            elem,
+            dictionary! {
+                "Type" => "StructElem",
+                "S" => "P",
+                "K" => kids,
+            },
+        );
+        let doc = finalize_tagged_doc(doc, elem);
+
+        let tree = StructTree::from_doc(&doc).expect("tree should parse");
+        assert!(
+            tree.mcid_count() <= MAX_STRUCT_NODES,
+            "content_refs unbounded: {} > {MAX_STRUCT_NODES}",
+            tree.mcid_count()
         );
     }
 }

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -514,6 +514,17 @@ impl StructWalk {
             active: HashSet::new(),
         }
     }
+
+    /// Charge one unit against the budget for a materialized item (a struct
+    /// element node or a marked-content reference). Returns `false` — without
+    /// underflowing — once the budget is exhausted, so callers skip the item.
+    fn charge(&mut self) -> bool {
+        if self.budget == 0 {
+            return false;
+        }
+        self.budget -= 1;
+        true
+    }
 }
 
 /// Parse child elements from a `/K` entry.
@@ -599,10 +610,9 @@ fn parse_kid(
     match obj {
         // Direct MCID integer — create a leaf wrapper
         Object::Integer(mcid) => {
-            if walk.budget == 0 {
+            if !walk.charge() {
                 return;
             }
-            walk.budget -= 1;
             // This is a bare MCID at the struct-element level.
             // We attach it to the parent element, so we create a wrapper struct element.
             // Actually, bare MCIDs inside /K are content refs for the parent,
@@ -642,12 +652,11 @@ fn parse_struct_element_dict(
     out: &mut Vec<StructElement>,
     walk: &mut StructWalk,
 ) {
-    if depth >= MAX_DEPTH || walk.budget == 0 {
-        return;
-    }
     // Charge this node against the global budget so aliased/DAG-shaped `/K`
     // graphs (which the per-path cycle guard alone cannot bound) still stop.
-    walk.budget -= 1;
+    if depth >= MAX_DEPTH || !walk.charge() {
+        return;
+    }
     // Check if this is a marked-content reference dict (has /Type /MCR)
     if is_mcr_dict(dict) {
         if let Ok(Object::Integer(mcid)) = dict.get(b"MCID") {
@@ -700,10 +709,12 @@ fn parse_struct_element_dict(
         let k_resolved = resolve_obj(doc, k_obj);
         match k_resolved {
             Object::Integer(mcid) => {
-                content_refs.push(MarkedContentRef {
-                    mcid: *mcid,
-                    page_id,
-                });
+                if walk.charge() {
+                    content_refs.push(MarkedContentRef {
+                        mcid: *mcid,
+                        page_id,
+                    });
+                }
             }
             Object::Array(arr) => {
                 for item in arr {
@@ -722,21 +733,23 @@ fn parse_struct_element_dict(
                     let resolved = resolve_obj(doc, item);
                     match resolved {
                         Object::Integer(mcid) => {
-                            walk.budget -= 1;
-                            content_refs.push(MarkedContentRef {
-                                mcid: *mcid,
-                                page_id,
-                            });
+                            if walk.charge() {
+                                content_refs.push(MarkedContentRef {
+                                    mcid: *mcid,
+                                    page_id,
+                                });
+                            }
                         }
                         Object::Dictionary(d) => {
                             if is_mcr_dict(d) {
                                 if let Ok(Object::Integer(mcid)) = d.get(b"MCID") {
-                                    let pg = get_page_ref(doc, d).or(page_id);
-                                    walk.budget -= 1;
-                                    content_refs.push(MarkedContentRef {
-                                        mcid: *mcid,
-                                        page_id: pg,
-                                    });
+                                    if walk.charge() {
+                                        let pg = get_page_ref(doc, d).or(page_id);
+                                        content_refs.push(MarkedContentRef {
+                                            mcid: *mcid,
+                                            page_id: pg,
+                                        });
+                                    }
                                 }
                             } else if is_objr_dict(d) {
                                 // Skip object references
@@ -772,11 +785,13 @@ fn parse_struct_element_dict(
             Object::Dictionary(d) => {
                 if is_mcr_dict(d) {
                     if let Ok(Object::Integer(mcid)) = d.get(b"MCID") {
-                        let pg = get_page_ref(doc, d).or(page_id);
-                        content_refs.push(MarkedContentRef {
-                            mcid: *mcid,
-                            page_id: pg,
-                        });
+                        if walk.charge() {
+                            let pg = get_page_ref(doc, d).or(page_id);
+                            content_refs.push(MarkedContentRef {
+                                mcid: *mcid,
+                                page_id: pg,
+                            });
+                        }
                     }
                 } else {
                     let ref_id = match k_obj {

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -496,11 +496,12 @@ const MAX_STRUCT_NODES: usize = 500_000;
 
 /// Traversal state shared across the recursive structure-tree parse.
 ///
-/// `budget` is a global allowance of nodes still permitted to be materialized;
-/// it caps total work even for aliased/DAG-shaped `/K` graphs of distinct
-/// objects. `active` holds the object IDs currently on the depth-first path so
-/// a struct element that references itself (or an ancestor) is not expanded
-/// into an unbounded/exponential subtree.
+/// `budget` is a global allowance charged once per materialized item — each
+/// struct-element node and each marked-content reference — so total work is
+/// bounded even for aliased/DAG-shaped `/K` graphs of distinct objects or a
+/// single element with a very wide `/K` array. `active` holds the object IDs
+/// currently on the depth-first path so a struct element that references itself
+/// (or an ancestor) is not expanded into an unbounded/exponential subtree.
 struct StructWalk {
     budget: usize,
     active: HashSet<ObjectId>,
@@ -709,11 +710,11 @@ fn parse_struct_element_dict(
                     if walk.budget == 0 {
                         break;
                     }
-                    // Charge every `/K` item against the budget *before* handling
-                    // it, so an array of bare MCIDs or MCR dicts (which append to
-                    // `content_refs` rather than recursing) cannot allocate
-                    // without bound.
-                    walk.budget -= 1;
+                    // Only content-ref items (bare MCIDs / MCR dicts) are charged
+                    // here — those are the unbounded allocations. Structural
+                    // children are charged once at their own node entry in the
+                    // recursive call, so charging them here too would double-count
+                    // and drain the budget ~2× faster than the per-node semantics.
                     let ref_id = match item {
                         Object::Reference(id) => Some(*id),
                         _ => None,
@@ -721,6 +722,7 @@ fn parse_struct_element_dict(
                     let resolved = resolve_obj(doc, item);
                     match resolved {
                         Object::Integer(mcid) => {
+                            walk.budget -= 1;
                             content_refs.push(MarkedContentRef {
                                 mcid: *mcid,
                                 page_id,
@@ -730,6 +732,7 @@ fn parse_struct_element_dict(
                             if is_mcr_dict(d) {
                                 if let Ok(Object::Integer(mcid)) = d.get(b"MCID") {
                                     let pg = get_page_ref(doc, d).or(page_id);
+                                    walk.budget -= 1;
                                     content_refs.push(MarkedContentRef {
                                         mcid: *mcid,
                                         page_id: pg,

--- a/src/structure_tree.rs
+++ b/src/structure_tree.rs
@@ -503,6 +503,14 @@ const MAX_DEPTH: usize = 64;
 /// This budget bounds total work and allocation regardless of tree shape.
 const MAX_STRUCT_NODES: usize = 500_000;
 
+/// Cap on the number of `/K` items *examined* during a single parse, regardless
+/// of whether they materialize anything. Bounds CPU for crafted wide `/K` arrays
+/// of non-materializing entries (unsupported value types, `/OBJR` dicts, cycle
+/// back-edges) that would otherwise be scanned in full without ever touching the
+/// node budget. Kept well above the node budget so it never truncates content
+/// that already fits within `MAX_STRUCT_NODES`.
+const MAX_STRUCT_WORK: usize = 2_000_000;
+
 /// Traversal state shared across the recursive structure-tree parse.
 ///
 /// `budget` is a global allowance charged once per materialized item — each
@@ -511,6 +519,11 @@ const MAX_STRUCT_NODES: usize = 500_000;
 /// single element with a very wide `/K` array. `active` holds the object IDs
 /// currently on the depth-first path so a struct element that references itself
 /// (or an ancestor) is not expanded into an unbounded/exponential subtree.
+/// `budget` bounds *materialization* (nodes + content refs). `work` separately
+/// bounds *traversal* — every `/K` item examined is charged against it, even
+/// ones that materialize nothing (unsupported values, `/OBJR`, cycle back-edges)
+/// — so a wide malformed array cannot force an unbounded scan, and those skipped
+/// items don't drain the materialization budget and truncate real content.
 /// `truncated` records whether any parse work was skipped — the budget was
 /// exhausted, a `/K` reference cycle was broken, or the depth cap was hit — so
 /// the caller can log it once rather than per skipped item. `stalled` is set
@@ -519,6 +532,7 @@ const MAX_STRUCT_NODES: usize = 500_000;
 /// not scanned to the end once no further leaf can be materialized.
 struct StructWalk {
     budget: usize,
+    work: usize,
     active: HashSet<ObjectId>,
     truncated: bool,
     stalled: bool,
@@ -528,10 +542,24 @@ impl StructWalk {
     fn new() -> Self {
         Self {
             budget: MAX_STRUCT_NODES,
+            work: MAX_STRUCT_WORK,
             active: HashSet::new(),
             truncated: false,
             stalled: false,
         }
+    }
+
+    /// Charge one unit of traversal work for an examined `/K` item, whether or
+    /// not it materializes anything. Returns `false` (flagging truncation) once
+    /// the traversal budget is spent, so an enclosing loop stops instead of
+    /// scanning the rest of a wide array of non-materializing entries.
+    fn spend_work(&mut self) -> bool {
+        if self.work == 0 {
+            self.truncated = true;
+            return false;
+        }
+        self.work -= 1;
+        true
     }
 
     /// Record that some parse work was skipped for a non-budget reason (a `/K`
@@ -613,7 +641,7 @@ fn parse_kids(
     match k_obj {
         Object::Array(arr) => {
             for item in arr {
-                if walk.exhausted() {
+                if walk.exhausted() || !walk.spend_work() {
                     break;
                 }
                 process_kid_item(doc, item, role_map, page_id, depth, &mut children, walk);
@@ -752,18 +780,15 @@ fn parse_struct_element_dict(
         return;
     }
 
-    // Charge this node against the global budget so aliased/DAG-shaped `/K`
-    // graphs (which the per-path cycle guard alone cannot bound) still stop.
-    if !walk.charge() {
-        return;
-    }
-
-    // Check if this is an object reference dict (has /Type /OBJR) — skip these
+    // Skip object-reference dicts (`/Type /OBJR`) — they materialize no node, so
+    // recognize and return *before* charging the budget (otherwise a document
+    // full of OBJRs would drain the shared budget and truncate real content).
     if is_objr_dict(dict) {
         return;
     }
 
-    // It's a struct element — parse its /S (structure type)
+    // It's a struct element — parse its /S (structure type). A dict without a
+    // valid /S also materializes nothing, so validate before charging.
     let role_name = match dict.get(b"S") {
         Ok(s_obj) => {
             let resolved = resolve_obj(doc, s_obj);
@@ -774,6 +799,12 @@ fn parse_struct_element_dict(
         }
         Err(_) => return,
     };
+
+    // Charge the node only now that we know it will materialize (bounds
+    // aliased/DAG-shaped `/K` graphs the per-path cycle guard alone cannot stop).
+    if !walk.charge() {
+        return;
+    }
 
     let role = StructRole::from_name_with_role_map(&role_name, role_map);
     let page_id = get_page_ref(doc, dict).or(inherited_page);
@@ -800,7 +831,7 @@ fn parse_struct_element_dict(
             }
             Object::Array(arr) => {
                 for item in arr {
-                    if walk.exhausted() {
+                    if walk.exhausted() || !walk.spend_work() {
                         break;
                     }
                     // Only content-ref items (bare MCIDs / MCR dicts) are charged
@@ -1799,5 +1830,66 @@ mod tests {
             "an insufficient reservation must stop the loop"
         );
         assert!(walk.truncated);
+    }
+
+    #[test]
+    fn work_budget_bounds_examined_items() {
+        let mut walk = StructWalk::new();
+        walk.work = 2;
+        assert!(walk.spend_work());
+        assert!(walk.spend_work());
+        assert!(!walk.spend_work(), "traversal budget exhausted");
+        assert!(walk.truncated);
+    }
+
+    #[test]
+    fn wide_unsupported_kids_stop_at_work_budget() {
+        // A wide `/K` array of unsupported values (nulls) materializes nothing;
+        // it must stop at the traversal budget instead of scanning every entry.
+        let mut doc = Document::new();
+        let elem = doc.new_object_id();
+        let kids: Vec<Object> = (0..1000).map(|_| Object::Null).collect();
+        doc.set_object(
+            elem,
+            dictionary! { "Type" => "StructElem", "S" => "P", "K" => kids },
+        );
+        let dict = doc.get_dictionary(elem).unwrap().clone();
+
+        let mut walk = StructWalk::new();
+        walk.work = 10; // far smaller than the 1000-entry array
+        let role_map = HashMap::new();
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &dict, &role_map, None, 0, &mut out, &mut walk);
+        assert!(
+            walk.truncated,
+            "a wide unsupported `/K` array must hit the work budget"
+        );
+    }
+
+    #[test]
+    fn non_materializing_dicts_do_not_charge_node_budget() {
+        let doc = Document::new();
+        let role_map = HashMap::new();
+
+        // OBJR dict: materializes no node, so it must not spend the node budget.
+        let objr = dictionary! { "Type" => "OBJR" };
+        let mut walk = StructWalk::new();
+        let before = walk.budget;
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &objr, &role_map, None, 0, &mut out, &mut walk);
+        assert!(out.is_empty());
+        assert_eq!(walk.budget, before, "OBJR must not spend the node budget");
+
+        // A struct dict without a valid /S also materializes nothing.
+        let no_s = dictionary! { "Type" => "StructElem" };
+        let mut walk = StructWalk::new();
+        let before = walk.budget;
+        let mut out = Vec::new();
+        parse_struct_element_dict(&doc, &no_s, &role_map, None, 0, &mut out, &mut walk);
+        assert!(out.is_empty());
+        assert_eq!(
+            walk.budget, before,
+            "a dict without /S must not spend the node budget"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the tagged structure-tree parser (`src/structure_tree.rs`) against malformed or pathological `/K` graphs.

`parse_struct_element_dict` builds the in-memory struct tree by recursing through each element's `/K` children, capping only recursion **depth** (`MAX_DEPTH = 64`). It does not track object identity along the path or the total amount of work/allocation. As a result, certain malformed inputs cause the parser to materialize far more than the document actually contains, using excessive memory on otherwise tiny files:

- a struct element that lists the same reference more than once in `/K`, or elements that reference each other, expand into a much larger (up to exponential) node tree; and
- a single element with a very wide `/K` array of bare MCIDs or marked-content-reference (MCR) dicts appends to `content_refs` without bound.

## Fix

Thread a small `StructWalk` state through the parse:

- **Active-path cycle guard** — a `HashSet<ObjectId>` of the object IDs currently on the depth-first path. Before descending into a child reached via an indirect reference, its id is recorded; if it is already on the path (a self- or ancestor-reference) the child is skipped. The set is seeded with the `/StructTreeRoot`'s own id. This handles self-references and mutual (`A ↔ B`) reference loops.
- **Global work budget** — `MAX_STRUCT_NODES = 500_000`, charged once per materialized item: each struct-element node and each marked-content reference. A leaf MCID wrapper (a bare integer in `/K` or an MCR `/Type /MCR` dict) materializes a Span node *plus* one reference, so both paths reserve **two units atomically** via `charge_n(2)` — either both or neither. An insufficient reservation marks the walk `stalled`, which `exhausted()` reports as done, so a wide `/K` array is not scanned to the end once no further leaf can fit (preserving the O(budget) work bound). One-unit loops (content refs, structural children) are unaffected. `charge()`/`charge_n()` guard against underflow. Both `/K` loops stop once the budget is spent or stalled.
- **One-shot truncation log** — a `truncated` flag is set whenever parse work is skipped for *any* reason: budget exhaustion, an insufficient reservation, a broken `/K` reference cycle, or the depth cap (`note_skipped()`). If it was set, `from_doc` emits a single `warn!` after parsing (no per-item spam), so any incomplete parse — of a genuinely enormous *or* a malformed tagged tree — is observable instead of silent.

Depth-first recursion is still capped at `MAX_DEPTH`. Well-formed tagged PDFs are unaffected: real trees are far below the budget and contain no reference loops.

## Tests

Added regression tests in `structure_tree.rs`:

- `struct_tree_self_alias_kids_terminates` / `struct_tree_mutual_alias_kids_terminates` — self- and `A → B → A` reference loops terminate with small trees.
- `struct_tree_aliased_dag_respects_node_budget` — a deep graph of distinct doubly-aliased elements stays within the budget.
- `struct_tree_wide_mcid_array_respects_budget` — a wide `/K` array of bare MCIDs keeps `content_refs` bounded.
- `budget_charge_flags_truncation_once_exhausted` / `exhausted_flags_truncation_after_budget_spent_by_charge` / `wide_kids_array_flags_truncation_via_parser` — the budget helpers and parser flag truncation without underflowing.
- `cycle_skip_flags_truncation` — a cycle-skipped `/K` child flags truncation.
- `bare_mcid_charges_node_and_reference` / `mcr_dict_charges_node_and_reference` — both leaf-MCID wrapper paths charge two budget units.
- `leaf_wrappers_reserve_both_units_atomically` — at the last unit, a two-item wrapper consumes nothing and preserves the unit.
- `insufficient_reservation_stops_the_scan` — a one-unit budget still allows a one-unit item, but a failed two-unit reservation stalls so wide-array scanning stops.

## Checks

Toolchain updated to a Rust that supports the pinned dependencies' edition-2024 requirement.

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — zero warnings
- `cargo test` — 853 lib + 152 integration + 2 doc-tests pass, including the new cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe34b-3848-7ece-9d38-3c8d085f84e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe34b-3848-7ece-9d38-3c8d085f84e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds tagged `/K` parsing with cycle detection, a node budget, and a traversal work budget to cap memory and CPU. Stops scanning wide arrays when two-unit leaves can’t fit, avoids charging non-materializing dicts, and logs a single truncation warning that now mentions both budgets.

- **Bug Fixes**
  - Added a shared `StructWalk` with an active-path `HashSet<ObjectId>` (seeded with `/StructTreeRoot`), `MAX_STRUCT_NODES`, and `MAX_STRUCT_WORK`; loops stop when the node budget is spent, a leaf reservation stalls, or the work limit is hit.
  - Introduced `charge_n(2)` for bare MCID and `/Type /MCR` wrappers; detect MCRs before any node charge; set `stalled` on failed reservations to halt wide `/K` scans early.
  - Charge only materializing items; hoist `/Type /OBJR` and missing/invalid `/S` checks so they don’t consume the node budget.
  - Guard loops with `exhausted()` and per-item `spend_work()`; mark cycle/depth skips via `note_skipped()`; emit a one-shot `warn!` after parsing that lists node/traversal budgets, cycles, and depth as possible causes. Added tests for cycles, aliased-DAG capping, wide `/K`, traversal/work bounds, non-materializing dicts, truncation flags, atomic reservations, and stalled scans.

<sup>Written for commit 528829cb6c4f54359047d8d052aeb9988fb6a2eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

