### PR TITLE
fix(python): use zero-based positioned-text page indexes

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -94,8 +94,8 @@ result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 | `classify_pdf_bytes(data)` | Lightweight classification from bytes |
 | `extract_text(path)` | Plain text extraction |
 | `extract_text_bytes(data)` | Plain text extraction from bytes |
-| `extract_text_with_positions(path, pages=None)` | Text with X/Y coords and font info |
-| `extract_text_with_positions_bytes(data, pages=None)` | Text with positions from bytes |
+| `extract_text_with_positions(path, pages=None)` | Text with X/Y coords and font info; page indexes are 0-based |
+| `extract_text_with_positions_bytes(data, pages=None)` | Text with positions from bytes; page indexes are 0-based |
 | `extract_text_in_regions(path, page_regions)` | Extract text in bounding-box regions |
 | `extract_text_in_regions_bytes(data, page_regions)` | Region extraction from bytes |
 | `extract_pages_markdown(path, pages=None)` | Per-page Markdown + layout metadata (all pages by default) |
@@ -138,7 +138,7 @@ class TextItem:                      # extract_text_with_positions
     height: float
     font: str
     font_size: float
-    page: int
+    page: int                        # 0-indexed
     is_bold: bool
     is_italic: bool
     is_underline: bool

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -46,6 +46,7 @@ class TextItem:
     font: str
     font_size: float
     page: int
+    """0-indexed page number."""
     is_bold: bool
     is_italic: bool
     is_underline: bool
@@ -60,7 +61,7 @@ class TextItem:
 class StructureElement:
     """One structure-tree element reference from a tagged PDF."""
     page: int
-    """1-indexed page number (matches TextItem.page)."""
+    """0-indexed page number (matches TextItem.page)."""
     mcid: int
     """Marked Content ID from the page's content stream (matches TextItem.mcid)."""
     role: str
@@ -139,23 +140,29 @@ def extract_text_bytes(data: bytes) -> str:
     ...
 
 def extract_text_with_positions(path: str, pages: Optional[list[int]] = None) -> list[TextItem]:
-    """Extract text with position information."""
+    """Extract text with position information.
+
+    ``pages`` and returned ``TextItem.page`` values are 0-indexed.
+    """
     ...
 
 def extract_text_with_positions_bytes(data: bytes, pages: Optional[list[int]] = None) -> list[TextItem]:
-    """Extract text with position information from bytes."""
+    """Extract text with position information from bytes.
+
+    ``pages`` and returned ``TextItem.page`` values are 0-indexed.
+    """
     ...
 
 def extract_structure_elements(path: str, pages: Optional[list[int]] = None) -> list[StructureElement]:
     """Extract structure-tree element references from a tagged PDF file.
 
-    Returns one entry per marked-content reference, resolved to its 1-indexed
+    Returns one entry per marked-content reference, resolved to its 0-indexed
     page, MCID, and structure type name ("H1".."H6", "P", "Table", ...), sorted
     by (page, mcid). Returns an empty list when the PDF is not tagged.
 
     Args:
         path: Path to the PDF file.
-        pages: Optional list of 1-indexed pages (matching ``TextItem.page``).
+        pages: Optional list of 0-indexed pages (matching ``TextItem.page``).
             When ``None`` (default), the whole document is returned.
     """
     ...

--- a/src/python.rs
+++ b/src/python.rs
@@ -259,6 +259,7 @@ pub struct PyTextItem {
     pub font: String,
     #[pyo3(get)]
     pub font_size: f32,
+    /// 0-indexed page number.
     #[pyo3(get)]
     pub page: u32,
     #[pyo3(get)]
@@ -296,7 +297,7 @@ impl PyTextItem {
 #[pyclass(name = "StructureElement")]
 #[derive(Clone)]
 pub struct PyStructureElement {
-    /// 1-indexed page number (matches TextItem.page).
+    /// 0-indexed page number (matches TextItem.page).
     #[pyo3(get)]
     pub page: u32,
     /// Marked Content ID from the page's content stream (matches
@@ -371,6 +372,20 @@ fn item_type_str(t: &ItemType) -> String {
     }
 }
 
+fn to_core_page_numbers(pages: Vec<u32>) -> PyResult<Vec<u32>> {
+    pages
+        .into_iter()
+        .map(|page| {
+            page.checked_add(1)
+                .ok_or_else(|| PyValueError::new_err("Page index is too large"))
+        })
+        .collect()
+}
+
+fn to_python_page_number(page: u32) -> u32 {
+    page.saturating_sub(1)
+}
+
 fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
     items
         .into_iter()
@@ -382,7 +397,7 @@ fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
             height: item.height,
             font: item.font,
             font_size: item.font_size,
-            page: item.page,
+            page: to_python_page_number(item.page),
             is_bold: item.is_bold,
             is_italic: item.is_italic,
             is_underline: item.is_underline,
@@ -397,7 +412,7 @@ fn convert_structure_elements(elements: Vec<crate::StructureElement>) -> Vec<PyS
     elements
         .into_iter()
         .map(|e| PyStructureElement {
-            page: e.page,
+            page: to_python_page_number(e.page),
             mcid: e.mcid,
             role: e.role,
         })
@@ -551,12 +566,14 @@ fn extract_text_bytes(data: &[u8]) -> PyResult<String> {
 }
 
 /// Extract text with position information from a file.
+///
+/// `pages` and returned `TextItem.page` values are 0-indexed.
 #[pyfunction]
 #[pyo3(signature = (path, pages=None))]
 fn extract_text_with_positions(path: &str, pages: Option<Vec<u32>>) -> PyResult<Vec<PyTextItem>> {
     let items = match pages {
         Some(p) => {
-            let page_set: HashSet<u32> = p.into_iter().collect();
+            let page_set: HashSet<u32> = to_core_page_numbers(p)?.into_iter().collect();
             crate::extract_text_with_positions_pages(path, Some(&page_set)).map_err(to_py_err)?
         }
         None => crate::extract_text_with_positions(path).map_err(to_py_err)?,
@@ -565,6 +582,8 @@ fn extract_text_with_positions(path: &str, pages: Option<Vec<u32>>) -> PyResult<
 }
 
 /// Extract text with position information from bytes.
+///
+/// `pages` and returned `TextItem.page` values are 0-indexed.
 #[pyfunction]
 #[pyo3(signature = (data, pages=None))]
 fn extract_text_with_positions_bytes(
@@ -573,7 +592,7 @@ fn extract_text_with_positions_bytes(
 ) -> PyResult<Vec<PyTextItem>> {
     let items = match pages {
         Some(p) => {
-            let page_set: HashSet<u32> = p.into_iter().collect();
+            let page_set: HashSet<u32> = to_core_page_numbers(p)?.into_iter().collect();
             crate::extractor::extract_text_with_positions_mem_pages(data, Some(&page_set))
                 .map_err(to_py_err)?
         }
@@ -660,7 +679,7 @@ fn extract_pages_markdown_bytes(
 /// Extract structure-tree element references from a tagged PDF file.
 ///
 /// Parses the document's structure tree (when present) and returns one
-/// entry per marked-content reference, resolved to its 1-indexed page,
+/// entry per marked-content reference, resolved to its 0-indexed page,
 /// MCID, and structure type name ("H1".."H6", "P", "Table", ...). Returns
 /// an empty list when the PDF is not tagged.
 ///
@@ -670,7 +689,7 @@ fn extract_pages_markdown_bytes(
 ///
 /// Args:
 ///     path: Path to the PDF file.
-///     pages: Optional list of 1-indexed pages (matching TextItem.page).
+///     pages: Optional list of 0-indexed pages (matching TextItem.page).
 ///         When None (default), the whole document is returned.
 ///
 /// Returns:
@@ -681,6 +700,7 @@ fn extract_structure_elements(
     path: &str,
     pages: Option<Vec<u32>>,
 ) -> PyResult<Vec<PyStructureElement>> {
+    let pages = pages.map(to_core_page_numbers).transpose()?;
     let elements = crate::extract_structure_elements(path, pages.as_deref()).map_err(to_py_err)?;
     Ok(convert_structure_elements(elements))
 }
@@ -694,6 +714,7 @@ fn extract_structure_elements_bytes(
     data: &[u8],
     pages: Option<Vec<u32>>,
 ) -> PyResult<Vec<PyStructureElement>> {
+    let pages = pages.map(to_core_page_numbers).transpose()?;
     let elements =
         crate::extract_structure_elements_mem(data, pages.as_deref()).map_err(to_py_err)?;
     Ok(convert_structure_elements(elements))

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -177,12 +177,19 @@ class TestExtractTextWithPositions:
         assert isinstance(item.is_italic, bool)
         assert isinstance(item.item_type, str)
 
-    def test_with_pages(self):
+    def test_first_page_uses_zero_based_index(self):
         items = pdf_inspector.extract_text_with_positions(
-            fixture_path("thermo-freon12.pdf"), pages=[1]
+            fixture_path("thermo-freon12.pdf"), pages=[0]
         )
         assert len(items) > 0
-        assert all(item.page == 1 for item in items)
+        assert all(item.page == 0 for item in items)
+
+    def test_multiple_pages_use_zero_based_indexes(self):
+        items = pdf_inspector.extract_text_with_positions(
+            fixture_path("thermo-freon12.pdf"), pages=[0, 1]
+        )
+        assert len(items) > 0
+        assert {item.page for item in items} == {0, 1}
 
     def test_repr(self):
         items = pdf_inspector.extract_text_with_positions(
@@ -199,9 +206,9 @@ class TestExtractTextWithPositions:
 
     def test_bytes_with_pages(self):
         data = fixture_bytes("thermo-freon12.pdf")
-        items = pdf_inspector.extract_text_with_positions_bytes(data, pages=[1])
+        items = pdf_inspector.extract_text_with_positions_bytes(data, pages=[0])
         assert len(items) > 0
-        assert all(item.page == 1 for item in items)
+        assert all(item.page == 0 for item in items)
 
     def test_mcid(self):
         # Untagged fixture: mcid is None or int, never anything else
@@ -247,12 +254,12 @@ class TestExtractStructureElements:
         assert len(h1_text.strip()) > 0
 
     def test_with_pages(self):
-        # pages filter is 1-indexed, matching TextItem.page
+        # pages filter is 0-indexed, matching TextItem.page
         elements = pdf_inspector.extract_structure_elements(
-            fixture_path("firecrawl_docs_tagged.pdf"), pages=[1]
+            fixture_path("firecrawl_docs_tagged.pdf"), pages=[0]
         )
         assert len(elements) > 0
-        assert all(e.page == 1 for e in elements)
+        assert all(e.page == 0 for e in elements)
 
     def test_bytes(self):
         data = fixture_bytes("firecrawl_docs_tagged.pdf")


### PR DESCRIPTION
Closes #308.

## Root cause

The Rust extraction core uses the one-based page numbers returned by `lopdf::Document::get_pages()`. The Python positioned-text bindings passed their `pages` filter through unchanged and exposed the core `TextItem.page` value unchanged, even though page-oriented Python APIs normally use zero-based indexes. As a result, `pages=[0]` selected no physical page and other filters were shifted by one.

## Changes

- translate zero-based Python page filters to the core's one-based page numbers for both file and bytes positioned-text APIs
- translate returned `TextItem.page` values back to zero-based indexes
- apply the same boundary conversion to `StructureElement.page` and its filters so `(page, mcid)` joins with `TextItem` remain valid
- reject an unrepresentable maximum page index instead of allowing integer wraparound
- document the zero-based contract in the Python API reference and type stub
- add first-page, bytes, multi-page, and structure-tree regression coverage

## Validation

- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path wasm/Cargo.toml -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --features python -- -D warnings`
- `cargo test` — 871 library tests, 2 binary tests, 155 integration tests, and 2 doc tests passed
- `python3 -m unittest discover -s scripts/tests` — 13 passed
- `cargo build --release`
- `maturin develop --features python` with Python 3.12
- focused Python regressions — 5 passed

The complete `tests/test_python.py` run passed 77 tests. Its sole failure is an existing unrelated parameterized case for `encrypted-secret123.pdf`, which calls `process_pdf` without a password and receives the expected `PDF is encrypted` error; neither that test nor the processing path is changed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes off-by-one page indexing in the Python API by switching to 0-based indexes for positioned text and structure elements. This aligns with Python conventions and makes page filters and returned `page` values correct.

- **Bug Fixes**
  - Convert Python 0-based `pages` to the core’s 1-based pages and back for `TextItem.page`.
  - Apply the same conversion for `StructureElement.page` and its `pages` filter to keep `(page, mcid)` joins valid.
  - Guard against unrepresentable page indexes (no integer wraparound).
  - Update docs and `pdf_inspector.pyi`; add regression tests for first page, bytes, multi-page, and structure tree.

- **Migration**
  - Use 0-based pages in calls, e.g., `pages=[0, 1]` instead of `[1, 2]`.
  - Returned `TextItem.page` and `StructureElement.page` are now 0-based.

<sup>Written for commit 89b6fd25fc191a890ed8e4631d97c23e0ba1261f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

