### PR TITLE
Clarify SECURITY.md reporting channels

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,19 +5,15 @@
 If you believe you've found a security vulnerability in pdf-inspector, please
 report it privately so we can fix it before public disclosure.
 
-**Preferred:** Email **help@firecrawl.dev** with:
+**Preferred:** Submit through Firecrawl's Bugcrowd vulnerability disclosure
+program at <https://bugcrowd.com/engagements/firecrawl-vdp-ess>. Please include:
 
 - A description of the issue and its impact
 - Steps to reproduce (a minimal PDF or input that triggers the bug is ideal)
 - The version or commit hash of pdf-inspector you tested against
 
-Email is the only channel we require, and a complete report sent this way needs
-no further action from you.
-
-**Alternative:** If you already use it, you may submit through Firecrawl's
-Bugcrowd vulnerability disclosure program at
-<https://bugcrowd.com/engagements/firecrawl-vdp-ess>. We do not require you to
-create a Bugcrowd account to report a bug — email is always sufficient.
+**Alternative:** If you'd rather not use Bugcrowd, email
+**help@firecrawl.dev** with the same details.
 
 We'll acknowledge your report in a timely manner and keep you updated on
 remediation progress. Please do not open a public GitHub issue for security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,13 @@ report it privately so we can fix it before public disclosure.
 - Steps to reproduce (a minimal PDF or input that triggers the bug is ideal)
 - The version or commit hash of pdf-inspector you tested against
 
-**Alternative:** Use GitHub's private vulnerability reporting under the
-[Security tab](https://github.com/firecrawl/pdf-inspector/security/advisories/new).
+Email is the only channel we require, and a complete report sent this way needs
+no further action from you.
+
+**Alternative:** If you already use it, you may submit through Firecrawl's
+Bugcrowd vulnerability disclosure program at
+<https://bugcrowd.com/engagements/firecrawl-vdp-ess>. We do not require you to
+create a Bugcrowd account to report a bug — email is always sufficient.
 
 We'll acknowledge your report in a timely manner and keep you updated on
 remediation progress. Please do not open a public GitHub issue for security


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tidies the reporting-channel section of `SECURITY.md`.

- Make Firecrawl's Bugcrowd vulnerability disclosure engagement (`https://bugcrowd.com/engagements/firecrawl-vdp-ess`) the **preferred** reporting channel.
- Offer email (`help@firecrawl.dev`) as the alternative for reporters who'd rather not use Bugcrowd.
- Removes the previous "GitHub private vulnerability reporting" link, which is not enabled on this repo and currently 404s.

No code changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe7a2-665a-7879-929e-ffdba3d33fe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe7a2-665a-7879-929e-ffdba3d33fe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates SECURITY.md to make Firecrawl’s Bugcrowd VDP (https://bugcrowd.com/engagements/firecrawl-vdp-ess) the preferred reporting channel, with email (help@firecrawl.dev) as the alternative. Removes the broken GitHub private advisory link.

<sup>Written for commit 8c3e07a491bbd41ff1d42a3c8db013a05dad3599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

