### PR TITLE
docs: document structure-element extraction and TextItem.mcid

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -80,6 +80,17 @@ for page in result.pages:
 
 # Restrict to specific 0-indexed pages (preserves caller order)
 result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
+
+# Structure-tree elements from tagged PDFs (empty list when untagged).
+# Pages are 1-indexed to match TextItem.page, so (page, mcid) joins directly
+# against extract_text_with_positions — e.g. to recover real heading levels:
+elements = pdf_inspector.extract_structure_elements("tagged.pdf")
+roles = {(e.page, e.mcid): e.role for e in elements}
+headings = [
+    item.text
+    for item in pdf_inspector.extract_text_with_positions("tagged.pdf")
+    if item.mcid is not None and roles.get((item.page, item.mcid), "").startswith("H")
+]
 ```
 
 ## API reference
@@ -100,6 +111,8 @@ result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 | `extract_text_in_regions_bytes(data, page_regions)` | Region extraction from bytes |
 | `extract_pages_markdown(path, pages=None)` | Per-page Markdown + layout metadata (all pages by default) |
 | `extract_pages_markdown_bytes(data, pages=None)` | Per-page Markdown from bytes |
+| `extract_structure_elements(path, pages=None)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
+| `extract_structure_elements_bytes(data, pages=None)` | Structure-tree elements from bytes |
 
 ## Types
 
@@ -144,6 +157,12 @@ class TextItem:                      # extract_text_with_positions
     is_underline: bool
     is_strikeout: bool
     item_type: str
+    mcid: int | None                 # marked-content ID for tagged PDFs (None otherwise)
+
+class StructureElement:              # extract_structure_elements
+    page: int                        # 1-indexed (matches TextItem.page)
+    mcid: int
+    role: str                        # "H1".."H6", "P", "Table", ... (resolved via /RoleMap)
 
 class RegionText:                    # extract_text_in_regions
     text: str

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -138,6 +138,34 @@ for page in &result.pages {
 println!("Complex layout? {}", result.is_complex);
 ```
 
+Extract structure-tree elements from tagged PDFs, and join them against
+`extract_text_with_positions` to attach semantic roles (heading levels,
+paragraphs, table cells) to extracted text:
+
+```rust
+use pdf_inspector::{extract_structure_elements, extract_text_with_positions};
+use std::collections::HashMap;
+
+// One entry per marked-content reference, sorted by (page, mcid); empty for
+// untagged PDFs. Pages are 1-indexed to match `TextItem::page`, so the
+// (page, mcid) pair is a direct join key.
+let elements = extract_structure_elements("tagged.pdf", None)?;
+let roles: HashMap<(u32, i64), &str> = elements
+    .iter()
+    .map(|e| ((e.page, e.mcid), e.role.as_str()))
+    .collect();
+
+for item in extract_text_with_positions("tagged.pdf")? {
+    if let Some(mcid) = item.mcid {
+        if let Some(role) = roles.get(&(item.page, mcid)) {
+            if role.starts_with('H') {
+                println!("{}: {}", role, item.text);
+            }
+        }
+    }
+}
+```
+
 ## Processing modes
 
 | Mode | What it does | Returns |
@@ -163,6 +191,8 @@ println!("Complex layout? {}", result.is_complex);
 | `to_markdown_from_items_with_rects(items, options, rects)` | Markdown with rectangle-based table detection |
 | `extract_pages_markdown(path, pages)` | Per-page Markdown + layout metadata (file) |
 | `extract_pages_markdown_mem(bytes, pages)` | Per-page Markdown from bytes |
+| `extract_structure_elements(path, pages)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
+| `extract_structure_elements_mem(bytes, pages)` | Structure-tree elements from bytes |
 
 Low-level detection functions are also available via the `detector` module (`detect_pdf_type`, `detect_pdf_type_with_config`, etc.) for callers who need `PdfTypeResult` instead of `PdfProcessResult`.
 
@@ -178,7 +208,8 @@ Low-level detection functions are also available via the `detector` module (`det
 | `DetectionConfig` | Configuration for detection: scan strategy, thresholds |
 | `ScanStrategy` | `EarlyExit`, `Full`, `Sample(n)`, `Pages(vec)` |
 | `LayoutComplexity` | Layout analysis: is_complex, pages_with_tables, pages_with_columns |
-| `TextItem` | Text with position, font info, and page number |
+| `TextItem` | Text with position, font info, page number, and optional structure-tree `mcid` |
+| `StructureElement` | Tagged-PDF structure reference: page (1-indexed), mcid, role (`"H1"`..`"H6"`, `"P"`, …) |
 | `MarkdownOptions` | Configuration for Markdown formatting (page numbers, etc.) |
 | `PageMarkdown` | Per-page result: page (0-indexed), markdown, needs_ocr |
 | `PagesExtractionResult` | Per-page output + 1-indexed pages_with_tables / pages_with_columns / pages_needing_ocr, is_complex |


### PR DESCRIPTION
Documentation follow-up to #346, which shipped in 1.14.0 without prose docs.

- **docs/rust-api.md**: worked example joining `extract_structure_elements` against `extract_text_with_positions` to recover heading roles from tagged PDFs; `extract_structure_elements(_mem)` rows in the Functions table; `StructureElement` in the Types table and `mcid` noted on `TextItem`.
- **docs/python.md**: same join example in the usage block; API-reference rows for `extract_structure_elements(_bytes)`; `mcid: int | None` added to the `TextItem` stub listing and a `StructureElement` stub entry.

Docs-only — no code changes. Semantics documented match the shipped API: one entry per marked-content reference, sorted by `(page, mcid)`, 1-indexed pages matching `TextItem.page`, empty list for untagged PDFs, roles resolved via `/RoleMap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for structure-tree extraction (`extract_structure_elements`) and `TextItem.mcid` in Rust and Python, with a join example to recover roles from tagged PDFs. Updates API/type tables and notes pages are 1-indexed, results are sorted by `(page, mcid)`, and untagged PDFs return an empty list.

<sup>Written for commit 0b0ca64ffb089bc6623119f6e1fd50dbd89bdd1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

