### PR TITLE
Bound column-detection histogram and harden coordinate handling

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -41,22 +41,35 @@ pub(crate) fn detect_columns(
     }
     debug!("page {}: detect_columns: {} items", page, page_items.len());
 
-    // Find page bounds
-    let x_min = page_items.iter().map(|i| i.x).fold(f32::INFINITY, f32::min);
+    // Find page bounds. Coordinates come straight from the content-stream text
+    // matrix, so a malformed document can place an item at a non-finite
+    // position. Such items are excluded from the bounds rather than failing the
+    // whole page: one bad glyph should not disable column detection, and the
+    // emitted regions must never carry a NaN/inf boundary to callers.
+    let x_min = page_items
+        .iter()
+        .map(|i| i.x)
+        .filter(|x| x.is_finite())
+        .fold(f32::INFINITY, f32::min);
     let x_max = page_items
         .iter()
         .map(|i| i.x + effective_width(i))
+        .filter(|x| x.is_finite())
         .fold(f32::NEG_INFINITY, f32::max);
 
-    // Cap the histogram size. Bounds are derived from text-item coordinates,
-    // which come straight from the content-stream text matrix and can be placed
-    // at any coordinate, so a crafted PDF can otherwise force an arbitrarily
-    // large `page_width` and an unbounded `vec![0u32; num_bins]` allocation.
-    // 65_536 bins covers ~128k points at BIN_WIDTH 2.0 — roughly 9x the largest
-    // legal page — so this never clamps a real layout. A non-finite width
-    // (NaN/inf coordinate propagating through the folds) short-circuits here.
+    // Every item sat at a non-finite coordinate, so there is no usable layout.
+    if !x_min.is_finite() || !x_max.is_finite() {
+        return vec![];
+    }
+
+    // Cap the histogram size. Because the bounds above are attacker-influenced,
+    // an unclamped `page_width / BIN_WIDTH` lets a crafted PDF force an
+    // arbitrarily large `vec![0u32; num_bins]` allocation. 65_536 bins covers
+    // ~128k points at BIN_WIDTH 2.0 — roughly 9x the largest legal page — so
+    // this never clamps a real layout.
     const MAX_BINS: usize = 65_536;
 
+    // Finite bounds can still subtract to infinity at the extremes of f32.
     let page_width = x_max - x_min;
     if !page_width.is_finite() || page_width < 200.0 {
         return vec![ColumnRegion { x_min, x_max }];
@@ -2561,17 +2574,48 @@ mod tests {
     }
 
     #[test]
-    fn non_finite_coordinate_short_circuits() {
-        // A NaN/inf coordinate propagates through the min/max folds and would
-        // otherwise reach the histogram cast. The finite-width guard handles it.
-        let mut items = Vec::new();
-        for i in 0..24 {
-            items.push(make_item(1, i as f32 * 10.0, 700.0 - i as f32 * 5.0, "A"));
+    fn non_finite_coordinates_never_leak_into_region_bounds() {
+        // An inf/NaN coordinate must not escape as a column boundary: callers
+        // treat these as page/column edges.
+        for bad_x in [f32::INFINITY, f32::NEG_INFINITY, f32::NAN] {
+            let mut items = Vec::new();
+            for i in 0..24 {
+                items.push(make_item(1, i as f32 * 10.0, 700.0 - i as f32 * 5.0, "A"));
+            }
+            items.push(make_item(1, bad_x, 700.0, "Z"));
+
+            for col in detect_columns(&items, 1, false) {
+                assert!(
+                    col.x_min.is_finite() && col.x_max.is_finite(),
+                    "bad_x {bad_x} leaked bounds {}..{}",
+                    col.x_min,
+                    col.x_max
+                );
+            }
         }
-        items.push(make_item(1, f32::INFINITY, 700.0, "Z"));
+    }
+
+    #[test]
+    fn all_non_finite_coordinates_yield_no_columns() {
+        let items: Vec<TextItem> = (0..24)
+            .map(|i| make_item(1, f32::NAN, 700.0 - i as f32 * 5.0, "A"))
+            .collect();
+
+        assert!(detect_columns(&items, 1, false).is_empty());
+    }
+
+    #[test]
+    fn one_bad_coordinate_does_not_disable_column_detection() {
+        // Excluding non-finite items from the bounds must not cost the page its
+        // real layout — a single stray coordinate should not collapse a clean
+        // two-column page to one region.
+        let mut items = Vec::new();
+        items.extend(fill_zone(1, 30.0, 280.0, 750.0, 50.0));
+        items.extend(fill_zone(1, 320.0, 570.0, 750.0, 50.0));
+        items.push(make_item(1, f32::NAN, 400.0, "Z"));
 
         let cols = detect_columns(&items, 1, false);
-        assert_eq!(cols.len(), 1, "non-finite width returns a single region");
+        assert_eq!(cols.len(), 2, "Expected 2 columns, got {}", cols.len());
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -87,10 +87,14 @@ pub(crate) fn detect_columns(
     // outlier cannot poison the scale. Outliers keep their text: column
     // assignment buckets them by nearest overlap, not by containment.
     if x_max - x_min > MAX_PAGE_EXTENT {
+        // Anchor on the same items `bounds` accepts, so a malformed width
+        // cannot shift the median that decides which items are strays.
         let mut xs: Vec<f32> = page_items
             .iter()
-            .map(|i| i.x)
-            .filter(|x| x.is_finite())
+            .filter_map(|i| {
+                let right = i.x + effective_width(i);
+                (i.x.is_finite() && right.is_finite()).then_some(i.x)
+            })
             .collect();
         xs.sort_by(f32::total_cmp);
         let median = xs[xs.len() / 2];
@@ -117,8 +121,8 @@ pub(crate) fn detect_columns(
     // the bounds are attacker-influenced, so an unclamped
     // `page_width / BIN_WIDTH` lets a crafted PDF force an arbitrarily large
     // `vec![0u32; num_bins]` allocation. 65_536 bins covers ~128k points at
-    // BIN_WIDTH 2.0 — roughly 9x the largest legal page — so this never clamps
-    // a real layout. Kept as a bound that does not depend on the outlier
+    // BIN_WIDTH 2.0 — roughly 9x the largest legal page — so this never binds
+    // on a real layout. Kept as a bound that does not depend on the outlier
     // heuristic staying correct.
     const MAX_BINS: usize = 65_536;
 
@@ -131,13 +135,20 @@ pub(crate) fn detect_columns(
         return vec![ColumnRegion { x_min, x_max }];
     }
 
+    // Widen the bins rather than dropping the tail of the page. Clamping the
+    // count alone would leave anything past MAX_BINS * BIN_WIDTH outside the
+    // histogram, folded into the last bin, which places gutters at the wrong
+    // coordinates. Scaling keeps full coverage under the same allocation
+    // ceiling; only the resolution degrades, and only beyond ~131k points.
+    let bin_width = BIN_WIDTH.max(page_width / MAX_BINS as f32);
+
     // Build occupancy histogram.
     // Exclude items wider than 60% of page width — these are spanning items
     // (titles, full-width paragraphs) that would fill the gutter and prevent
     // detection of partial-page column layouts (e.g. two-column abstracts on
     // a page that also has single-column introduction text).
     let wide_threshold = page_width * 0.6;
-    let num_bins = ((page_width / BIN_WIDTH).ceil() as usize).clamp(1, MAX_BINS);
+    let num_bins = ((page_width / bin_width).ceil() as usize).clamp(1, MAX_BINS);
     let mut histogram = vec![0u32; num_bins];
 
     for item in &page_items {
@@ -145,8 +156,8 @@ pub(crate) fn detect_columns(
         if w > wide_threshold {
             continue;
         }
-        let left = ((item.x - x_min) / BIN_WIDTH).floor() as usize;
-        let right = (((item.x + w) - x_min) / BIN_WIDTH).ceil() as usize;
+        let left = ((item.x - x_min) / bin_width).floor() as usize;
+        let right = (((item.x + w) - x_min) / bin_width).ceil() as usize;
         let left = left.min(num_bins);
         let right = right.min(num_bins);
         for count in histogram.iter_mut().take(right).skip(left) {
@@ -183,12 +194,12 @@ pub(crate) fn detect_columns(
     let valleys: Vec<(usize, usize)> = valleys
         .into_iter()
         .filter(|&(start, end)| {
-            let width_pts = (end - start) as f32 * BIN_WIDTH;
+            let width_pts = (end - start) as f32 * bin_width;
             if width_pts < MIN_GUTTER_WIDTH {
                 return false;
             }
             // Valley center must not be within 5% of page edges
-            let center_pts = ((start + end) as f32 / 2.0) * BIN_WIDTH;
+            let center_pts = ((start + end) as f32 / 2.0) * bin_width;
             center_pts > margin_threshold && center_pts < (page_width - margin_threshold)
         })
         .collect();
@@ -206,7 +217,7 @@ pub(crate) fn detect_columns(
             &histogram,
             num_bins,
             x_min,
-            BIN_WIDTH,
+            bin_width,
             page_width,
             margin_threshold,
         );
@@ -215,7 +226,7 @@ pub(crate) fn detect_columns(
                 &rel_valleys,
                 &page_items,
                 x_min,
-                BIN_WIDTH,
+                bin_width,
                 x_max,
                 MIN_ITEMS_PER_COLUMN,
                 MIN_VERTICAL_SPAN_RATIO,
@@ -256,7 +267,7 @@ pub(crate) fn detect_columns(
         &valleys,
         &page_items,
         x_min,
-        BIN_WIDTH,
+        bin_width,
         x_max,
         MIN_ITEMS_PER_COLUMN,
         MIN_VERTICAL_SPAN_RATIO,
@@ -270,7 +281,7 @@ pub(crate) fn detect_columns(
         &valleys,
         &page_items,
         x_min,
-        BIN_WIDTH,
+        bin_width,
         x_max,
         MIN_ITEMS_PER_COLUMN,
         MIN_VERTICAL_SPAN_RATIO,
@@ -2698,6 +2709,32 @@ mod tests {
 
     /// Mirrors `MAX_PAGE_EXTENT` in `detect_columns`.
     const MAX_PAGE_EXTENT_FOR_TEST: f32 = 14_400.0;
+
+    #[test]
+    fn very_wide_page_keeps_full_histogram_coverage() {
+        // Beyond MAX_BINS * BIN_WIDTH (~131k points) the bins must widen rather
+        // than stop covering the page. Three zones: the first gutter is inside
+        // the old coverage limit, the second is past it. Because the first
+        // gutter is found, the XY-cut fallback never runs, so a truncated
+        // histogram silently reports two columns instead of three.
+        let mut items = Vec::new();
+        items.extend(fill_zone(1, 0.0, 60_000.0, 750.0, 700.0));
+        items.extend(fill_zone(1, 70_000.0, 140_000.0, 750.0, 700.0));
+        items.extend(fill_zone(1, 160_000.0, 200_000.0, 750.0, 700.0));
+
+        let cols = detect_columns(&items, 1, false);
+        assert_eq!(
+            cols.len(),
+            3,
+            "Expected 3 columns across a 200k-wide page, got {}",
+            cols.len()
+        );
+        assert!(
+            (140_000.0..=160_000.0).contains(&cols[1].x_max),
+            "second gutter at {}, expected inside the real 140k..160k gap",
+            cols[1].x_max
+        );
+    }
 
     #[test]
     fn genuinely_wide_layout_keeps_its_true_bounds() {

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -41,35 +41,71 @@ pub(crate) fn detect_columns(
     }
     debug!("page {}: detect_columns: {} items", page, page_items.len());
 
+    // The PDF specification caps a page at 14_400 units (200 inches). Content
+    // may sit a little outside the MediaBox, but a span far beyond one whole
+    // page means stray items, not a real layout.
+    const MAX_PAGE_EXTENT: f32 = 14_400.0;
+
     // Find page bounds. Coordinates come straight from the content-stream text
-    // matrix, so a malformed document can place an item at a non-finite
-    // position. Such items are excluded from the bounds rather than failing the
-    // whole page: one bad glyph should not disable column detection, and the
-    // emitted regions must never carry a NaN/inf boundary to callers.
-    let x_min = page_items
-        .iter()
-        .map(|i| i.x)
-        .filter(|x| x.is_finite())
-        .fold(f32::INFINITY, f32::min);
-    let x_max = page_items
-        .iter()
-        .map(|i| i.x + effective_width(i))
-        .filter(|x| x.is_finite())
-        .fold(f32::NEG_INFINITY, f32::max);
+    // matrix, so a malformed document can place items at non-finite positions.
+    // Those are excluded rather than failing the whole page: one bad glyph
+    // should not disable column detection, and the emitted regions must never
+    // carry a NaN/inf boundary out to callers.
+    let bounds = |keep: &dyn Fn(f32) -> bool| {
+        page_items
+            .iter()
+            .filter(|i| i.x.is_finite() && keep(i.x))
+            .map(|i| (i.x, i.x + effective_width(i)))
+            .filter(|(_, right)| right.is_finite())
+            .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), (l, r)| {
+                (lo.min(l), hi.max(r))
+            })
+    };
+
+    let (mut x_min, mut x_max) = bounds(&|_| true);
 
     // Every item sat at a non-finite coordinate, so there is no usable layout.
     if !x_min.is_finite() || !x_max.is_finite() {
         return vec![];
     }
 
-    // Cap the histogram size. Because the bounds above are attacker-influenced,
-    // an unclamped `page_width / BIN_WIDTH` lets a crafted PDF force an
-    // arbitrarily large `vec![0u32; num_bins]` allocation. 65_536 bins covers
-    // ~128k points at BIN_WIDTH 2.0 — roughly 9x the largest legal page — so
-    // this never clamps a real layout.
+    // Every threshold below (gutter margins, spanning-item width, the XY-cut
+    // margin) is a fraction of the page width, so a single far-but-finite item
+    // would otherwise set the scale for the whole page and shrink the effective
+    // detection window to a rounding error — real gutters then fall inside the
+    // margin band and a genuine multi-column page collapses to one region.
+    // Re-derive the bounds from the items clustered around the median so a lone
+    // outlier cannot poison the scale. Outliers keep their text: column
+    // assignment buckets them by nearest overlap, not by containment.
+    if x_max - x_min > MAX_PAGE_EXTENT {
+        let mut xs: Vec<f32> = page_items
+            .iter()
+            .map(|i| i.x)
+            .filter(|x| x.is_finite())
+            .collect();
+        xs.sort_by(f32::total_cmp);
+        let median = xs[xs.len() / 2];
+
+        let (lo, hi) = bounds(&|x| (x - median).abs() <= MAX_PAGE_EXTENT);
+        if lo.is_finite() && hi.is_finite() {
+            debug!(
+                "page {page}: bounds {x_min}..{x_max} span > one page; \
+                 trimming outliers to {lo}..{hi}"
+            );
+            x_min = lo;
+            x_max = hi;
+        }
+    }
+
+    // Hard ceiling on the histogram size, independent of the trimming above:
+    // the bounds are attacker-influenced, so an unclamped
+    // `page_width / BIN_WIDTH` lets a crafted PDF force an arbitrarily large
+    // `vec![0u32; num_bins]` allocation. 65_536 bins covers ~128k points at
+    // BIN_WIDTH 2.0 — roughly 9x the largest legal page — so this never clamps
+    // a real layout. Kept as a bound that does not depend on the outlier
+    // heuristic staying correct.
     const MAX_BINS: usize = 65_536;
 
-    // Finite bounds can still subtract to infinity at the extremes of f32.
     let page_width = x_max - x_min;
     if !page_width.is_finite() || page_width < 200.0 {
         return vec![ColumnRegion { x_min, x_max }];
@@ -2606,16 +2642,49 @@ mod tests {
 
     #[test]
     fn one_bad_coordinate_does_not_disable_column_detection() {
-        // Excluding non-finite items from the bounds must not cost the page its
-        // real layout — a single stray coordinate should not collapse a clean
-        // two-column page to one region.
+        // A single stray coordinate should not collapse a clean two-column page
+        // to one region. Finite outliers matter as much as NaN/inf ones: every
+        // gutter threshold is a fraction of the page width, so an untrimmed
+        // outlier pushes real gutters inside the rejected margin band.
+        for bad_x in [f32::NAN, f32::INFINITY, 50_000.0, 1e12] {
+            let mut items = Vec::new();
+            items.extend(fill_zone(1, 30.0, 280.0, 750.0, 50.0));
+            items.extend(fill_zone(1, 320.0, 570.0, 750.0, 50.0));
+            items.push(make_item(1, bad_x, 400.0, "Z"));
+
+            let cols = detect_columns(&items, 1, false);
+            assert_eq!(
+                cols.len(),
+                2,
+                "bad_x {bad_x}: expected 2 columns, got {}",
+                cols.len()
+            );
+            for col in &cols {
+                assert!(
+                    col.x_max - col.x_min <= 14_400.0,
+                    "bad_x {bad_x}: region {}..{} exceeds one page",
+                    col.x_min,
+                    col.x_max
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn oversized_but_legal_page_is_not_trimmed() {
+        // A wide-format page well inside the 14_400pt spec limit must keep its
+        // real bounds — outlier trimming is only for spans beyond a legal page.
         let mut items = Vec::new();
-        items.extend(fill_zone(1, 30.0, 280.0, 750.0, 50.0));
-        items.extend(fill_zone(1, 320.0, 570.0, 750.0, 50.0));
-        items.push(make_item(1, f32::NAN, 400.0, "Z"));
+        items.extend(fill_zone(1, 100.0, 4_000.0, 750.0, 400.0));
+        items.extend(fill_zone(1, 4_400.0, 8_000.0, 750.0, 400.0));
 
         let cols = detect_columns(&items, 1, false);
         assert_eq!(cols.len(), 2, "Expected 2 columns, got {}", cols.len());
+        assert!(
+            cols[1].x_max > 7_000.0,
+            "right column should keep its true extent, got {}",
+            cols[1].x_max
+        );
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -48,8 +48,17 @@ pub(crate) fn detect_columns(
         .map(|i| i.x + effective_width(i))
         .fold(f32::NEG_INFINITY, f32::max);
 
+    // Cap the histogram size. Bounds are derived from text-item coordinates,
+    // which come straight from the content-stream text matrix and can be placed
+    // at any coordinate, so a crafted PDF can otherwise force an arbitrarily
+    // large `page_width` and an unbounded `vec![0u32; num_bins]` allocation.
+    // 65_536 bins covers ~128k points at BIN_WIDTH 2.0 — roughly 9x the largest
+    // legal page — so this never clamps a real layout. A non-finite width
+    // (NaN/inf coordinate propagating through the folds) short-circuits here.
+    const MAX_BINS: usize = 65_536;
+
     let page_width = x_max - x_min;
-    if page_width < 200.0 {
+    if !page_width.is_finite() || page_width < 200.0 {
         return vec![ColumnRegion { x_min, x_max }];
     }
 
@@ -63,7 +72,7 @@ pub(crate) fn detect_columns(
     // detection of partial-page column layouts (e.g. two-column abstracts on
     // a page that also has single-column introduction text).
     let wide_threshold = page_width * 0.6;
-    let num_bins = ((page_width / BIN_WIDTH).ceil() as usize).max(1);
+    let num_bins = ((page_width / BIN_WIDTH).ceil() as usize).clamp(1, MAX_BINS);
     let mut histogram = vec![0u32; num_bins];
 
     for item in &page_items {
@@ -1827,7 +1836,7 @@ fn split_column_stragglers(lines: Vec<TextLine>) -> (Vec<TextLine>, Vec<TextLine
         .unwrap();
 
     let (cs, ce) = segments[core_seg];
-    let mut core = Vec::with_capacity(ce - cs);
+    let mut core = Vec::with_capacity(ce.saturating_sub(cs));
     let mut stragglers = Vec::new();
     for (i, line) in lines.into_iter().enumerate() {
         if i >= cs && i < ce {
@@ -2531,6 +2540,38 @@ mod tests {
             (620.0..=680.0).contains(&g2),
             "Second gutter at {g2}, expected between middle and right zones"
         );
+    }
+
+    #[test]
+    fn extreme_far_coordinate_does_not_allocate_unboundedly() {
+        // A crafted PDF can place a text run at an arbitrary coordinate via the
+        // text matrix. The derived page width must not drive an unbounded
+        // histogram allocation (previously `page_width / BIN_WIDTH` bins with no
+        // upper bound would try to reserve terabytes and abort the process).
+        let mut items = Vec::new();
+        for i in 0..24 {
+            items.push(make_item(1, i as f32 * 10.0, 700.0 - i as f32 * 5.0, "A"));
+        }
+        // Item placed 1e12 points away — 5e11 bins if left unclamped.
+        items.push(make_item(1, 1e12, 700.0, "Z"));
+
+        // Must return without aborting; content is preserved as a single region.
+        let cols = detect_columns(&items, 1, false);
+        assert!(!cols.is_empty());
+    }
+
+    #[test]
+    fn non_finite_coordinate_short_circuits() {
+        // A NaN/inf coordinate propagates through the min/max folds and would
+        // otherwise reach the histogram cast. The finite-width guard handles it.
+        let mut items = Vec::new();
+        for i in 0..24 {
+            items.push(make_item(1, i as f32 * 10.0, 700.0 - i as f32 * 5.0, "A"));
+        }
+        items.push(make_item(1, f32::INFINITY, 700.0, "Z"));
+
+        let cols = detect_columns(&items, 1, false);
+        assert_eq!(cols.len(), 1, "non-finite width returns a single region");
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -41,79 +41,83 @@ pub(crate) fn detect_columns(
     }
     debug!("page {}: detect_columns: {} items", page, page_items.len());
 
-    // A span wider than this means the bounds are being set by stray items
-    // rather than by a real layout. This is a heuristic, not a format rule:
-    // PDF 2.0 sets no page-size limit, and since PDF 1.6 `UserUnit` scales a
-    // page's physical size independently of its coordinates. 14_400 units
-    // (200in at the default 1/72in unit) is the traditional Acrobat
-    // architectural limit, which makes it a reasonable "wider than any
-    // ordinary page" mark in coordinate space.
+    // The width of one ordinary page, used three ways below: as the largest
+    // credible width for a single text run, as the size of empty gap that marks
+    // content as detached, and as the span past which those checks run at all.
+    // This is a heuristic, not a format rule: PDF 2.0 sets no page-size limit,
+    // and since PDF 1.6 `UserUnit` scales a page's physical size independently
+    // of its coordinates. 14_400 units (200in at the default 1/72in unit) is
+    // the traditional Acrobat architectural limit, which makes it a reasonable
+    // "wider than any ordinary page" mark in coordinate space.
     const MAX_PAGE_EXTENT: f32 = 14_400.0;
-    // Trimming is only safe when the far items are a small minority. A
-    // genuinely large-format page has content spread across its whole width,
-    // so a large share of items falls outside the window and the page keeps
-    // its true bounds; a malformed page has just a few strays.
+    // A detached cluster is only dropped if it also holds a small minority of
+    // the items, so a genuine two-part layout keeps its full bounds even when
+    // the halves are far apart.
     const MAX_TRIM_FRACTION: f32 = 0.10;
 
-    // Find page bounds. Coordinates come straight from the content-stream text
-    // matrix, so a malformed document can place items at non-finite positions.
-    // Those are excluded rather than failing the whole page: one bad glyph
-    // should not disable column detection, and the emitted regions must never
-    // carry a NaN/inf boundary out to callers.
-    let bounds = |keep: &dyn Fn(f32, f32) -> bool| {
-        page_items
-            .iter()
-            .map(|i| (i.x, i.x + effective_width(i)))
-            .filter(|&(left, right)| left.is_finite() && right.is_finite() && keep(left, right))
-            .fold(
-                (f32::INFINITY, f32::NEG_INFINITY, 0usize),
-                |(lo, hi, n), (left, right)| (lo.min(left), hi.max(right), n + 1),
-            )
+    // Usable extent of an item, or None if its geometry is malformed.
+    // Coordinates come straight from the content-stream text matrix, so a
+    // document can place a run at a non-finite position or give it a width
+    // wider than any page. Such items are skipped rather than failing the whole
+    // page: one bad glyph should not disable column detection, and the emitted
+    // regions must never carry a NaN/inf boundary out to callers.
+    let usable = |i: &&TextItem| -> Option<(f32, f32)> {
+        let (left, width) = (i.x, effective_width(i));
+        let right = left + width;
+        (left.is_finite() && right.is_finite() && width <= MAX_PAGE_EXTENT).then_some((left, right))
     };
 
-    let (mut x_min, mut x_max, total) = bounds(&|_, _| true);
+    let (mut x_min, mut x_max, total) = page_items.iter().filter_map(usable).fold(
+        (f32::INFINITY, f32::NEG_INFINITY, 0usize),
+        |(lo, hi, n), (left, right)| (lo.min(left), hi.max(right), n + 1),
+    );
 
-    // Every item sat at a non-finite coordinate, so there is no usable layout.
-    if !x_min.is_finite() || !x_max.is_finite() {
+    // No item had usable geometry, so there is no layout to report.
+    if total == 0 {
         return vec![];
     }
 
     // Every threshold below (gutter margins, spanning-item width, the XY-cut
-    // margin) is a fraction of the page width, so a single far item would
-    // otherwise set the scale for the whole page and shrink the effective
-    // detection window to a rounding error — real gutters then fall inside the
-    // margin band and a genuine multi-column page collapses to one region.
-    // Re-derive the bounds from the items clustered around the median so a lone
-    // outlier cannot poison the scale. Outliers keep their text: column
-    // assignment buckets them by nearest overlap, not by containment.
+    // margin) is a fraction of the page width, so a far item can set the scale
+    // for the whole page and shrink the effective detection window to a
+    // rounding error — real gutters then fall inside the margin band and a
+    // genuine multi-column page collapses to one region.
+    //
+    // Detaching such an item needs positive evidence that it is not part of the
+    // layout, because a count-based rule alone cannot tell a stray from a
+    // sparse far sidebar. The evidence used here is geometric: content is
+    // grouped into clusters separated by more than a whole page of continuous
+    // emptiness. Real content, however sparse, does not leave a void that
+    // large; a malformed coordinate sits alone beyond one. A cluster is only
+    // dropped when it also holds a small minority of the items.
     if x_max - x_min > MAX_PAGE_EXTENT {
-        // Anchor on the same items `bounds` accepts, so a malformed width
-        // cannot shift the median that decides which items are strays.
-        let mut xs: Vec<f32> = page_items
-            .iter()
-            .filter_map(|i| {
-                let right = i.x + effective_width(i);
-                (i.x.is_finite() && right.is_finite()).then_some(i.x)
-            })
-            .collect();
-        xs.sort_by(f32::total_cmp);
-        let median = xs[xs.len() / 2];
+        let mut spans: Vec<(f32, f32)> = page_items.iter().filter_map(usable).collect();
+        spans.sort_by(|a, b| a.0.total_cmp(&b.0));
 
-        // Both edges are checked: a malformed width poisons `x_max` from an
-        // ordinary position just as a malformed position poisons `x_min`.
-        let near = |left: f32, right: f32| {
-            (left - median).abs() <= MAX_PAGE_EXTENT && (right - median).abs() <= MAX_PAGE_EXTENT
-        };
-        let (lo, hi, kept) = bounds(&near);
-        let dropped = total - kept;
+        // (item count, lo, hi) per cluster.
+        let mut clusters: Vec<(usize, f32, f32)> = Vec::new();
+        for &(left, right) in &spans {
+            match clusters.last_mut() {
+                Some((count, _, hi)) if left - *hi <= MAX_PAGE_EXTENT => {
+                    *count += 1;
+                    *hi = hi.max(right);
+                }
+                _ => clusters.push((1, left, right)),
+            }
+        }
 
-        if lo.is_finite() && hi.is_finite() && dropped as f32 <= total as f32 * MAX_TRIM_FRACTION {
-            debug!(
-                "page {page}: bounds {x_min}..{x_max} span > one page; \
-                 dropping {dropped}/{total} stray item(s), trimming to {lo}..{hi}"
-            );
-            x_min = lo;
-            x_max = hi;
+        if let Some(&(count, lo, hi)) = clusters.iter().max_by_key(|&&(count, _, _)| count) {
+            let dropped = total - count;
+            if clusters.len() > 1 && dropped as f32 <= total as f32 * MAX_TRIM_FRACTION {
+                debug!(
+                    "page {page}: bounds {x_min}..{x_max} span > one page in \
+                     {} clusters; dropping {dropped}/{total} detached item(s), \
+                     trimming to {lo}..{hi}",
+                    clusters.len()
+                );
+                x_min = lo;
+                x_max = hi;
+            }
         }
     }
 
@@ -2733,6 +2737,29 @@ mod tests {
             (140_000.0..=160_000.0).contains(&cols[1].x_max),
             "second gutter at {}, expected inside the real 140k..160k gap",
             cols[1].x_max
+        );
+    }
+
+    #[test]
+    fn sparse_far_sidebar_on_a_large_page_is_kept() {
+        // A large-format page with a thin, sparsely-populated sidebar far from
+        // the main block. The sidebar is a small minority of the items, so an
+        // item-count rule alone would discard it — but nothing about its
+        // geometry says it is invalid, so its bounds must survive.
+        let mut items = Vec::new();
+        items.extend(fill_zone(1, 0.0, 12_000.0, 750.0, 500.0));
+        for i in 0..12 {
+            items.push(make_item(1, 24_000.0, 750.0 - i as f32 * 14.0, "Sidebar"));
+        }
+
+        let cols = detect_columns(&items, 1, false);
+        let right_edge = cols
+            .iter()
+            .map(|c| c.x_max)
+            .fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            right_edge > 24_000.0,
+            "sidebar was trimmed away: right edge {right_edge}, expected >24_000"
         );
     }
 

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -55,21 +55,15 @@ pub(crate) fn detect_columns(
     // the halves are far apart.
     const MAX_TRIM_FRACTION: f32 = 0.10;
 
-    // Usable extent of an item, or None if its geometry is malformed.
-    // Coordinates come straight from the content-stream text matrix, so a
-    // document can place a run at a non-finite position or give it a width
-    // wider than any page. Such items are skipped rather than failing the whole
-    // page: one bad glyph should not disable column detection, and the emitted
-    // regions must never carry a NaN/inf boundary out to callers.
-    let usable = |i: &&TextItem| -> Option<(f32, f32)> {
+    // Position and width of each item, skipping only non-finite geometry.
+    let finite_span = |i: &&TextItem| -> Option<(f32, f32)> {
         let (left, width) = (i.x, effective_width(i));
-        let right = left + width;
-        (left.is_finite() && right.is_finite() && width <= MAX_PAGE_EXTENT).then_some((left, right))
+        (left.is_finite() && (left + width).is_finite()).then_some((left, width))
     };
 
-    let (mut x_min, mut x_max, total) = page_items.iter().filter_map(usable).fold(
+    let (min_left, max_right, total) = page_items.iter().filter_map(finite_span).fold(
         (f32::INFINITY, f32::NEG_INFINITY, 0usize),
-        |(lo, hi, n), (left, right)| (lo.min(left), hi.max(right), n + 1),
+        |(lo, hi, n), (left, width)| (lo.min(left), hi.max(left + width), n + 1),
     );
 
     // No item had usable geometry, so there is no layout to report.
@@ -83,43 +77,62 @@ pub(crate) fn detect_columns(
     // rounding error — real gutters then fall inside the margin band and a
     // genuine multi-column page collapses to one region.
     //
-    // Detaching such an item needs positive evidence that it is not part of the
-    // layout, because a count-based rule alone cannot tell a stray from a
-    // sparse far sidebar. The evidence used here is geometric: content is
-    // grouped into clusters separated by more than a whole page of continuous
-    // emptiness. Real content, however sparse, does not leave a void that
-    // large; a malformed coordinate sits alone beyond one. A cluster is only
-    // dropped when it also holds a small minority of the items.
-    if x_max - x_min > MAX_PAGE_EXTENT {
-        let mut spans: Vec<(f32, f32)> = page_items.iter().filter_map(usable).collect();
+    // Anything inside one page extent is ordinary, so the common case keeps the
+    // plain bounds and skips the work below entirely.
+    let (x_min, x_max) = if max_right - min_left <= MAX_PAGE_EXTENT {
+        (min_left, max_right)
+    } else {
+        // Discarding content needs positive evidence that it is not part of the
+        // layout, because a count-based rule alone cannot tell a stray from a
+        // sparse far sidebar. The evidence is geometric: positions are grouped
+        // into clusters separated by more than a whole page of continuous
+        // emptiness. Real content, however sparse, does not leave a void that
+        // large; a malformed coordinate sits alone beyond one.
+        let mut spans: Vec<(f32, f32)> = page_items.iter().filter_map(finite_span).collect();
         spans.sort_by(|a, b| a.0.total_cmp(&b.0));
 
-        // (item count, lo, hi) per cluster.
-        let mut clusters: Vec<(usize, f32, f32)> = Vec::new();
-        for &(left, right) in &spans {
-            match clusters.last_mut() {
-                Some((count, _, hi)) if left - *hi <= MAX_PAGE_EXTENT => {
-                    *count += 1;
-                    *hi = hi.max(right);
-                }
-                _ => clusters.push((1, left, right)),
+        let mut core: Option<std::ops::Range<usize>> = None;
+        let mut start = 0usize;
+        for i in 1..=spans.len() {
+            if i < spans.len() && spans[i].0 - spans[i - 1].0 <= MAX_PAGE_EXTENT {
+                continue;
             }
+            if core.as_ref().is_none_or(|best| i - start > best.len()) {
+                core = Some(start..i);
+            }
+            start = i;
         }
+        let mut core = core.unwrap_or(0..spans.len());
 
-        if let Some(&(count, lo, hi)) = clusters.iter().max_by_key(|&&(count, _, _)| count) {
-            let dropped = total - count;
-            if clusters.len() > 1 && dropped as f32 <= total as f32 * MAX_TRIM_FRACTION {
-                debug!(
-                    "page {page}: bounds {x_min}..{x_max} span > one page in \
-                     {} clusters; dropping {dropped}/{total} detached item(s), \
-                     trimming to {lo}..{hi}",
-                    clusters.len()
-                );
-                x_min = lo;
-                x_max = hi;
-            }
+        // Only drop the detached clusters when they are a small minority, so a
+        // genuine two-part layout keeps its full bounds.
+        let dropped = spans.len() - core.len();
+        if dropped as f32 > spans.len() as f32 * MAX_TRIM_FRACTION {
+            core = 0..spans.len();
         }
-    }
+        let core = &spans[core];
+
+        // Positions cannot be inflated by a bogus width, so the spread of the
+        // content is a sound scale for judging one. A run much wider than the
+        // page's own content is a malformed width — the test is relative, so a
+        // genuinely large page keeps its genuinely long runs.
+        let (lo, widest_left) = (core[0].0, core[core.len() - 1].0);
+        let max_run_width = (widest_left - lo) + MAX_PAGE_EXTENT;
+        let hi = core
+            .iter()
+            .filter(|&&(_, width)| width <= max_run_width)
+            .map(|&(left, width)| left + width)
+            .fold(widest_left, f32::max);
+
+        if lo != min_left || hi != max_right {
+            debug!(
+                "page {page}: bounds {min_left}..{max_right} exceed one page; \
+                 dropped {dropped}/{} detached item(s), using {lo}..{hi}",
+                spans.len()
+            );
+        }
+        (lo, hi)
+    };
 
     // Hard ceiling on the histogram size, independent of the trimming above:
     // the bounds are attacker-influenced, so an unclamped
@@ -2737,6 +2750,36 @@ mod tests {
             (140_000.0..=160_000.0).contains(&cols[1].x_max),
             "second gutter at {}, expected inside the real 140k..160k gap",
             cols[1].x_max
+        );
+    }
+
+    #[test]
+    fn large_page_with_legitimately_long_runs_is_kept() {
+        // On a very large page, individual runs can exceed one ordinary page's
+        // width. They are real content, so they must not be judged malformed:
+        // the page keeps its columns and its full right edge.
+        let mut items = Vec::new();
+        for row in 0..30 {
+            let y = 750.0 - row as f32 * 14.0;
+            let mut left = make_item(1, 0.0, y, "Left run");
+            left.width = 20_000.0;
+            let mut right = make_item(1, 25_000.0, y, "Right run");
+            right.width = 20_000.0;
+            items.extend([left, right]);
+        }
+
+        let cols = detect_columns(&items, 1, false);
+        assert!(
+            !cols.is_empty(),
+            "a page of long-but-valid runs must still report a layout"
+        );
+        let right_edge = cols
+            .iter()
+            .map(|c| c.x_max)
+            .fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            right_edge > 44_000.0,
+            "long runs were treated as malformed: right edge {right_edge}, expected ~45_000"
         );
     }
 

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -41,28 +41,37 @@ pub(crate) fn detect_columns(
     }
     debug!("page {}: detect_columns: {} items", page, page_items.len());
 
-    // The PDF specification caps a page at 14_400 units (200 inches). Content
-    // may sit a little outside the MediaBox, but a span far beyond one whole
-    // page means stray items, not a real layout.
+    // A span wider than this means the bounds are being set by stray items
+    // rather than by a real layout. This is a heuristic, not a format rule:
+    // PDF 2.0 sets no page-size limit, and since PDF 1.6 `UserUnit` scales a
+    // page's physical size independently of its coordinates. 14_400 units
+    // (200in at the default 1/72in unit) is the traditional Acrobat
+    // architectural limit, which makes it a reasonable "wider than any
+    // ordinary page" mark in coordinate space.
     const MAX_PAGE_EXTENT: f32 = 14_400.0;
+    // Trimming is only safe when the far items are a small minority. A
+    // genuinely large-format page has content spread across its whole width,
+    // so a large share of items falls outside the window and the page keeps
+    // its true bounds; a malformed page has just a few strays.
+    const MAX_TRIM_FRACTION: f32 = 0.10;
 
     // Find page bounds. Coordinates come straight from the content-stream text
     // matrix, so a malformed document can place items at non-finite positions.
     // Those are excluded rather than failing the whole page: one bad glyph
     // should not disable column detection, and the emitted regions must never
     // carry a NaN/inf boundary out to callers.
-    let bounds = |keep: &dyn Fn(f32) -> bool| {
+    let bounds = |keep: &dyn Fn(f32, f32) -> bool| {
         page_items
             .iter()
-            .filter(|i| i.x.is_finite() && keep(i.x))
             .map(|i| (i.x, i.x + effective_width(i)))
-            .filter(|(_, right)| right.is_finite())
-            .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), (l, r)| {
-                (lo.min(l), hi.max(r))
-            })
+            .filter(|&(left, right)| left.is_finite() && right.is_finite() && keep(left, right))
+            .fold(
+                (f32::INFINITY, f32::NEG_INFINITY, 0usize),
+                |(lo, hi, n), (left, right)| (lo.min(left), hi.max(right), n + 1),
+            )
     };
 
-    let (mut x_min, mut x_max) = bounds(&|_| true);
+    let (mut x_min, mut x_max, total) = bounds(&|_, _| true);
 
     // Every item sat at a non-finite coordinate, so there is no usable layout.
     if !x_min.is_finite() || !x_max.is_finite() {
@@ -70,8 +79,8 @@ pub(crate) fn detect_columns(
     }
 
     // Every threshold below (gutter margins, spanning-item width, the XY-cut
-    // margin) is a fraction of the page width, so a single far-but-finite item
-    // would otherwise set the scale for the whole page and shrink the effective
+    // margin) is a fraction of the page width, so a single far item would
+    // otherwise set the scale for the whole page and shrink the effective
     // detection window to a rounding error — real gutters then fall inside the
     // margin band and a genuine multi-column page collapses to one region.
     // Re-derive the bounds from the items clustered around the median so a lone
@@ -86,11 +95,18 @@ pub(crate) fn detect_columns(
         xs.sort_by(f32::total_cmp);
         let median = xs[xs.len() / 2];
 
-        let (lo, hi) = bounds(&|x| (x - median).abs() <= MAX_PAGE_EXTENT);
-        if lo.is_finite() && hi.is_finite() {
+        // Both edges are checked: a malformed width poisons `x_max` from an
+        // ordinary position just as a malformed position poisons `x_min`.
+        let near = |left: f32, right: f32| {
+            (left - median).abs() <= MAX_PAGE_EXTENT && (right - median).abs() <= MAX_PAGE_EXTENT
+        };
+        let (lo, hi, kept) = bounds(&near);
+        let dropped = total - kept;
+
+        if lo.is_finite() && hi.is_finite() && dropped as f32 <= total as f32 * MAX_TRIM_FRACTION {
             debug!(
                 "page {page}: bounds {x_min}..{x_max} span > one page; \
-                 trimming outliers to {lo}..{hi}"
+                 dropping {dropped}/{total} stray item(s), trimming to {lo}..{hi}"
             );
             x_min = lo;
             x_max = hi;
@@ -2641,33 +2657,66 @@ mod tests {
     }
 
     #[test]
-    fn one_bad_coordinate_does_not_disable_column_detection() {
-        // A single stray coordinate should not collapse a clean two-column page
-        // to one region. Finite outliers matter as much as NaN/inf ones: every
-        // gutter threshold is a fraction of the page width, so an untrimmed
-        // outlier pushes real gutters inside the rejected margin band.
-        for bad_x in [f32::NAN, f32::INFINITY, 50_000.0, 1e12] {
+    fn one_bad_item_does_not_disable_column_detection() {
+        // A single stray item should not collapse a clean two-column page to
+        // one region. Every gutter threshold is a fraction of the page width,
+        // so an untrimmed outlier pushes real gutters inside the rejected
+        // margin band. A malformed *width* at an ordinary position poisons the
+        // bounds just as a malformed position does.
+        for (label, bad_x, bad_width) in [
+            ("nan position", f32::NAN, 0.0),
+            ("inf position", f32::INFINITY, 0.0),
+            ("far position", 50_000.0, 0.0),
+            ("very far position", 1e12, 0.0),
+            ("huge width", 100.0, 1e12),
+            ("inf width", 100.0, f32::INFINITY),
+        ] {
             let mut items = Vec::new();
             items.extend(fill_zone(1, 30.0, 280.0, 750.0, 50.0));
             items.extend(fill_zone(1, 320.0, 570.0, 750.0, 50.0));
-            items.push(make_item(1, bad_x, 400.0, "Z"));
+            let mut bad = make_item(1, bad_x, 400.0, "Z");
+            bad.width = bad_width;
+            items.push(bad);
 
             let cols = detect_columns(&items, 1, false);
             assert_eq!(
                 cols.len(),
                 2,
-                "bad_x {bad_x}: expected 2 columns, got {}",
+                "{label}: expected 2 columns, got {}",
                 cols.len()
             );
             for col in &cols {
                 assert!(
-                    col.x_max - col.x_min <= 14_400.0,
-                    "bad_x {bad_x}: region {}..{} exceeds one page",
+                    col.x_max - col.x_min <= MAX_PAGE_EXTENT_FOR_TEST,
+                    "{label}: region {}..{} exceeds one page",
                     col.x_min,
                     col.x_max
                 );
             }
         }
+    }
+
+    /// Mirrors `MAX_PAGE_EXTENT` in `detect_columns`.
+    const MAX_PAGE_EXTENT_FOR_TEST: f32 = 14_400.0;
+
+    #[test]
+    fn genuinely_wide_layout_keeps_its_true_bounds() {
+        // A large-format page whose content really is spread beyond one
+        // ordinary page must not be trimmed to the median cluster: its far
+        // items are the majority, not strays.
+        let mut items = Vec::new();
+        items.extend(fill_zone(1, 100.0, 20_000.0, 750.0, 600.0));
+        items.extend(fill_zone(1, 22_000.0, 40_000.0, 750.0, 600.0));
+
+        let cols = detect_columns(&items, 1, false);
+        let widest = cols
+            .iter()
+            .map(|c| c.x_max)
+            .fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            widest > 35_000.0,
+            "wide layout was trimmed: right edge {widest}, expected ~40_000"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`detect_columns()` in `src/extractor/layout.rs` derives its page bounds from text-item coordinates, which come straight from the content-stream text matrix (`Tm`/`Td`). A document can therefore place a run at any position, and those bounds fed two problems:

1. **Unbounded allocation.** The histogram bin count (`page_width / BIN_WIDTH`) had no upper bound, so an extreme coordinate drove an arbitrarily large `vec![0u32; num_bins]`.
2. **Poisoned thresholds.** Gutter margins, the spanning-item width cut-off and the XY-cut margin are all fractions of `page_width`, so one far item shrank the effective detection window and silently disabled column detection for the whole page.

## Changes

- Clamp the bin count with a `MAX_BINS = 65_536` ceiling (~128k points at `BIN_WIDTH = 2.0`). Kept as a hard allocation bound that does not depend on the heuristics below staying correct.
- Exclude items at non-finite coordinates when folding the bounds. A NaN is otherwise silently dropped by `f32::min`/`f32::max` while an inf propagates through and can escape as a `ColumnRegion` boundary. Bad items are skipped individually rather than failing the page.
- Trim far outliers when the span exceeds `MAX_PAGE_EXTENT = 14_400` units, re-deriving the bounds from items clustered around the median. **Both item edges are checked**, since a malformed *width* at an ordinary position poisons `x_max` exactly as a malformed position poisons `x_min`.
- Only trim when the far items are a small minority (`MAX_TRIM_FRACTION = 10%`). A genuinely large-format page has content spread across its full width, so it keeps its true bounds rather than being reduced to the median cluster.
- Return no columns when every item sits at a non-finite coordinate (callers already treat `len() <= 1` as single-column).
- Use `saturating_sub` for the sibling `Vec::with_capacity` in `split_column_stragglers()` as cheap defence-in-depth (capacity is only a hint).

Outliers never lose their text: column assignment buckets by greatest overlap and falls back to column 0, so a zero-overlap item is still placed.

### On `MAX_PAGE_EXTENT`

14_400 units is **not** a format limit, and the comment now says so. PDF 2.0 sets no page-size cap, and since PDF 1.6 `UserUnit` scales a page's physical size independently of its coordinates. 14_400 is the traditional Acrobat architectural limit (PDF 1.7 Annex C), which makes it a reasonable "wider than any ordinary page" mark in coordinate space. It is documented as a heuristic, and the 10% minority rule is what actually protects valid large-format documents.

## Testing

- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` all pass (852 lib + 152 integration + doc tests).
- New tests: unbounded-allocation guard; non-finite values never leaking into emitted bounds (`+inf`, `-inf`, NaN); all-non-finite page yields no columns; a two-column page keeping both columns across six malformed-item shapes (NaN/inf/far positions **and** huge/inf widths); a genuinely wide 40_000pt layout keeping its true bounds; a wide-but-ordinary 8_000pt page not trimmed.
- The wide-layout test was verified to be load-bearing: relaxing `MAX_TRIM_FRACTION` to 1.0 makes it fail (right edge 33_390 instead of ~40_000).
- Verified before/after on a crafted 1.2 KB PDF: the previous build aborted while trying to reserve terabytes; now it converts normally at low RSS, with NaN, ±inf and float-saturation variants all clean.

### Output-stability check

The `pdf-evals` snapshot suite is not reachable from this environment, so `bench.py test` / `bench.py score` have not been run. As a substitute, binaries built from `main` and from this branch were run over all 27 fixture PDFs in `tests/fixtures/`:

- **27/27 byte-identical output.**
- **0/27 reach the outlier-trim path** (checked via the new debug log).

That matches the design: every new branch is gated behind a condition well-formed PDFs cannot meet — `MAX_BINS` needs a span above 131_072pt, trimming needs one above 14_400pt plus a <10% stray minority, and the non-finite filters need a NaN/inf coordinate. Snapshots should only move for a document that genuinely has a few stray off-page items, where the expected change is recovering column detection that is silently lost today.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe7a2-665a-7879-929e-ffdba3d33fe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe7a2-665a-7879-929e-ffdba3d33fe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound and scale the column-detection histogram, harden geometry handling, judge run widths relative to page content, and require geometric evidence before trimming detached items. This prevents huge allocations and bad bounds while preserving real layouts, including very wide pages and long runs.

- **Bug Fixes**
  - Cap histogram bins at 65,536 and derive `bin_width` from `page_width` so coverage spans the full page; gutters stay correct past ~131k points.
  - Skip items with non-finite geometry (NaN/±inf positions or left+width); all-non-finite pages yield no columns; region edges are always finite.
  - Replace median trim with gap-based clustering on positions; only drop clusters split by >1 page of empty space and ≤10% of items; judge widths relative to the page’s content spread (+1 page) so valid large pages and long runs keep true bounds; check both edges so huge widths can’t poison bounds.
  - Use saturating capacity in `split_column_stragglers()`.

<sup>Written for commit 83d378ebe8457040a5d9b0180c956750b29b3876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

