### PR TITLE
Validate the CIDSystemInfo ordering before using it as a bcmap file name

### DIFF
--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -1173,6 +1173,13 @@ fn build_gid_to_unicode(face: &ttf_parser::Face<'_>) -> Option<HashMap<u16, char
 
 /// Build a ToUnicodeCMap from pdf.js built-in binary CMaps (bcmaps).
 fn build_cmap_from_builtin_cmap(ordering: &str) -> Option<ToUnicodeCMap> {
+    // `ordering` comes from the PDF's CIDSystemInfo and is interpolated into a
+    // file name, so restrict it to a plain alphanumeric token. Real Adobe
+    // orderings (Japan1, GB1, CNS1, Korea1, ...) match this, while separators
+    // and "." components that could escape the bcmaps directory do not.
+    if ordering.is_empty() || !ordering.bytes().all(|b| b.is_ascii_alphanumeric()) {
+        return None;
+    }
     let name = format!("Adobe-{}-UCS2.bcmap", ordering);
     let data = read_builtin_cmap_file(&name)?;
     let mut cmap = parse_binary_cmap(&data).ok()?;


### PR DESCRIPTION
While reading CID fonts I noticed that build_cmap_from_builtin_cmap takes the Ordering string straight from the PDF's CIDSystemInfo and drops it into format!("Adobe-{}-UCS2.bcmap", ordering), which then gets joined onto the bcmaps directory and read from disk. Nothing checks the value first, so a font whose Ordering contains slashes or dot segments builds a lookup path that points outside external/bcmaps.

Real Adobe orderings like Japan1, GB1, CNS1 and Korea1 are all plain alphanumeric tokens, so this just returns early when the value contains anything else. Valid files are unaffected and there is no API change. Happy to add a test if you want one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the CIDSystemInfo Ordering before building the bcmap file name to prevent path traversal and invalid lookups. Real Adobe orderings still work; invalid tokens are ignored.

- **Bug Fixes**
  - Reject empty or non-alphanumeric `ordering` values when creating the bcmap path.
  - Prevents escaping `external/bcmaps` via slashes or dot segments.
  - No API changes; `Japan1`, `GB1`, `CNS1`, and `Korea1` remain supported.

<sup>Written for commit b988d005ad56c5396928a6e17877678187d84ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

