### PR TITLE
fix(extractor): preserve line origins in Form XObjects

### DIFF
--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -245,7 +245,9 @@ fn extract_form_xobject_text_inner(
     // Process the content stream
     let mut current_font = String::new();
     let mut current_font_size: f32 = 12.0;
+    let mut text_leading: f32 = 0.0;
     let mut text_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
+    let mut line_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
@@ -321,6 +323,7 @@ fn extract_form_xobject_text_inner(
             "BT" => {
                 in_text_block = true;
                 text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                line_matrix = text_matrix;
             }
             "ET" => {
                 in_text_block = false;
@@ -333,12 +336,21 @@ fn extract_form_xobject_text_inner(
                     current_font_size = get_number(&op.operands[1]).unwrap_or(12.0);
                 }
             }
+            "TL" => {
+                if let Some(tl) = op.operands.first().and_then(get_number) {
+                    text_leading = tl;
+                }
+            }
             "Td" | "TD" => {
                 if op.operands.len() >= 2 {
                     let tx = get_number(&op.operands[0]).unwrap_or(0.0);
                     let ty = get_number(&op.operands[1]).unwrap_or(0.0);
-                    text_matrix[4] += tx * text_matrix[0] + ty * text_matrix[2];
-                    text_matrix[5] += tx * text_matrix[1] + ty * text_matrix[3];
+                    line_matrix[4] += tx * line_matrix[0] + ty * line_matrix[2];
+                    line_matrix[5] += tx * line_matrix[1] + ty * line_matrix[3];
+                    text_matrix = line_matrix;
+                    if op.operator == "TD" {
+                        text_leading = -ty;
+                    }
                 }
             }
             "Tm" => {
@@ -347,7 +359,18 @@ fn extract_form_xobject_text_inner(
                         text_matrix[i] =
                             get_number(operand).unwrap_or(if i == 0 || i == 3 { 1.0 } else { 0.0 });
                     }
+                    line_matrix = text_matrix;
                 }
+            }
+            "T*" => {
+                let leading = if text_leading != 0.0 {
+                    text_leading
+                } else {
+                    current_font_size * 1.2
+                };
+                line_matrix[4] += (-leading) * line_matrix[2];
+                line_matrix[5] += (-leading) * line_matrix[3];
+                text_matrix = line_matrix;
             }
             "g" => {
                 if let Some(gray) = op.operands.first().and_then(get_number) {
@@ -682,4 +705,82 @@ pub(crate) fn get_form_fonts<'a>(
     }
 
     fonts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tounicode::FontCMaps;
+    use lopdf::{dictionary, Object, Stream};
+
+    fn extract_form_items(content: &[u8]) -> Vec<TextItem> {
+        let mut doc = Document::new();
+        let widths: Vec<Object> = (0..=255).map(|_| 600.into()).collect();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "FirstChar" => 0,
+            "LastChar" => 255,
+            "Widths" => Object::Array(widths),
+        });
+        let form_id = doc.add_object(Object::Stream(Stream::new(
+            dictionary! {
+                "Type" => "XObject",
+                "Subtype" => "Form",
+                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                "Resources" => dictionary! {
+                    "Font" => dictionary! {
+                        "F1" => Object::Reference(font_id),
+                    },
+                },
+            },
+            content.to_vec(),
+        )));
+
+        extract_form_xobject_text(
+            &doc,
+            form_id,
+            1,
+            &FontCMaps::default(),
+            &[1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            &mut CMapDecisionCache::new(),
+            &mut FontStyleCache::new(),
+        )
+    }
+
+    #[test]
+    fn relative_line_move_uses_form_text_line_matrix() {
+        let items = extract_form_items(b"BT /F1 12 Tf 100 500 Td (AAAA) Tj 0 -20 Td (BBBB) Tj ET");
+        let first = items.iter().find(|item| item.text == "AAAA").unwrap();
+        let second = items.iter().find(|item| item.text == "BBBB").unwrap();
+
+        assert!((first.x - 100.0).abs() < 0.1);
+        assert!((second.x - 100.0).abs() < 0.1);
+        assert!((second.y - 480.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn next_line_uses_form_text_leading_and_line_origin() {
+        let items =
+            extract_form_items(b"BT /F1 12 Tf 20 TL 1 0 0 1 100 500 Tm (AAAA) Tj T* (BBBB) Tj ET");
+        let second = items.iter().find(|item| item.text == "BBBB").unwrap();
+
+        assert!((second.x - 100.0).abs() < 0.1);
+        assert!((second.y - 480.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn relative_line_move_with_leading_sets_next_line_origin() {
+        let items = extract_form_items(
+            b"BT /F1 12 Tf 1 0 0 1 100 500 Tm (AAAA) Tj 0 -20 TD (BBBB) Tj T* (CCCC) Tj ET",
+        );
+        let second = items.iter().find(|item| item.text == "BBBB").unwrap();
+        let third = items.iter().find(|item| item.text == "CCCC").unwrap();
+
+        assert!((second.x - 100.0).abs() < 0.1);
+        assert!((second.y - 480.0).abs() < 0.1);
+        assert!((third.x - 100.0).abs() < 0.1);
+        assert!((third.y - 460.0).abs() < 0.1);
+    }
 }


### PR DESCRIPTION
## Summary

- track the PDF text line matrix separately from the advancing text matrix inside Form XObjects
- make `Td`, `TD`, `Tm`, `TL`, and `T*` preserve the correct line origin and leading
- prevent valid Form XObject text from drifting outside the page box and being clipped
- add focused regression tests for relative line moves and leading

Fixes #325.

## Root cause

The page-box clipping introduced in v0.1.7 exposed a pre-existing Form XObject positioning bug. After a text-showing operator advanced the text matrix to the end of a line, the Form extractor applied the next `Td` to that advanced matrix instead of the separate text line matrix required by the PDF specification. Wrapped lines therefore accumulated horizontal displacement until they fell outside the page box.

## Reproduction result

On the Adam paper from the issue (`arXiv:1412.6980`), full-document Markdown increases from **33,145** to **46,900** characters. The affected pages are restored close to the v0.1.6 measurements:

| Page | v0.1.6 baseline | Fixed main |
| --- | ---: | ---: |
| 6 | 3,508 | 3,497 |
| 7 | 2,133 | 2,119 |
| 8 | 2,795 | 2,767 |
| 9 | 3,180 | 3,118 |
| 10 | 3,902 | 3,900 |
| 11 | 1,512 | 1,512 |

The small remaining differences are from later extractor changes on `main`; the severe page-level loss is resolved.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --offline -- -D warnings`
- `cargo test --offline` — 1,005 tests passed
- `python3 -m unittest discover -s scripts/tests` — 13 tests passed
- `cargo build --release --offline`
- real-document regression check against the issue PDF

## AI assistance

OpenAI Codex assisted with diagnosis and implementation. The change, regression tests, and real-document output were reviewed and validated locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves text line origins and leading in Form XObjects to stop wrapped text from drifting and getting clipped. Restores missing lines in affected PDFs. Fixes #325.

- **Bug Fixes**
  - Track a separate text line matrix from the advancing text matrix.
  - Apply `TL`, `Td`, `TD`, `Tm`, and `T*` per spec (line origin, leading, and next-line moves).
  - Prevent valid Form XObject text from moving outside the page box.
  - Add focused regression tests for relative moves, leading, and `T*` behavior.

<sup>Written for commit ef2b7700756f1add141c086fb2022e47799111e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

