### PR TITLE
fix(extractor): use a separate text line matrix in Form XObjects

### DIFF
--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -251,16 +251,31 @@ fn extract_form_xobject_text_inner(
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
-    let mut ctm_stack: Vec<[f32; 6]> = Vec::new();
+    let mut ctm_stack: Vec<([f32; 6], f32, String, f32)> = Vec::new();
 
     for op in &content.operations {
         match op.operator.as_str() {
             "q" => {
-                ctm_stack.push(ctm);
+                // Save graphics state — PDF spec: q/Q bracket the full
+                // graphics state, including text state (leading, font,
+                // font size). Without restoring these, a TL/TD set inside a
+                // q/Q block leaks into subsequent T* lines (cubic review,
+                // PR #340).
+                ctm_stack.push((
+                    ctm,
+                    text_leading,
+                    current_font.clone(),
+                    current_font_size,
+                ));
             }
             "Q" => {
-                if let Some(saved) = ctm_stack.pop() {
-                    ctm = saved;
+                if let Some((saved_ctm, saved_leading, saved_font, saved_font_size)) =
+                    ctm_stack.pop()
+                {
+                    ctm = saved_ctm;
+                    text_leading = saved_leading;
+                    current_font = saved_font;
+                    current_font_size = saved_font_size;
                 }
             }
             "cm" => {

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -251,31 +251,45 @@ fn extract_form_xobject_text_inner(
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
-    let mut ctm_stack: Vec<([f32; 6], f32, String, f32)> = Vec::new();
+    /// Full text/graphics state saved on `q` and restored on `Q` (PR #340).
+    type SavedFormState = ([f32; 6], f32, String, f32, [f32; 6], [f32; 6]);
+    let mut ctm_stack: Vec<SavedFormState> = Vec::new();
 
     for op in &content.operations {
         match op.operator.as_str() {
             "q" => {
                 // Save graphics state — PDF spec: q/Q bracket the full
-                // graphics state, including text state (leading, font,
-                // font size). Without restoring these, a TL/TD set inside a
-                // q/Q block leaks into subsequent T* lines (cubic review,
-                // PR #340).
+                // graphics state, including text state. Leading, font and
+                // font size were the first gap (cubic review, PR #340); the
+                // text matrix and text line matrix are part of the same
+                // state (PDF spec erratum on text objects) — a Td/Tm/T*
+                // inside a q/Q block must not leak its shifted matrices
+                // into lines after Q.
                 ctm_stack.push((
                     ctm,
                     text_leading,
                     current_font.clone(),
                     current_font_size,
+                    text_matrix,
+                    line_matrix,
                 ));
             }
             "Q" => {
-                if let Some((saved_ctm, saved_leading, saved_font, saved_font_size)) =
-                    ctm_stack.pop()
+                if let Some((
+                    saved_ctm,
+                    saved_leading,
+                    saved_font,
+                    saved_font_size,
+                    saved_text_matrix,
+                    saved_line_matrix,
+                )) = ctm_stack.pop()
                 {
                     ctm = saved_ctm;
                     text_leading = saved_leading;
                     current_font = saved_font;
                     current_font_size = saved_font_size;
+                    text_matrix = saved_text_matrix;
+                    line_matrix = saved_line_matrix;
                 }
             }
             "cm" => {

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -246,6 +246,8 @@ fn extract_form_xobject_text_inner(
     let mut current_font = String::new();
     let mut current_font_size: f32 = 12.0;
     let mut text_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
+    let mut line_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
+    let mut text_leading: f32 = 0.0;
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
@@ -321,6 +323,7 @@ fn extract_form_xobject_text_inner(
             "BT" => {
                 in_text_block = true;
                 text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
             }
             "ET" => {
                 in_text_block = false;
@@ -333,13 +336,42 @@ fn extract_form_xobject_text_inner(
                     current_font_size = get_number(&op.operands[1]).unwrap_or(12.0);
                 }
             }
+            "TL" => {
+                // Set text leading (used by T*)
+                if let Some(lead) = op.operands.first().and_then(get_number) {
+                    text_leading = lead;
+                }
+            }
             "Td" | "TD" => {
+                // Move text position: TLM = T(tx,ty) × TLM; Tm = TLM.
+                // tx,ty are in text space — must be scaled by the text line
+                // matrix, and must NOT accumulate on the text matrix that Tj
+                // has advanced (issue #325: without a separate line matrix,
+                // every following line starts further right).
                 if op.operands.len() >= 2 {
                     let tx = get_number(&op.operands[0]).unwrap_or(0.0);
                     let ty = get_number(&op.operands[1]).unwrap_or(0.0);
-                    text_matrix[4] += tx * text_matrix[0] + ty * text_matrix[2];
-                    text_matrix[5] += tx * text_matrix[1] + ty * text_matrix[3];
+                    line_matrix[4] += tx * line_matrix[0] + ty * line_matrix[2];
+                    line_matrix[5] += tx * line_matrix[1] + ty * line_matrix[3];
+                    text_matrix = line_matrix;
                 }
+                if op.operator.as_str() == "TD" {
+                    // TD additionally sets the leading to -ty
+                    if let Some(ty) = op.operands.get(1).and_then(get_number) {
+                        text_leading = -ty;
+                    }
+                }
+            }
+            "T*" => {
+                // Move to start of next line: equivalent to 0 -TL Td
+                let tl = if text_leading != 0.0 {
+                    text_leading
+                } else {
+                    current_font_size * 1.2
+                };
+                line_matrix[4] += (-tl) * line_matrix[2]; // Usually 0 for non-rotated text
+                line_matrix[5] += (-tl) * line_matrix[3];
+                text_matrix = line_matrix;
             }
             "Tm" => {
                 if op.operands.len() >= 6 {
@@ -347,6 +379,7 @@ fn extract_form_xobject_text_inner(
                         text_matrix[i] =
                             get_number(operand).unwrap_or(if i == 0 || i == 3 { 1.0 } else { 0.0 });
                     }
+                    line_matrix = text_matrix;
                 }
             }
             "g" => {


### PR DESCRIPTION
Closes #325

## Problem
Text inside **Form XObjects** was positioned by mutating the text matrix directly on `Td`/`TD`. After `Tj` advances the matrix (width accumulation), the next `Td`/`Tm` summed on top — so every following line started further right (measured x up to 1485pt on a 595pt page). The CropBox clipping added in 0.1.7 then discarded those off-box items, losing 60-96% of the text on pages 6-11 of `arxiv.org/pdf/1412.6980`.

## Root cause
The PDF text state machine has two matrices: **TLM** (text line matrix) and **Tm** (text matrix). `Td`/`TD`/`T*` update TLM and set `Tm = TLM`; `Tm` sets both. The Form XObject extractor (`xobjects.rs`) only tracked one matrix, so relative line moves accumulated on the already-advanced text matrix. The top-level extractor (`content_stream.rs`) implements this correctly — this PR ports that machine to `xobjects.rs`.

## Changes (`src/extractor/xobjects.rs`)
- Track `line_matrix` (TLM) separately; `Td`/`TD` update it then `text_matrix = line_matrix`
- `Tm` updates `line_matrix` too
- Implement `T*` (next line, using `TL` or font-size-derived leading) and `TL`
- `TD` additionally sets leading to `-ty`
- `BT` resets both matrices

## Verification
- `arxiv.org/pdf/1412.6980`: markdown **33,145 → 46,901 chars** (0.1.6 extracted 47,809; the residual delta is the unmerged Form-XObject work in #333)
- Page 6-11 clipping log messages are gone
- `cargo test --lib`: **846 passed**; `cargo test --test integration_tests`: **152 passed** — 0 failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text positioning inside Form XObjects by keeping a separate text line matrix (TLM) and fully saving/restoring text state across `q`/`Q` (including matrices). This stops rightward drift, prevents CropBox clipping, and fixes leaked leading and matrix shifts after `Q`, restoring missing text on affected PDFs (addresses #325).

- **Bug Fixes**
  - Track `line_matrix` (TLM) alongside `text_matrix`; `Td`/`TD` update TLM then set `text_matrix = line_matrix`; `Tm` updates both.
  - Implement `T*` and `TL`; `TD` sets leading to `-ty`; `BT` resets both.
  - Save/restore full text/graphics state with `q`/`Q`: CTM, leading, font, font size, and both text matrices; prevents `T*`/`Td`/`Tm` inside `q`/`Q` from leaking leading or shifted matrices.

<sup>Written for commit c1c4d0314bed22cdd0abb577f6733e75ce795b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

