### PR TITLE
fix: don't route blank pages to OCR (#319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ wasm/                   — Browser bindings (wasm-bindgen)
 3. Look for `Tj`/`TJ` (text operators) and `Do` (image operators) in content streams
 4. Classify based on text operator presence across sampled pages
 
-This detects 300+ page PDFs in milliseconds. The result includes `pages_needing_ocr` — a list of specific page numbers that lack text, enabling per-page OCR routing instead of all-or-nothing.
+This detects 300+ page PDFs in milliseconds. The result includes `pages_needing_ocr` — a list of specific page numbers that require OCR, enabling per-page OCR routing instead of all-or-nothing. Note that a page only requires OCR if it has some painted content (such as images or vector paths) but extraction failed to yield text items. Truly blank pages (no painted content and no extracted items) are not routed to OCR to avoid unnecessary OCR jobs.
 
 ### Scan strategies
 

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1787,7 +1787,7 @@ pub(crate) fn analyze_page_images(doc: &Document, page_id: ObjectId) -> (bool, u
 /// Exposed at crate visibility so `extract_pages_markdown_mem` can apply
 /// the same gates classification needs elsewhere instead of treating the
 /// raw signals alone as sufficient — see #227/#231.
-pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool) {
+pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool, bool) {
     let analysis = analyze_page_content(doc, page_id);
 
     let needs_ocr_for_template_image = if !analysis.has_template_image {
@@ -1802,7 +1802,14 @@ pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool
         looks_like_scan || insufficient_text
     };
 
-    (needs_ocr_for_template_image, analysis.has_vector_text)
+    let has_painted_content =
+        analysis.has_images || analysis.path_op_count > 0 || analysis.text_operator_count > 0;
+
+    (
+        needs_ocr_for_template_image,
+        analysis.has_vector_text,
+        has_painted_content,
+    )
 }
 
 /// Recursively collect image dimensions from XObject resources,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,10 +564,12 @@ pub fn extract_pages_markdown_mem(
         // detect_from_document's Mixed-type per-page routing always sends
         // these pages to OCR; mirror that here too. Both signals share one
         // analyze_page_content pass — see page_ocr_signals's doc comment.
-        let (has_template_image, has_vector_text) = lopdf_pages
+        let (has_template_image, has_vector_text, has_painted_content) = lopdf_pages
             .get(&page_1idx)
             .map(|&page_id| detector::page_ocr_signals(&doc, page_id))
-            .unwrap_or((false, false));
+            .unwrap_or((false, false, false));
+
+        let is_empty_page_items = page_items.is_empty();
 
         // Build markdown with document-wide font stats
         let options = MarkdownOptions {
@@ -614,12 +616,16 @@ pub fn extract_pages_markdown_mem(
         }
         let ocr_reason = page_ocr_reason(&ocr_reasons_by_page, page_1idx);
 
-        let needs_ocr = ocr_reason.is_some()
-            || md.trim().is_empty()
-            || has_gid
-            || is_garbage_text(&md)
-            || has_template_image
-            || has_vector_text;
+        let needs_ocr = if !has_painted_content && is_empty_page_items {
+            false
+        } else {
+            ocr_reason.is_some()
+                || md.trim().is_empty()
+                || has_gid
+                || is_garbage_text(&md)
+                || has_template_image
+                || has_vector_text
+        };
 
         if needs_ocr {
             pages_needing_ocr.push(page_1idx);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4052,3 +4052,228 @@ fn test_extract_pages_markdown_agrees_with_classify_on_scan_with_native_header()
         page.markdown
     );
 }
+
+#[test]
+fn blank_page_is_not_an_ocr_job() {
+    let pdf = make_text_pdf("", "0 0 612 792");
+    let result = extract_pages_markdown_mem(&pdf, None).expect("blank PDF should parse");
+
+    assert!(result.pages[0].markdown.is_empty());
+    assert!(!result.pages[0].needs_ocr);
+    assert!(result.pages_needing_ocr.is_empty());
+}
+
+fn make_image_only_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    fn add_stream_object(
+        pdf: &mut Vec<u8>,
+        offsets: &mut Vec<usize>,
+        id: usize,
+        dict: &str,
+        stream_bytes: &[u8],
+    ) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(
+            format!("<< {} /Length {} >>\nstream\n", dict, stream_bytes.len()).as_bytes(),
+        );
+        pdf.extend_from_slice(stream_bytes);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    }
+
+    add_object(&mut pdf, &mut offsets, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    add_object(&mut pdf, &mut offsets, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /XObject << /Im0 5 0 R >> >> \
+         /Contents 4 0 R >>",
+    );
+    add_stream_object(&mut pdf, &mut offsets, 4, "", b"q 100 0 0 100 100 100 cm /Im0 Do Q");
+    let image_pixel = [128u8];
+    add_stream_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        "/Type /XObject /Subtype /Image /Width 1 /Height 1 \
+         /ColorSpace /DeviceGray /BitsPerComponent 8",
+        &image_pixel,
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
+#[test]
+fn image_only_page_needs_ocr() {
+    let pdf = make_image_only_pdf();
+    let result = extract_pages_markdown_mem(&pdf, None).expect("image-only PDF should parse");
+
+    assert!(result.pages[0].markdown.is_empty());
+    assert!(result.pages[0].needs_ocr);
+    assert_eq!(result.pages_needing_ocr, vec![1]);
+}
+
+fn make_vector_only_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    fn add_stream_object(
+        pdf: &mut Vec<u8>,
+        offsets: &mut Vec<usize>,
+        id: usize,
+        dict: &str,
+        stream_bytes: &[u8],
+    ) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(
+            format!("<< {} /Length {} >>\nstream\n", dict, stream_bytes.len()).as_bytes(),
+        );
+        pdf.extend_from_slice(stream_bytes);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    }
+
+    add_object(&mut pdf, &mut offsets, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    add_object(&mut pdf, &mut offsets, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>",
+    );
+    add_stream_object(&mut pdf, &mut offsets, 4, "", b"10 10 m 20 20 l S");
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
+#[test]
+fn vector_only_page_needs_ocr() {
+    let pdf = make_vector_only_pdf();
+    let result = extract_pages_markdown_mem(&pdf, None).expect("vector-only PDF should parse");
+
+    assert!(result.pages[0].markdown.is_empty());
+    assert!(result.pages[0].needs_ocr);
+    assert_eq!(result.pages_needing_ocr, vec![1]);
+}
+
+fn make_mixed_empty_markdown_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    fn add_stream_object(
+        pdf: &mut Vec<u8>,
+        offsets: &mut Vec<usize>,
+        id: usize,
+        dict: &str,
+        stream_bytes: &[u8],
+    ) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(
+            format!("<< {} /Length {} >>\nstream\n", dict, stream_bytes.len()).as_bytes(),
+        );
+        pdf.extend_from_slice(stream_bytes);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    }
+
+    add_object(&mut pdf, &mut offsets, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    add_object(&mut pdf, &mut offsets, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /XObject << /Im0 5 0 R >> >> \
+         /Contents 4 0 R >>",
+    );
+    // Stream has both vector paths and image invocation, but no text.
+    add_stream_object(&mut pdf, &mut offsets, 4, "", b"10 10 m 20 20 l S q 100 0 0 100 100 100 cm /Im0 Do Q");
+    let image_pixel = [128u8];
+    add_stream_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        "/Type /XObject /Subtype /Image /Width 1 /Height 1 \
+         /ColorSpace /DeviceGray /BitsPerComponent 8",
+        &image_pixel,
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
+#[test]
+fn mixed_empty_markdown_needs_ocr() {
+    let pdf = make_mixed_empty_markdown_pdf();
+    let result = extract_pages_markdown_mem(&pdf, None).expect("mixed empty PDF should parse");
+
+    assert!(result.pages[0].markdown.is_empty());
+    assert!(result.pages[0].needs_ocr);
+    assert_eq!(result.pages_needing_ocr, vec![1]);
+}


### PR DESCRIPTION
Fix: Don't route blank pages to OCR (#319)

Problem
extract_pages_markdown_mem decided needs_ocr using only:

md.trim().is_empty()

This conflated two different cases:
- a page with no painted content at all (truly blank)
- a page with content (image-only or vector-only) where extraction just returned empty markdown

Both were routed to OCR, even though a truly blank page has nothing for OCR to recover. This wastes work, adds latency, and risks an OCR model inventing content from noise.

Fix
needs_ocr is now false only when both hold:
1. The page has no painted content (no image, no vector path, no text-drawing operator)
2. Extraction returned no items for the page

Pages with painted content but empty markdown (image-only, vector-only, or mixed) continue to route to OCR exactly as before — no behavior change there.

Changes
- src/detector.rs — adds/uses a has_painted_content signal from the existing page-content analysis
- src/lib.rs — updates the per-page needs_ocr decision to require both conditions instead of relying solely on empty markdown
- tests/integration_tests.rs — adds the regression test from #319 (blank_page_is_not_an_ocr_job), plus coverage confirming image-only, vector-only, and mixed-content-with-empty-markdown pages still route to OCR
- README.md — clarifies the distinction between "no painted content" (skips OCR) and "has content but extraction failed" (still routes to OCR), since this changes the documented meaning of "pages that lack text"

Testing
cargo test blank_page_is_not_an_ocr_job
cargo test

All existing tests pass; new regression test from the issue passes; OCR routing for raster/vector/mixed pages is unchanged.

Closes #319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop routing truly blank pages to OCR. We now require painted content on the page before considering OCR, reducing unnecessary work and avoiding hallucinated text.

- **Bug Fixes**
  - needs_ocr is false only when the page has no painted content and no extracted items; pages with painted content but empty markdown still go to OCR.
  - Added a has_painted_content signal to detector page analysis and used it in per-page OCR routing.
  - Added integration tests: blank page skips OCR; image-only, vector-only, and mixed-with-empty-markdown pages still route to OCR.
  - Updated README to clarify when a page requires OCR.

<sup>Written for commit 61303db83b5427353dee25a61d6460bc710b7de9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

