### PR TITLE
Ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ test_output/
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# Local env (never commit secrets)
+.env
+.env.*
+!.env.example
+!**/.env.example
+


### PR DESCRIPTION
## Summary
- Add standard `.env` / `.env.*` ignore rules (with `.env.example` exceptions) so local secret files cannot be committed accidentally.
- Small hygiene fix; no runtime behavior change.

## Test plan
- [x] `git check-ignore .env` succeeds after change
- [ ] CI green


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .gitignore rules to ignore local .env files so secrets aren’t committed by mistake. Covers `.env` and `.env.*` while keeping `.env.example` tracked; no runtime changes.

<sup>Written for commit 013626b29c089e5144e81637b8c54f608a1be2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

