### PR TITLE
fix(parser): drop trailing bytes after the last %%EOF during container repair

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3553,6 +3553,7 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
     let mut candidates = Vec::new();
 
     add_repair_candidate(&mut candidates, append_missing_eof_marker(buf), buf);
+    add_repair_candidate(&mut candidates, truncate_after_last_eof_marker(buf), buf);
     add_repair_candidate(&mut candidates, recover_startxref_pointer(buf), buf);
 
     let stripped = strip_leading_pdf_container_bytes(buf);
@@ -3561,6 +3562,11 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
         add_repair_candidate(
             &mut candidates,
             append_missing_eof_marker(stripped_buf),
+            buf,
+        );
+        add_repair_candidate(
+            &mut candidates,
+            truncate_after_last_eof_marker(stripped_buf),
             buf,
         );
         add_repair_candidate(
@@ -3709,6 +3715,32 @@ fn append_missing_eof_marker(buf: &[u8]) -> Option<Vec<u8>> {
 fn contains_recent_eof_marker(buf: &[u8]) -> bool {
     let start = buf.len().saturating_sub(1024);
     buf[start..].windows(b"%%EOF".len()).any(|w| w == b"%%EOF")
+}
+
+/// Some producers pad the file after the final `%%EOF` — iTextSharp 4.1.2
+/// emits tens of kilobytes of NULs (issue #301). lopdf only scans the last
+/// 512 bytes for the marker, so past ~506 bytes of padding it never finds
+/// the trailer and the load fails outright, while pypdf/pdfium read the
+/// same file fine. Dropping everything after the last `%%EOF` line restores
+/// the tail the producer wrote, whatever the cross-reference flavor —
+/// unlike `recover_startxref_pointer`, which can re-point classic tables
+/// but has no way to recover a PDF 1.5+ cross-reference *stream*.
+fn truncate_after_last_eof_marker(buf: &[u8]) -> Option<Vec<u8>> {
+    const MARKER: &[u8] = b"%%EOF";
+    let eof = buf.windows(MARKER.len()).rposition(|w| w == MARKER)?;
+    let mut end = eof + MARKER.len();
+    // Keep the marker's own end-of-line so the file still terminates with a
+    // conventional `%%EOF` line.
+    if buf.get(end) == Some(&b'\r') {
+        end += 1;
+    }
+    if buf.get(end) == Some(&b'\n') {
+        end += 1;
+    }
+    if end == buf.len() {
+        return None;
+    }
+    Some(buf[..end].to_vec())
 }
 
 fn strip_leading_pdf_container_bytes(buf: &[u8]) -> Option<Vec<u8>> {
@@ -7261,5 +7293,40 @@ mod tests {
     fn recover_startxref_pointer_returns_none_without_a_valid_table() {
         let buf = b"Please refer to the xref appendix for details.";
         assert!(recover_startxref_pointer(buf).is_none());
+    }
+
+    #[test]
+    fn truncate_after_eof_drops_trailing_padding() {
+        // NUL padding (the iTextSharp shape from #301) and space padding
+        // both truncate back to the `%%EOF` line, keeping its newline.
+        for pad in [&b"\x00"[..], b" "] {
+            let buf = [b"body\nstartxref\n9\n%%EOF\n".as_slice(), &pad.repeat(507)].concat();
+            let repaired = truncate_after_last_eof_marker(&buf).expect("padding should truncate");
+            assert_eq!(repaired, b"body\nstartxref\n9\n%%EOF\n");
+        }
+    }
+
+    #[test]
+    fn truncate_after_eof_keeps_crlf_and_marker_without_eol() {
+        let repaired = truncate_after_last_eof_marker(b"%%EOF\r\n\x00\x00").unwrap();
+        assert_eq!(repaired, b"%%EOF\r\n");
+        // A marker with no end-of-line at all still anchors the cut.
+        let repaired = truncate_after_last_eof_marker(b"%%EOF\x00\x00").unwrap();
+        assert_eq!(repaired, b"%%EOF");
+    }
+
+    #[test]
+    fn truncate_after_eof_cuts_at_the_last_marker() {
+        // Incremental updates carry earlier `%%EOF` lines; only bytes after
+        // the final one are padding.
+        let buf = b"rev1\n%%EOF\nrev2\n%%EOF\n\x00\x00\x00";
+        let repaired = truncate_after_last_eof_marker(buf).unwrap();
+        assert_eq!(repaired, b"rev1\n%%EOF\nrev2\n%%EOF\n");
+    }
+
+    #[test]
+    fn truncate_after_eof_is_a_noop_on_clean_or_markerless_buffers() {
+        assert!(truncate_after_last_eof_marker(b"body\n%%EOF\n").is_none());
+        assert!(truncate_after_last_eof_marker(b"no marker here\x00\x00").is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3725,9 +3725,20 @@ fn contains_recent_eof_marker(buf: &[u8]) -> bool {
 /// the tail the producer wrote, whatever the cross-reference flavor —
 /// unlike `recover_startxref_pointer`, which can re-point classic tables
 /// but has no way to recover a PDF 1.5+ cross-reference *stream*.
+///
+/// Only markers that begin a line count — the shape the real trailer line
+/// always takes — so a stray `%%EOF` inside the padding cannot anchor the
+/// cut and hide the producer's actual trailer.
 fn truncate_after_last_eof_marker(buf: &[u8]) -> Option<Vec<u8>> {
     const MARKER: &[u8] = b"%%EOF";
-    let eof = buf.windows(MARKER.len()).rposition(|w| w == MARKER)?;
+    let eof = buf
+        .windows(MARKER.len())
+        .enumerate()
+        .rev()
+        .find_map(|(offset, w)| {
+            (w == MARKER && (offset == 0 || matches!(buf[offset - 1], b'\r' | b'\n')))
+                .then_some(offset)
+        })?;
     let mut end = eof + MARKER.len();
     // Keep the marker's own end-of-line so the file still terminates with a
     // conventional `%%EOF` line.
@@ -7322,6 +7333,20 @@ mod tests {
         let buf = b"rev1\n%%EOF\nrev2\n%%EOF\n\x00\x00\x00";
         let repaired = truncate_after_last_eof_marker(buf).unwrap();
         assert_eq!(repaired, b"rev1\n%%EOF\nrev2\n%%EOF\n");
+    }
+
+    #[test]
+    fn truncate_after_eof_ignores_markers_that_do_not_begin_a_line() {
+        // A stray `%%EOF` inside the padding must not anchor the cut; the
+        // producer's real trailer line is the last marker at a line start.
+        let buf = b"body\nstartxref\n9\n%%EOF\njunk %%EOF junk\x00\x00";
+        let repaired = truncate_after_last_eof_marker(buf).unwrap();
+        assert_eq!(repaired, b"body\nstartxref\n9\n%%EOF\n");
+        // Padding made entirely of mid-line markers leaves no valid anchor
+        // beyond the real one.
+        let buf = b"%%EOF\r\nsee %%EOF for details";
+        let repaired = truncate_after_last_eof_marker(buf).unwrap();
+        assert_eq!(repaired, b"%%EOF\r\n");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -267,6 +267,68 @@ fn truncate_eof_marker(mut pdf: Vec<u8>) -> Vec<u8> {
     pdf
 }
 
+/// Like `make_text_pdf`, but indexed by a PDF 1.5 cross-reference *stream*
+/// (uncompressed, `/W [1 2 2]`) instead of a classic `xref` table — the
+/// shape `recover_startxref_pointer` explicitly cannot rebuild.
+fn make_xref_stream_pdf(content: &str) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.5\n".to_vec();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    let mut add_object = |pdf: &mut Vec<u8>, id: usize, body: &[u8]| {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    };
+
+    add_object(&mut pdf, 1, b"<< /Type /Catalog /Pages 2 0 R >>");
+    add_object(&mut pdf, 2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    add_object(
+        &mut pdf,
+        3,
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+          /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        4,
+        format!(
+            "<< /Length {} >>\nstream\n{content}\nendstream",
+            content.len()
+        )
+        .as_bytes(),
+    );
+    add_object(
+        &mut pdf,
+        5,
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    );
+
+    let xref_pos = pdf.len();
+    // One entry per object 0..=6: type byte, 2-byte offset, 2-byte gen.
+    let mut entries: Vec<u8> = vec![0, 0, 0, 0xFF, 0xFF];
+    for &off in &offsets {
+        entries.push(1);
+        entries.extend_from_slice(&u16::try_from(off).unwrap().to_be_bytes());
+        entries.extend_from_slice(&[0, 0]);
+    }
+    entries.push(1);
+    entries.extend_from_slice(&u16::try_from(xref_pos).unwrap().to_be_bytes());
+    entries.extend_from_slice(&[0, 0]);
+
+    pdf.extend_from_slice(
+        format!(
+            "6 0 obj\n<< /Type /XRef /Size 7 /W [1 2 2] /Root 1 0 R /Length {} >>\nstream\n",
+            entries.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(&entries);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{xref_pos}\n%%EOF\n").as_bytes());
+    pdf
+}
+
 fn add_leading_tab(mut pdf: Vec<u8>) -> Vec<u8> {
     pdf.insert(0, b'\t');
     pdf
@@ -4017,6 +4079,37 @@ fn test_process_pdf_recovers_corrupted_startxref_pointer() {
         md.contains("Order Detail Report by Account") && md.contains("WIDGET ASSEMBLY"),
         "recovered document should extract its real text, got: {md:?}"
     );
+}
+
+/// Regression for #301 case A: some producers pad the file after `%%EOF`
+/// (the reported file carried 80,508 NULs from iTextSharp 4.1.2). lopdf
+/// scans only the last 512 bytes for the marker, so the load fails outright
+/// while pypdf, pdftotext and browsers all read the file. The container
+/// repair must drop the padding — including for PDFs indexed by a
+/// cross-reference stream, which `recover_startxref_pointer` cannot rebuild.
+#[test]
+fn test_process_pdf_recovers_trailing_bytes_after_eof() {
+    let classic = make_minimal_text_pdf();
+    let xref_stream = make_xref_stream_pdf("BT /F1 12 Tf 100 700 Td (Hello World) Tj ET");
+    // Unpadded control: the cross-reference-stream fixture must be valid.
+    let control = process_pdf_mem(&xref_stream).expect("xref-stream fixture should parse as-is");
+    assert!(control.markdown.unwrap_or_default().contains("Hello World"));
+
+    for (label, base) in [("classic xref", &classic), ("xref stream", &xref_stream)] {
+        for (padding, len) in [("NULs", 80_508), ("spaces", 507)] {
+            let byte = if padding == "NULs" { 0x00 } else { b' ' };
+            let padded = [base.as_slice(), &vec![byte; len]].concat();
+            let result = process_pdf_mem(&padded).unwrap_or_else(|e| {
+                panic!("{label} + {len} trailing {padding} should be recoverable: {e:?}")
+            });
+            assert_eq!(result.page_count, 1, "{label} + {padding}");
+            let md = result.markdown.unwrap_or_default();
+            assert!(
+                md.contains("Hello World"),
+                "{label} + {padding}: recovered document should extract its text, got: {md:?}"
+            );
+        }
+    }
 }
 
 /// Regression for #227: `extract_pages_markdown`'s per-page `needs_ocr`


### PR DESCRIPTION
Fixes the remaining half of #301.

## Problem

Some producers pad the file after the final `%%EOF` — the file reported in #301 carried 80,508 NUL bytes appended by iTextSharp 4.1.2, and the reporter bisected the failure threshold to the exact byte (506 trailing bytes parse, 507 fail). lopdf's `get_xref_start` scans only the last 512 bytes for the marker, so past that window the trailer is never found and every entry point fails with `Invalid PDF structure` — while pypdf, pdftotext and browsers all read the same file.

## What main already covers

Both cases in #301 were reproduced against the anydoc 0.1.7 wheel, which predates the container-repair work:

- **Case B** (startxref pointing at the EOL before `xref`) is already healed on `main` by #230: `recover_startxref_pointer` locates the real table and appends a corrected pointer block. Verified against both a classic-table and a cross-reference-stream fixture.
- **Case A** (trailing padding) is also healed on `main` — but only for **classic-xref** files, and only as a side effect: the corrected pointer block that #230 appends lands *after* the padding, inside lopdf's scan window.

Files indexed by a PDF 1.5+ **cross-reference stream** get neither: `recover_startxref_pointer` explicitly cannot rebuild a stream pointer (recovering one needs the containing object's number, not a byte offset), so the padding stays fatal for them:

```text
xs-507-nulls    : Error: Invalid PDF structure   (main @ 493fed4)
xs-80508-nulls  : Error: Invalid PDF structure   (main @ 493fed4)
```

## Change

Add a `truncate_after_last_eof_marker` repair candidate that cuts the buffer just after the last `%%EOF` line, restoring the tail the producer wrote regardless of cross-reference flavor. Like the existing candidates it runs only after a normal load has failed, and it composes with the leading-bytes strip. Cutting at the *last* marker keeps incremental-update revisions intact.

For classic files it also becomes the preferred repair over the #230 pointer append — the truncated buffer keeps the producer's own `startxref` rather than a reconstructed one.

## Tests

- Unit tests for the truncation: NUL and space padding, CRLF and missing end-of-line after the marker, cutting at the last `%%EOF` of an incremental update, and no-op on clean or markerless buffers.
- Integration regression (`test_process_pdf_recovers_trailing_bytes_after_eof`): a new `make_xref_stream_pdf` helper builds a minimal PDF indexed by an uncompressed cross-reference stream (`/W [1 2 2]`) — the shape the existing repair cannot rebuild — and both that and the classic fixture must survive 80,508 trailing NULs (the reported real-world size) and 507 trailing spaces. The xref-stream fixture is also parsed unpadded as a control.

The integration test fails on current `main` for both xref-stream cases and passes with this change.

## Validation

- `cargo fmt --check`, `cargo clippy -- -D warnings`: clean
- `cargo test`: 845 lib + 153 integration + 2 CLI + 2 doc tests pass
- End-to-end via `pdf2md` on nine generated repros (classic/stream × clean/nulls/spaces/off-by-one): all extract their text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop trailing bytes after the last %%EOF during container repair so padded PDFs load correctly, including cross‑reference stream files. Fixes the remaining half of #301 and matches behavior of common PDF readers.

- **Bug Fixes**
  - Added truncate_after_last_eof_marker repair that trims the buffer just after the final %%EOF (keeps its newline) and only when the marker begins a line. Runs only after a normal load fails and composes with leading‑bytes stripping.
  - Works for both classic xref and xref‑stream PDFs; preferred over pointer‑append for classic files because it preserves the original startxref.
  - Added unit and integration tests covering NUL/space padding (including 80,508 NULs), CRLF/missing EOL, incremental updates, mid‑line %%EOF ignored in padding, and control cases.

<sup>Written for commit 1a84ffe0428ddb06cd713da315dcf431a1037768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

