### PR TITLE
feat(napi): add async variants that keep the Node event loop free

### DIFF
--- a/napi/README.md
+++ b/napi/README.md
@@ -87,7 +87,7 @@ for (const region of result[0].regions) {
 
 `processPdf`, `classifyPdf`, and `extractPagesMarkdown` are synchronous and parse on the calling thread — in Node, that's the event loop. For a one-off call in a script that's fine, but in a server a large document can hold the loop for tens to hundreds of milliseconds.
 
-`processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` take the same arguments and produce the same results, but run the parse on the libuv thread pool and return a promise, keeping the event loop free. The input buffer is read in place — no copy is made, so don't mutate it until the promise settles:
+`processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` take the same arguments and produce the same results, but run the parse on the libuv thread pool and return a promise, keeping the event loop free. The input buffer is copied before the call returns, so it's safe to reuse or mutate immediately:
 
 ```typescript
 import { classifyPdfAsync, extractPagesMarkdownAsync } from '@firecrawl/pdf-inspector'

--- a/napi/README.md
+++ b/napi/README.md
@@ -83,6 +83,22 @@ for (const region of result[0].regions) {
 }
 ```
 
+### Async variants
+
+`processPdf`, `classifyPdf`, and `extractPagesMarkdown` are synchronous and parse on the calling thread — in Node, that's the event loop. For a one-off call in a script that's fine, but in a server a large document can hold the loop for tens to hundreds of milliseconds.
+
+`processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` take the same arguments and produce the same results, but run the parse on the libuv thread pool and return a promise, keeping the event loop free:
+
+```typescript
+import { classifyPdfAsync, extractPagesMarkdownAsync } from '@firecrawl/pdf-inspector'
+
+const classification = await classifyPdfAsync(pdf)
+if (classification.pdfType === 'TextBased') {
+  const { pages } = await extractPagesMarkdownAsync(pdf)
+  // ...
+}
+```
+
 ## Types
 
 ```typescript

--- a/napi/README.md
+++ b/napi/README.md
@@ -87,7 +87,7 @@ for (const region of result[0].regions) {
 
 `processPdf`, `classifyPdf`, and `extractPagesMarkdown` are synchronous and parse on the calling thread — in Node, that's the event loop. For a one-off call in a script that's fine, but in a server a large document can hold the loop for tens to hundreds of milliseconds.
 
-`processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` take the same arguments and produce the same results, but run the parse on the libuv thread pool and return a promise, keeping the event loop free:
+`processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` take the same arguments and produce the same results, but run the parse on the libuv thread pool and return a promise, keeping the event loop free. The input buffer is read in place — no copy is made, so don't mutate it until the promise settles:
 
 ```typescript
 import { classifyPdfAsync, extractPagesMarkdownAsync } from '@firecrawl/pdf-inspector'

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -153,9 +153,7 @@ fn to_napi_result(r: pdf_inspector::PdfProcessResult) -> PdfResult {
     }
 }
 
-fn to_napi_page_ocr_reasons(
-    reasons: Vec<pdf_inspector::PageOcrReasons>,
-) -> Vec<PageOcrReasons> {
+fn to_napi_page_ocr_reasons(reasons: Vec<pdf_inspector::PageOcrReasons>) -> Vec<PageOcrReasons> {
     reasons
         .into_iter()
         .map(|reason| PageOcrReasons {
@@ -203,6 +201,31 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Shared implementations (single body behind sync and async entry points)
+// ---------------------------------------------------------------------------
+
+fn process_pdf_impl(bytes: &[u8], pages: Option<Vec<u32>>) -> Result<PdfResult> {
+    let mut opts = pdf_inspector::PdfOptions::new();
+    if let Some(p) = pages {
+        opts = opts.pages(p);
+    }
+    let result = pdf_inspector::process_pdf_mem_with_options(bytes, opts)
+        .map_err(|e| to_napi_err(e, "process_pdf"))?;
+    Ok(to_napi_result(result))
+}
+
+fn classify_pdf_impl(bytes: &[u8]) -> Result<PdfClassification> {
+    let result =
+        pdf_inspector::classify_pdf_mem(bytes).map_err(|e| to_napi_err(e, "classify_pdf"))?;
+    Ok(PdfClassification {
+        pdf_type: convert_pdf_type(result.pdf_type),
+        page_count: result.page_count,
+        pages_needing_ocr: result.pages_needing_ocr,
+        confidence: result.confidence as f64,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Public NAPI API
 // ---------------------------------------------------------------------------
 
@@ -210,15 +233,7 @@ where
 #[napi]
 pub fn process_pdf(buffer: Buffer, pages: Option<Vec<u32>>) -> Result<PdfResult> {
     let bytes: Vec<u8> = buffer.to_vec();
-    catch_panic("process_pdf", move || {
-        let mut opts = pdf_inspector::PdfOptions::new();
-        if let Some(p) = pages {
-            opts = opts.pages(p);
-        }
-        let result = pdf_inspector::process_pdf_mem_with_options(&bytes, opts)
-            .map_err(|e| to_napi_err(e, "process_pdf"))?;
-        Ok(to_napi_result(result))
-    })
+    catch_panic("process_pdf", move || process_pdf_impl(&bytes, pages))
 }
 
 /// Fast detection only — no text extraction or markdown.
@@ -238,16 +253,7 @@ pub fn detect_pdf(buffer: Buffer) -> Result<PdfResult> {
 #[napi]
 pub fn classify_pdf(buffer: Buffer) -> Result<PdfClassification> {
     let bytes: Vec<u8> = buffer.to_vec();
-    catch_panic("classify_pdf", move || {
-        let result =
-            pdf_inspector::classify_pdf_mem(&bytes).map_err(|e| to_napi_err(e, "classify_pdf"))?;
-        Ok(PdfClassification {
-            pdf_type: convert_pdf_type(result.pdf_type),
-            page_count: result.page_count,
-            pages_needing_ocr: result.pages_needing_ocr,
-            confidence: result.confidence as f64,
-        })
-    })
+    catch_panic("classify_pdf", move || classify_pdf_impl(&bytes))
 }
 
 /// Extract plain text from a PDF Buffer.
@@ -633,25 +639,32 @@ pub fn extract_pages_markdown(
 ) -> Result<PagesExtractionResult> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("extract_pages_markdown", move || {
-        let result = pdf_inspector::extract_pages_markdown_mem(&bytes, pages.as_deref())
-            .map_err(|e| to_napi_err(e, "extract_pages_markdown"))?;
-        Ok(PagesExtractionResult {
-            pages: result
-                .pages
-                .into_iter()
-                .map(|r| PageMarkdownResult {
-                    page: r.page,
-                    markdown: r.markdown,
-                    needs_ocr: r.needs_ocr,
-                    ocr_reason: r.ocr_reason,
-                })
-                .collect(),
-            pages_with_tables: result.pages_with_tables,
-            pages_with_columns: result.pages_with_columns,
-            pages_needing_ocr: result.pages_needing_ocr,
-            ocr_reasons_by_page: to_napi_page_ocr_reasons(result.ocr_reasons_by_page),
-            is_complex: result.is_complex,
-        })
+        extract_pages_markdown_impl(&bytes, pages.as_deref())
+    })
+}
+
+fn extract_pages_markdown_impl(
+    bytes: &[u8],
+    pages: Option<&[u32]>,
+) -> Result<PagesExtractionResult> {
+    let result = pdf_inspector::extract_pages_markdown_mem(bytes, pages)
+        .map_err(|e| to_napi_err(e, "extract_pages_markdown"))?;
+    Ok(PagesExtractionResult {
+        pages: result
+            .pages
+            .into_iter()
+            .map(|r| PageMarkdownResult {
+                page: r.page,
+                markdown: r.markdown,
+                needs_ocr: r.needs_ocr,
+                ocr_reason: r.ocr_reason,
+            })
+            .collect(),
+        pages_with_tables: result.pages_with_tables,
+        pages_with_columns: result.pages_with_columns,
+        pages_needing_ocr: result.pages_needing_ocr,
+        ocr_reasons_by_page: to_napi_page_ocr_reasons(result.ocr_reasons_by_page),
+        is_complex: result.is_complex,
     })
 }
 
@@ -691,4 +704,118 @@ fn to_page_region_texts(results: Vec<pdf_inspector::PageRegionResult>) -> Vec<Pa
                 .collect(),
         })
         .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Async variants (libuv thread pool via AsyncTask)
+//
+// The synchronous exports above parse on the calling thread, which in Node is
+// the event loop. These `*Async` variants run the same shared implementations
+// on the libuv thread pool and hand JavaScript a promise, so servers under
+// concurrent load keep answering requests while a document parses. The sync
+// exports keep their names, signatures, and behaviour.
+// ---------------------------------------------------------------------------
+
+pub struct ProcessPdfTask {
+    bytes: Vec<u8>,
+    pages: Option<Vec<u32>>,
+}
+
+impl Task for ProcessPdfTask {
+    type Output = PdfResult;
+    type JsValue = PdfResult;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        let bytes = std::mem::take(&mut self.bytes);
+        let pages = self.pages.take();
+        // AssertUnwindSafe: `bytes`/`pages` are moved into the closure and
+        // dropped on unwind — no shared state can be observed broken.
+        catch_panic(
+            "process_pdf",
+            panic::AssertUnwindSafe(move || process_pdf_impl(&bytes, pages)),
+        )
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+/// Async variant of [`processPdf`]: same result, but the parse runs on the
+/// libuv thread pool instead of the event loop and the call returns a
+/// promise.
+#[napi(ts_return_type = "Promise<PdfResult>")]
+pub fn process_pdf_async(buffer: Buffer, pages: Option<Vec<u32>>) -> AsyncTask<ProcessPdfTask> {
+    AsyncTask::new(ProcessPdfTask {
+        bytes: buffer.to_vec(),
+        pages,
+    })
+}
+
+pub struct ClassifyPdfTask {
+    bytes: Vec<u8>,
+}
+
+impl Task for ClassifyPdfTask {
+    type Output = PdfClassification;
+    type JsValue = PdfClassification;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        let bytes = std::mem::take(&mut self.bytes);
+        catch_panic(
+            "classify_pdf",
+            panic::AssertUnwindSafe(move || classify_pdf_impl(&bytes)),
+        )
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+/// Async variant of [`classifyPdf`]: same result, but the classification runs
+/// on the libuv thread pool instead of the event loop and the call returns a
+/// promise.
+#[napi(ts_return_type = "Promise<PdfClassification>")]
+pub fn classify_pdf_async(buffer: Buffer) -> AsyncTask<ClassifyPdfTask> {
+    AsyncTask::new(ClassifyPdfTask {
+        bytes: buffer.to_vec(),
+    })
+}
+
+pub struct ExtractPagesMarkdownTask {
+    bytes: Vec<u8>,
+    pages: Option<Vec<u32>>,
+}
+
+impl Task for ExtractPagesMarkdownTask {
+    type Output = PagesExtractionResult;
+    type JsValue = PagesExtractionResult;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        let bytes = std::mem::take(&mut self.bytes);
+        let pages = self.pages.take();
+        catch_panic(
+            "extract_pages_markdown",
+            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(&bytes, pages.as_deref())),
+        )
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+/// Async variant of [`extractPagesMarkdown`]: same result, but the extraction
+/// runs on the libuv thread pool instead of the event loop and the call
+/// returns a promise.
+#[napi(ts_return_type = "Promise<PagesExtractionResult>")]
+pub fn extract_pages_markdown_async(
+    buffer: Buffer,
+    pages: Option<Vec<u32>>,
+) -> AsyncTask<ExtractPagesMarkdownTask> {
+    AsyncTask::new(ExtractPagesMarkdownTask {
+        bytes: buffer.to_vec(),
+        pages,
+    })
 }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -714,10 +714,17 @@ fn to_page_region_texts(results: Vec<pdf_inspector::PageRegionResult>) -> Vec<Pa
 // on the libuv thread pool and hand JavaScript a promise, so servers under
 // concurrent load keep answering requests while a document parses. The sync
 // exports keep their names, signatures, and behaviour.
+//
+// The tasks hold the napi `Buffer` itself rather than a copy: the Buffer
+// keeps a reference that pins the JS-side allocation for the task's lifetime,
+// and its backing store is stable, so `compute` can read it from the worker
+// thread without an event-loop-blocking memcpy at call time. The caller must
+// not mutate the buffer until the promise settles — the same contract as
+// Node's own async `fs` APIs.
 // ---------------------------------------------------------------------------
 
 pub struct ProcessPdfTask {
-    bytes: Vec<u8>,
+    buffer: Buffer,
     pages: Option<Vec<u32>>,
 }
 
@@ -726,13 +733,13 @@ impl Task for ProcessPdfTask {
     type JsValue = PdfResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes = std::mem::take(&mut self.bytes);
+        let bytes: &[u8] = &self.buffer;
         let pages = self.pages.take();
-        // AssertUnwindSafe: `bytes`/`pages` are moved into the closure and
-        // dropped on unwind — no shared state can be observed broken.
+        // AssertUnwindSafe: the closure only reads `bytes` and owns `pages`;
+        // on unwind no shared state can be observed broken.
         catch_panic(
             "process_pdf",
-            panic::AssertUnwindSafe(move || process_pdf_impl(&bytes, pages)),
+            panic::AssertUnwindSafe(move || process_pdf_impl(bytes, pages)),
         )
     }
 
@@ -743,17 +750,17 @@ impl Task for ProcessPdfTask {
 
 /// Async variant of [`processPdf`]: same result, but the parse runs on the
 /// libuv thread pool instead of the event loop and the call returns a
-/// promise.
+/// promise. The buffer is read in place (no copy) — do not mutate it until
+/// the promise settles.
+// ts_return_type is required: napi-rs emits `Promise<unknown>` for
+// `AsyncTask<T>` returns without it.
 #[napi(ts_return_type = "Promise<PdfResult>")]
 pub fn process_pdf_async(buffer: Buffer, pages: Option<Vec<u32>>) -> AsyncTask<ProcessPdfTask> {
-    AsyncTask::new(ProcessPdfTask {
-        bytes: buffer.to_vec(),
-        pages,
-    })
+    AsyncTask::new(ProcessPdfTask { buffer, pages })
 }
 
 pub struct ClassifyPdfTask {
-    bytes: Vec<u8>,
+    buffer: Buffer,
 }
 
 impl Task for ClassifyPdfTask {
@@ -761,10 +768,10 @@ impl Task for ClassifyPdfTask {
     type JsValue = PdfClassification;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes = std::mem::take(&mut self.bytes);
+        let bytes: &[u8] = &self.buffer;
         catch_panic(
             "classify_pdf",
-            panic::AssertUnwindSafe(move || classify_pdf_impl(&bytes)),
+            panic::AssertUnwindSafe(move || classify_pdf_impl(bytes)),
         )
     }
 
@@ -775,16 +782,15 @@ impl Task for ClassifyPdfTask {
 
 /// Async variant of [`classifyPdf`]: same result, but the classification runs
 /// on the libuv thread pool instead of the event loop and the call returns a
-/// promise.
+/// promise. The buffer is read in place (no copy) — do not mutate it until
+/// the promise settles.
 #[napi(ts_return_type = "Promise<PdfClassification>")]
 pub fn classify_pdf_async(buffer: Buffer) -> AsyncTask<ClassifyPdfTask> {
-    AsyncTask::new(ClassifyPdfTask {
-        bytes: buffer.to_vec(),
-    })
+    AsyncTask::new(ClassifyPdfTask { buffer })
 }
 
 pub struct ExtractPagesMarkdownTask {
-    bytes: Vec<u8>,
+    buffer: Buffer,
     pages: Option<Vec<u32>>,
 }
 
@@ -793,11 +799,11 @@ impl Task for ExtractPagesMarkdownTask {
     type JsValue = PagesExtractionResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes = std::mem::take(&mut self.bytes);
+        let bytes: &[u8] = &self.buffer;
         let pages = self.pages.take();
         catch_panic(
             "extract_pages_markdown",
-            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(&bytes, pages.as_deref())),
+            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(bytes, pages.as_deref())),
         )
     }
 
@@ -808,14 +814,12 @@ impl Task for ExtractPagesMarkdownTask {
 
 /// Async variant of [`extractPagesMarkdown`]: same result, but the extraction
 /// runs on the libuv thread pool instead of the event loop and the call
-/// returns a promise.
+/// returns a promise. The buffer is read in place (no copy) — do not mutate
+/// it until the promise settles.
 #[napi(ts_return_type = "Promise<PagesExtractionResult>")]
 pub fn extract_pages_markdown_async(
     buffer: Buffer,
     pages: Option<Vec<u32>>,
 ) -> AsyncTask<ExtractPagesMarkdownTask> {
-    AsyncTask::new(ExtractPagesMarkdownTask {
-        bytes: buffer.to_vec(),
-        pages,
-    })
+    AsyncTask::new(ExtractPagesMarkdownTask { buffer, pages })
 }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -715,16 +715,18 @@ fn to_page_region_texts(results: Vec<pdf_inspector::PageRegionResult>) -> Vec<Pa
 // concurrent load keep answering requests while a document parses. The sync
 // exports keep their names, signatures, and behaviour.
 //
-// The tasks hold the napi `Buffer` itself rather than a copy: the Buffer
-// keeps a reference that pins the JS-side allocation for the task's lifetime,
-// and its backing store is stable, so `compute` can read it from the worker
-// thread without an event-loop-blocking memcpy at call time. The caller must
-// not mutate the buffer until the promise settles — the same contract as
-// Node's own async `fs` APIs.
+// Each factory copies the input Buffer to an owned `Vec<u8>` on the calling
+// (JS) thread — deliberately. JS execution is single-threaded, so no JS code
+// can mutate the buffer while the synchronous part of the call copies it.
+// Holding the napi `Buffer` and reading it from the worker instead would be
+// zero-copy, but a caller mutating the buffer before the promise settles
+// would then race the worker's reads — undefined behavior, not a recoverable
+// error (a known napi-rs soundness hazard with cross-thread Buffer access).
+// The copy is a one-time memcpy, negligible next to the parse it unblocks.
 // ---------------------------------------------------------------------------
 
 pub struct ProcessPdfTask {
-    buffer: Buffer,
+    bytes: Vec<u8>,
     pages: Option<Vec<u32>>,
 }
 
@@ -733,13 +735,13 @@ impl Task for ProcessPdfTask {
     type JsValue = PdfResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes: &[u8] = &self.buffer;
+        let bytes = std::mem::take(&mut self.bytes);
         let pages = self.pages.take();
-        // AssertUnwindSafe: the closure only reads `bytes` and owns `pages`;
-        // on unwind no shared state can be observed broken.
+        // AssertUnwindSafe: `bytes`/`pages` are moved into the closure and
+        // dropped on unwind — no shared state can be observed broken.
         catch_panic(
             "process_pdf",
-            panic::AssertUnwindSafe(move || process_pdf_impl(bytes, pages)),
+            panic::AssertUnwindSafe(move || process_pdf_impl(&bytes, pages)),
         )
     }
 
@@ -750,17 +752,20 @@ impl Task for ProcessPdfTask {
 
 /// Async variant of [`processPdf`]: same result, but the parse runs on the
 /// libuv thread pool instead of the event loop and the call returns a
-/// promise. The buffer is read in place (no copy) — do not mutate it until
-/// the promise settles.
+/// promise. The buffer is copied before the call returns, so it may be
+/// reused or mutated immediately.
 // ts_return_type is required: napi-rs emits `Promise<unknown>` for
 // `AsyncTask<T>` returns without it.
 #[napi(ts_return_type = "Promise<PdfResult>")]
 pub fn process_pdf_async(buffer: Buffer, pages: Option<Vec<u32>>) -> AsyncTask<ProcessPdfTask> {
-    AsyncTask::new(ProcessPdfTask { buffer, pages })
+    AsyncTask::new(ProcessPdfTask {
+        bytes: buffer.to_vec(),
+        pages,
+    })
 }
 
 pub struct ClassifyPdfTask {
-    buffer: Buffer,
+    bytes: Vec<u8>,
 }
 
 impl Task for ClassifyPdfTask {
@@ -768,10 +773,10 @@ impl Task for ClassifyPdfTask {
     type JsValue = PdfClassification;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes: &[u8] = &self.buffer;
+        let bytes = std::mem::take(&mut self.bytes);
         catch_panic(
             "classify_pdf",
-            panic::AssertUnwindSafe(move || classify_pdf_impl(bytes)),
+            panic::AssertUnwindSafe(move || classify_pdf_impl(&bytes)),
         )
     }
 
@@ -782,15 +787,17 @@ impl Task for ClassifyPdfTask {
 
 /// Async variant of [`classifyPdf`]: same result, but the classification runs
 /// on the libuv thread pool instead of the event loop and the call returns a
-/// promise. The buffer is read in place (no copy) — do not mutate it until
-/// the promise settles.
+/// promise. The buffer is copied before the call returns, so it may be
+/// reused or mutated immediately.
 #[napi(ts_return_type = "Promise<PdfClassification>")]
 pub fn classify_pdf_async(buffer: Buffer) -> AsyncTask<ClassifyPdfTask> {
-    AsyncTask::new(ClassifyPdfTask { buffer })
+    AsyncTask::new(ClassifyPdfTask {
+        bytes: buffer.to_vec(),
+    })
 }
 
 pub struct ExtractPagesMarkdownTask {
-    buffer: Buffer,
+    bytes: Vec<u8>,
     pages: Option<Vec<u32>>,
 }
 
@@ -799,11 +806,11 @@ impl Task for ExtractPagesMarkdownTask {
     type JsValue = PagesExtractionResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let bytes: &[u8] = &self.buffer;
+        let bytes = std::mem::take(&mut self.bytes);
         let pages = self.pages.take();
         catch_panic(
             "extract_pages_markdown",
-            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(bytes, pages.as_deref())),
+            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(&bytes, pages.as_deref())),
         )
     }
 
@@ -814,12 +821,15 @@ impl Task for ExtractPagesMarkdownTask {
 
 /// Async variant of [`extractPagesMarkdown`]: same result, but the extraction
 /// runs on the libuv thread pool instead of the event loop and the call
-/// returns a promise. The buffer is read in place (no copy) — do not mutate
-/// it until the promise settles.
+/// returns a promise. The buffer is copied before the call returns, so it
+/// may be reused or mutated immediately.
 #[napi(ts_return_type = "Promise<PagesExtractionResult>")]
 pub fn extract_pages_markdown_async(
     buffer: Buffer,
     pages: Option<Vec<u32>>,
 ) -> AsyncTask<ExtractPagesMarkdownTask> {
-    AsyncTask::new(ExtractPagesMarkdownTask { buffer, pages })
+    AsyncTask::new(ExtractPagesMarkdownTask {
+        bytes: buffer.to_vec(),
+        pages,
+    })
 }

--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -2,13 +2,16 @@ import { readFileSync } from 'fs';
 import { strict as assert } from 'assert';
 import {
   processPdf,
+  processPdfAsync,
   detectPdf,
   classifyPdf,
+  classifyPdfAsync,
   extractText,
   extractTextWithPositions,
   extractTextInRegions,
   detectVectorGridInRegion,
   extractPagesMarkdown,
+  extractPagesMarkdownAsync,
 } from './index.js';
 
 const fixture = readFileSync('../tests/fixtures/thermo-freon12.pdf');
@@ -124,10 +127,66 @@ assert.equal(picked.pages[0].page, 2);
 assert.equal(picked.pages[1].page, 0);
 console.log('  extractPagesMarkdown with pages: OK');
 
+// --- Async variants ---
+console.log('Testing async variants...');
+
+// processPdfAsync returns a promise and matches the sync result
+const asyncResultPromise = processPdfAsync(fixture);
+assert.ok(asyncResultPromise instanceof Promise);
+const asyncResult = await asyncResultPromise;
+assert.equal(asyncResult.pdfType, result.pdfType);
+assert.equal(asyncResult.pageCount, result.pageCount);
+assert.equal(asyncResult.markdown, result.markdown);
+console.log('  processPdfAsync: OK');
+
+// processPdfAsync with pages
+const asyncResult2 = await processPdfAsync(fixture, [1]);
+assert.equal(asyncResult2.markdown, result2.markdown);
+console.log('  processPdfAsync with pages: OK');
+
+// classifyPdfAsync matches the sync result
+const asyncClassified = await classifyPdfAsync(fixture);
+assert.equal(asyncClassified.pdfType, classified.pdfType);
+assert.equal(asyncClassified.pageCount, classified.pageCount);
+assert.equal(asyncClassified.confidence, classified.confidence);
+assert.deepEqual(asyncClassified.pagesNeedingOcr, classified.pagesNeedingOcr);
+console.log('  classifyPdfAsync: OK');
+
+// extractPagesMarkdownAsync matches the sync result
+const asyncAllPages = await extractPagesMarkdownAsync(fixture);
+assert.equal(asyncAllPages.pages.length, allPages.pages.length);
+assert.deepEqual(
+  asyncAllPages.pages.map(p => p.markdown),
+  allPages.pages.map(p => p.markdown),
+);
+assert.equal(asyncAllPages.isComplex, allPages.isComplex);
+console.log('  extractPagesMarkdownAsync: OK');
+
+// selected pages preserve caller order
+const asyncPicked = await extractPagesMarkdownAsync(fixture, [2, 0]);
+assert.equal(asyncPicked.pages.length, 2);
+assert.equal(asyncPicked.pages[0].page, 2);
+assert.equal(asyncPicked.pages[1].page, 0);
+console.log('  extractPagesMarkdownAsync with pages: OK');
+
+// concurrent async calls all settle
+const [c1, c2, c3] = await Promise.all([
+  processPdfAsync(fixture),
+  classifyPdfAsync(fixture),
+  extractPagesMarkdownAsync(fixture),
+]);
+assert.equal(c1.pdfType, 'TextBased');
+assert.equal(c2.pdfType, 'TextBased');
+assert.equal(c3.pages.length, 3);
+console.log('  concurrent async calls: OK');
+
 // --- Error handling ---
 console.log('Testing error handling...');
 assert.throws(() => processPdf(Buffer.from('not a pdf')), /process_pdf/);
 assert.throws(() => classifyPdf(Buffer.from('')), /classify_pdf/);
+await assert.rejects(processPdfAsync(Buffer.from('not a pdf')), /process_pdf/);
+await assert.rejects(classifyPdfAsync(Buffer.from('')), /classify_pdf/);
+await assert.rejects(extractPagesMarkdownAsync(Buffer.from('')), /extract_pages_markdown/);
 console.log('  error handling: OK');
 
 console.log('\nAll NAPI tests passed!');

--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -169,6 +169,15 @@ assert.equal(asyncPicked.pages[0].page, 2);
 assert.equal(asyncPicked.pages[1].page, 0);
 console.log('  extractPagesMarkdownAsync with pages: OK');
 
+// input buffer is copied at call time: mutating it immediately after the
+// call must not affect the in-flight parse
+const scratch = Buffer.from(fixture);
+const inFlight = processPdfAsync(scratch);
+scratch.fill(0);
+const fromMutated = await inFlight;
+assert.equal(fromMutated.markdown, result.markdown);
+console.log('  processPdfAsync input copied at call time: OK');
+
 // concurrent async calls all settle
 const [c1, c2, c3] = await Promise.all([
   processPdfAsync(fixture),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #336.

## Problem

All exported functions in the Node bindings are synchronous, so every parse runs on the thread that called it — in Node, the event loop. Per the measurements in #336, that means 16–20ms of blocked loop per `classifyPdf` call and up to ~300ms per `extractPagesMarkdown` call on large documents. In a server under concurrent load those stalls stack up in tail latency.

## Change

Takes the additive route proposed in the issue: adds `processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` alongside the existing exports. Each is a napi-rs `AsyncTask` that runs the parse on the libuv thread pool and returns a promise (`Promise<PdfResult>`, `Promise<PdfClassification>`, `Promise<PagesExtractionResult>` in the generated `index.d.ts`).

- The existing synchronous exports keep their names, signatures, and behaviour — no breaking change, no forced major version.
- Each sync/async pair shares one implementation (`process_pdf_impl`, `classify_pdf_impl`, `extract_pages_markdown_impl`), so there is no second body to keep in step — only a second entry point.
- Panics inside `compute()` are caught with the existing `catch_panic` helper and surface as promise rejections with the same `ctx: Rust panic: ...` message shape the sync exports throw, so the error contract matches.
- README documents the async variants and when to prefer them.

## Testing

- `napi/test.mjs` extended: async results asserted equal to their sync counterparts (including the `pages` argument and caller-supplied page order), concurrent `Promise.all` across all three variants, and rejection tests for invalid input. All pass locally against a debug build (`node test.mjs`).
- Generated `index.d.ts` verified to contain the `Promise<T>` signatures.
- `cargo fmt --check`, `cargo clippy -- -D warnings` (root and `napi/`), and `cargo test` (152 integration + unit + doc tests shown locally) all pass.

Not run: `pdf-evals` regression suite — no extraction logic changed; the Rust core is untouched and the sync binding paths delegate to the identical code they inlined before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019feac6-27e7-7fbc-9257-0d3868c247a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019feac6-27e7-7fbc-9257-0d3868c247a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds async Node bindings that run PDF parsing on the libuv thread pool to keep the Node event loop responsive. Async variants now copy the input `Buffer` on the JS thread before queuing for soundness, so callers can reuse or mutate it immediately; sync APIs are unchanged.

- **New Features**
  - Added `processPdfAsync`, `classifyPdfAsync`, and `extractPagesMarkdownAsync` with the same args/results; each returns a Promise.
  - Sync and async share one implementation for parity; errors/panics reject with the same message shape as sync throws.

- **Bug Fixes**
  - Async input handling: copy the `Buffer` at call time (race-free); README and tests updated, including a mutation-in-flight test.
  - Kept `ts_return_type` annotations so `index.d.ts` emits correct `Promise<T>` types.

<sup>Written for commit 92e2d6ec8ebc6cdd92d89ea3c552f8c1e72de6b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

