### PR TITLE
fix(cli): reject malformed page numbers

### DIFF
--- a/napi/bin/pdf-inspector.mjs
+++ b/napi/bin/pdf-inspector.mjs
@@ -55,8 +55,11 @@ function parseArgs(argv) {
       i++;
       if (!argv[i]) die("--pages requires a value (e.g. 1,3,5)");
       opts.pages = argv[i].split(",").map((p) => {
-        const n = parseInt(p.trim(), 10);
-        if (Number.isNaN(n) || n < 1) die(`invalid page number: ${p}`);
+        const value = p.trim();
+        const n = Number(value);
+        if (!/^\d+$/.test(value) || !Number.isSafeInteger(n) || n < 1) {
+          die(`invalid page number: ${p}`);
+        }
         return n;
       });
     } else if (arg === "-o" || arg === "--output") {

--- a/napi/bin/pdf-inspector.test.mjs
+++ b/napi/bin/pdf-inspector.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const cli = fileURLToPath(new URL("./pdf-inspector.mjs", import.meta.url));
+
+test("rejects malformed page numbers", () => {
+  const result = spawnSync(process.execPath, [cli, "missing.pdf", "--pages", "1foo"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /invalid page number: 1foo/);
+});

--- a/napi/package.json
+++ b/napi/package.json
@@ -46,7 +46,8 @@
   },
   "scripts": {
     "build": "napi build --platform --release",
-    "build:debug": "napi build --platform"
+    "build:debug": "napi build --platform",
+    "test": "node --test bin/*.test.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.4.1"

--- a/napi/package.json
+++ b/napi/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test bin/*.test.mjs"
+    "test": "node --test bin/pdf-inspector.test.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.4.1"


### PR DESCRIPTION
## Summary

Reject malformed `--pages` values instead of partially parsing them. Values such as `1foo`, decimals, and unsafe integers now fail with the existing invalid-page error.

## Root cause

`parseInt` accepted a valid numeric prefix and ignored the remaining characters.

## Validation

- `npm test`
- `node --check napi/bin/pdf-inspector.mjs`
- `node --check napi/bin/pdf-inspector.test.mjs`
- `git diff --check`

Rust checks were not run locally because `cargo` is unavailable in this environment.

Fixes #362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CLI now rejects malformed `--pages` values instead of partially parsing them. Inputs like `1foo`, decimals, and unsafe integers now fail with the existing invalid-page error.

- **Bug Fixes**
  - Strictly validate `--pages`: digits only, safe integers, and >= 1; no `parseInt` partial parsing.
  - Added a Node test that runs without a shell to avoid glob expansion, plus an `npm test` script.

<sup>Written for commit f3c060ac523ff163b55c006c8538a2582fd6e756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

