### PR TITLE
fix(tounicode): decode UniGB fonts without ToUnicode

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1028,6 +1028,12 @@ fn identity_h_font_has_fallback(font_dict: &lopdf::Dictionary, doc: &Document) -
         }
     }
 
+    // Fallback 3: CIDSystemInfo / fixed-width Uni*-UCS2-* encodings map
+    // through bundled Adobe predefined CMaps (or safe UCS-2 passthrough).
+    if crate::tounicode::predefined_cmap_for_font(font_dict, doc).is_some() {
+        return true;
+    }
+
     false
 }
 

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1030,7 +1030,7 @@ fn identity_h_font_has_fallback(font_dict: &lopdf::Dictionary, doc: &Document) -
 
     // Fallback 3: CIDSystemInfo / fixed-width Uni*-UCS2-* encodings map
     // through bundled Adobe predefined CMaps (or safe UCS-2 passthrough).
-    if crate::tounicode::predefined_cmap_for_font(font_dict, doc).is_some() {
+    if crate::tounicode::predefined_cmap_is_available(font_dict, doc) {
         return true;
     }
 

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -6,7 +6,7 @@
 use crate::text_utils::{
     decode_text_string, effective_font_size, expand_ligatures, is_bold_font, is_italic_font,
 };
-use crate::tounicode::FontCMaps;
+use crate::tounicode::{build_resource_scoped_cmap_entry, FontCMaps};
 use crate::types::{ItemType, PageExtraction, PdfLine, PdfRect, TextItem};
 use crate::PdfError;
 use log::trace;
@@ -222,7 +222,9 @@ pub(crate) fn extract_page_text_items(
                 }
             }
             Err(_) => {
-                if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
+                if let Some(entry) = build_resource_scoped_cmap_entry(font_dict, doc) {
+                    inline_cmaps.insert(resource_name, entry);
+                } else if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
                     font_tounicode_refs.insert(resource_name, ff2_obj_num);
                 }
             }

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -903,20 +903,24 @@ fn is_ligature_char(ch: char) -> bool {
     )
 }
 
-/// Get the CMap lookup key for an Identity-H/V CID font without ToUnicode.
+/// Get the CMap lookup key for a Type0 CID font without ToUnicode.
 /// Returns the object number used by `collect_cmaps_from_fonts` to store the CMap:
 /// - FontFile2 or FontFile3 obj_num (for embedded font cmap)
-/// - CIDFont dict obj_num (for predefined CIDSystemInfo-based mapping)
+/// - CIDFont dict obj_num (for predefined CIDSystemInfo / named-encoding maps)
 pub(crate) fn get_font_file2_obj_num(doc: &Document, font_dict: &lopdf::Dictionary) -> Option<u32> {
     let subtype = font_dict
         .get(b"Subtype")
         .ok()
         .and_then(|o| o.as_name().ok());
 
-    // Type0 (CID) fonts
+    // Type0 (CID) fonts without ToUnicode: Identity-H/V and fixed-width
+    // Uni*-UCS2-* encodings register fallback CMaps under the FontFile or
+    // CIDFont object id. Mixed-width/four-byte encodings are not supported by
+    // the current decoder and must not be routed through this lookup.
     if subtype == Some(b"Type0") {
         let encoding = font_dict.get(b"Encoding").ok()?.as_name().ok()?;
-        if encoding != b"Identity-H" && encoding != b"Identity-V" {
+        let is_identity = encoding == b"Identity-H" || encoding == b"Identity-V";
+        if !is_identity && !crate::tounicode::is_fixed_two_byte_unicode_encoding(encoding) {
             return None;
         }
         let desc_fonts_obj = font_dict.get(b"DescendantFonts").ok()?;

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -905,22 +905,24 @@ fn is_ligature_char(ch: char) -> bool {
 
 /// Get the CMap lookup key for a Type0 CID font without ToUnicode.
 /// Returns the object number used by `collect_cmaps_from_fonts` to store the CMap:
-/// - FontFile2 or FontFile3 obj_num (for embedded font cmap)
-/// - CIDFont dict obj_num (for predefined CIDSystemInfo / named-encoding maps)
+/// - CIDFont dict obj_num for Type0 fonts
+/// - FontFile2 or FontFile3 obj_num for simple fonts
+///
+/// Named Uni*-UCS2-* mappings are deliberately excluded: their encoding is a
+/// property of the parent Type0 font, so a shared FontFile is not a unique key.
 pub(crate) fn get_font_file2_obj_num(doc: &Document, font_dict: &lopdf::Dictionary) -> Option<u32> {
     let subtype = font_dict
         .get(b"Subtype")
         .ok()
         .and_then(|o| o.as_name().ok());
 
-    // Type0 (CID) fonts without ToUnicode: Identity-H/V and fixed-width
-    // Uni*-UCS2-* encodings register fallback CMaps under the FontFile or
-    // CIDFont object id. Mixed-width/four-byte encodings are not supported by
-    // the current decoder and must not be routed through this lookup.
+    // Identity-H/V mappings are keyed by the CIDFont, not the embedded font
+    // program: CIDSystemInfo and CIDToGIDMap can differ even when FontFile is
+    // shared. Named encodings use resource-scoped CMaps instead.
     if subtype == Some(b"Type0") {
         let encoding = font_dict.get(b"Encoding").ok()?.as_name().ok()?;
         let is_identity = encoding == b"Identity-H" || encoding == b"Identity-V";
-        if !is_identity && !crate::tounicode::is_fixed_two_byte_unicode_encoding(encoding) {
+        if !is_identity {
             return None;
         }
         let desc_fonts_obj = font_dict.get(b"DescendantFonts").ok()?;
@@ -928,26 +930,8 @@ pub(crate) fn get_font_file2_obj_num(doc: &Document, font_dict: &lopdf::Dictiona
         if desc_fonts.is_empty() {
             return None;
         }
-        let cid_font_dict = resolve_dict(doc, &desc_fonts[0])?;
-        let font_descriptor_obj = cid_font_dict.get(b"FontDescriptor").ok()?;
-        let font_descriptor = resolve_dict(doc, font_descriptor_obj)?;
-
-        // Try FontFile2 (TrueType), then FontFile3 (OpenType/CFF)
-        if let Some(ff_ref) = font_descriptor
-            .get(b"FontFile2")
-            .ok()
-            .and_then(|o| o.as_reference().ok())
-            .or_else(|| {
-                font_descriptor
-                    .get(b"FontFile3")
-                    .ok()
-                    .and_then(|o| o.as_reference().ok())
-            })
-        {
-            return Some(ff_ref.0);
-        }
-
-        // Fallback: use DescendantFonts[0] obj_num (for predefined CIDSystemInfo mapping)
+        // Direct descendant dictionaries have no collision-free document key;
+        // the extraction path installs those under the concrete resource name.
         if let Object::Reference(r) = &desc_fonts[0] {
             return Some(r.0);
         }

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -2,7 +2,7 @@
 
 use super::fonts::descriptor_style_flags;
 use crate::text_utils::{effective_font_size, expand_ligatures, is_bold_font, is_italic_font};
-use crate::tounicode::FontCMaps;
+use crate::tounicode::{build_resource_scoped_cmap_entry, FontCMaps};
 use crate::types::{ItemType, TextItem};
 use lopdf::{Document, Encoding, Object, ObjectId};
 use std::collections::HashMap;
@@ -283,7 +283,9 @@ fn extract_form_xobject_text_inner(
                 }
             }
             Err(_) => {
-                if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
+                if let Some(entry) = build_resource_scoped_cmap_entry(font_dict, doc) {
+                    inline_cmaps.insert(resource_name, entry);
+                } else if let Some(ff2_obj_num) = get_font_file2_obj_num(doc, font_dict) {
                     font_tounicode_refs.insert(resource_name, ff2_obj_num);
                 }
             }

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -1248,6 +1248,9 @@ fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
     let mut cmap = ToUnicodeCMap::new();
     let mut use_cmap: Option<String> = None;
 
+    // bfchar/bfrange source codes are always 2 raw bytes (ucs2DataSize=1 in pdf.js).
+    let ucs2_data_size = 1;
+
     while let Some(b) = stream.read_byte() {
         let typ = b >> 5;
         if typ == 7 {
@@ -1270,61 +1273,123 @@ fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
         }
         let subitems = stream.read_number()? as usize;
         match typ {
+            0 | 1 => {
+                // codespacerange (0) / notdefrange (1).
+                // First start is raw bytes; every end/start after that is a
+                // varint delta added to the previous value. Type 1 reads an
+                // extra code that we discard.
+                let mut start = stream.read_hex_bytes(data_size + 1)?;
+                let mut end = start.clone();
+                let end_delta = stream.read_hex_number(data_size)?;
+                add_hex(&mut end, &end_delta);
+                if typ == 1 {
+                    let _ = stream.read_number()?;
+                }
+                for _ in 1..subitems {
+                    inc_hex(&mut end);
+                    let start_delta = stream.read_hex_number(data_size)?;
+                    start = end.clone();
+                    add_hex(&mut start, &start_delta);
+                    let end_delta = stream.read_hex_number(data_size)?;
+                    end = start.clone();
+                    add_hex(&mut end, &end_delta);
+                    if typ == 1 {
+                        let _ = stream.read_number()?;
+                    }
+                }
+            }
+            2 | 3 => {
+                // cidchar (2) / cidrange (3): CID→CID maps, irrelevant to
+                // ToUnicode. Consume the payload faithfully so the stream
+                // stays aligned.
+                let mut first = stream.read_hex_bytes(data_size + 1)?;
+                if typ == 2 {
+                    let mut _code = stream.read_number()?;
+                    for _ in 1..subitems {
+                        inc_hex(&mut first);
+                        if !sequence {
+                            let tmp = stream.read_hex_number(data_size)?;
+                            add_hex(&mut first, &tmp);
+                        }
+                        _code = stream
+                            .read_signed()?
+                            .checked_add(i64::from(_code) + 1)
+                            .ok_or("overflow in cidchar code")?
+                            as u32;
+                    }
+                } else {
+                    let mut end = first.clone();
+                    let end_delta = stream.read_hex_number(data_size)?;
+                    add_hex(&mut end, &end_delta);
+                    let _ = stream.read_number()?;
+                    for _ in 1..subitems {
+                        inc_hex(&mut end);
+                        if !sequence {
+                            let start_delta = stream.read_hex_number(data_size)?;
+                            first = end.clone();
+                            add_hex(&mut first, &start_delta);
+                        } else {
+                            first = end.clone();
+                        }
+                        let end_delta = stream.read_hex_number(data_size)?;
+                        end = first.clone();
+                        add_hex(&mut end, &end_delta);
+                        let _ = stream.read_number()?;
+                    }
+                }
+            }
             4 => {
-                // bfchar
-                for i in 0..subitems {
-                    let src = stream.read_hex_number(1)?;
-                    let dst = stream.read_hex_bytes(data_size + 1)?;
+                // bfchar: src is 2 raw bytes; dst is data_size+1 raw bytes
+                // (first), then prev dst + 1 + signed delta for subsequent
+                // subitems.
+                let mut src = stream.read_hex_bytes(ucs2_data_size + 1)?;
+                let mut dst = stream.read_hex_bytes(data_size + 1)?;
+                let src_code = hex_to_u32(&src) as u16;
+                if let Some(s) = bytes_to_unicode_string(&dst) {
+                    cmap.char_map.insert(src_code, s);
+                }
+                for _ in 1..subitems {
+                    inc_hex(&mut src);
+                    if !sequence {
+                        let tmp = stream.read_hex_number(ucs2_data_size)?;
+                        add_hex(&mut src, &tmp);
+                    }
+                    inc_hex(&mut dst);
+                    let tmp = stream.read_hex_signed(data_size)?;
+                    add_hex(&mut dst, &tmp);
                     let src_code = hex_to_u32(&src) as u16;
                     if let Some(s) = bytes_to_unicode_string(&dst) {
                         cmap.char_map.insert(src_code, s);
                     }
-                    if i + 1 < subitems && sequence {
-                        // sequence handled by encoded data, nothing to do
-                    }
                 }
             }
             5 => {
-                // bfrange
-                for _ in 0..subitems {
-                    let start = stream.read_hex_number(1)?;
-                    let end_delta = stream.read_hex_number(1)?;
-                    let mut end = start.clone();
+                // bfrange: start is 2 raw bytes; end = start + varint delta;
+                // dst is data_size+1 raw bytes read fresh for every subitem.
+                let mut start = stream.read_hex_bytes(ucs2_data_size + 1)?;
+                let mut end = start.clone();
+                let end_delta = stream.read_hex_number(ucs2_data_size)?;
+                add_hex(&mut end, &end_delta);
+                let dst = stream.read_hex_bytes(data_size + 1)?;
+                insert_bfrange(&mut cmap, &start, &end, &dst);
+                for _ in 1..subitems {
+                    inc_hex(&mut end);
+                    if !sequence {
+                        let start_delta = stream.read_hex_number(ucs2_data_size)?;
+                        start = end.clone();
+                        add_hex(&mut start, &start_delta);
+                    } else {
+                        start = end.clone();
+                    }
+                    let end_delta = stream.read_hex_number(ucs2_data_size)?;
+                    end = start.clone();
                     add_hex(&mut end, &end_delta);
                     let dst = stream.read_hex_bytes(data_size + 1)?;
-                    let start_code = hex_to_u32(&start) as u16;
-                    let end_code = hex_to_u32(&end) as u16;
-                    if let Some(s) = bytes_to_unicode_string(&dst) {
-                        if s.chars().count() == 1 {
-                            let base = s.chars().next().unwrap() as u32;
-                            cmap.ranges.push((start_code, end_code, base));
-                        } else {
-                            // Expand multi-char sequences
-                            let mut cid = start_code;
-                            for ch in s.chars() {
-                                cmap.char_map.insert(cid, ch.to_string());
-                                if cid == end_code {
-                                    break;
-                                }
-                                cid = cid.saturating_add(1);
-                            }
-                        }
-                    }
+                    insert_bfrange(&mut cmap, &start, &end, &dst);
                 }
             }
             _ => {
-                // Skip unsupported types by consuming their payload.
-                // We only implement bfchar/bfrange for UCS2 maps.
-                for _ in 0..subitems {
-                    // Best-effort skip: read a few fields based on type.
-                    if typ <= 3 {
-                        let _ = stream.read_hex_number(data_size)?;
-                        let _ = stream.read_hex_number(data_size)?;
-                        if typ >= 1 {
-                            let _ = stream.read_number()?;
-                        }
-                    }
-                }
+                return Err(format!("unsupported bcmap type {typ}"));
             }
         }
     }
@@ -1338,6 +1403,29 @@ fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
         }
     }
     Ok(cmap)
+}
+
+/// Insert a single bfrange entry into the CMap. Single-char destinations go
+/// into `ranges`; multi-char sequences are expanded across the CID span.
+fn insert_bfrange(cmap: &mut ToUnicodeCMap, start: &[u8], end: &[u8], dst: &[u8]) {
+    let start_code = hex_to_u32(start) as u16;
+    let end_code = hex_to_u32(end) as u16;
+    let Some(s) = bytes_to_unicode_string(dst) else {
+        return;
+    };
+    if s.chars().count() == 1 {
+        let base = s.chars().next().unwrap() as u32;
+        cmap.ranges.push((start_code, end_code, base));
+    } else {
+        let mut cid = start_code;
+        for ch in s.chars() {
+            cmap.char_map.insert(cid, ch.to_string());
+            if cid == end_code {
+                break;
+            }
+            cid = cid.saturating_add(1);
+        }
+    }
 }
 
 struct BinaryCMapStream<'a> {
@@ -1410,6 +1498,29 @@ impl<'a> BinaryCMapStream<'a> {
         Ok(out)
     }
 
+    /// Signed varint: pdf.js zigzag encoding `n & 1 ? ~(n >>> 1) : n >>> 1`.
+    fn read_signed(&mut self) -> Result<i64, String> {
+        let n = self.read_number()?;
+        Ok(if n & 1 != 0 {
+            !(n >> 1) as i64
+        } else {
+            (n >> 1) as i64
+        })
+    }
+
+    /// Signed big-endian field of `size + 1` bytes. Matches pdf.js `readHexSigned`.
+    fn read_hex_signed(&mut self, size: usize) -> Result<Vec<u8>, String> {
+        let num = self.read_hex_number(size)?;
+        let sign = if num[size] & 1 != 0 { 255 } else { 0 };
+        let mut out = vec![0u8; size + 1];
+        let mut c = 0u16;
+        for i in 0..=size {
+            c = ((c & 1) << 8) | u16::from(num[i]);
+            out[i] = ((c >> 1) as u8) ^ sign;
+        }
+        Ok(out)
+    }
+
     fn read_string(&mut self) -> Result<String, String> {
         let len = self.read_number()? as usize;
         let mut buf = Vec::with_capacity(len);
@@ -1435,6 +1546,16 @@ fn add_hex(a: &mut [u8], b: &[u8]) {
         c += a[i] as u16 + b[i] as u16;
         a[i] = (c & 0xff) as u8;
         c >>= 8;
+    }
+}
+
+/// Increment a big-endian byte array by one.
+fn inc_hex(a: &mut [u8]) {
+    for i in (0..a.len()).rev() {
+        a[i] = a[i].wrapping_add(1);
+        if a[i] != 0 {
+            break;
+        }
     }
 }
 
@@ -1465,6 +1586,19 @@ struct EncodingCMap {
     map: HashMap<u16, u16>,
     code_byte_length: u8,
     is_identity: bool,
+}
+
+/// True when a named predefined encoding uses fixed-width, two-byte UCS-2
+/// character codes that already represent Unicode (e.g. UniGB-UCS2-H).
+///
+/// The current decoder can only consume a single global code width. Keep
+/// mixed-width encodings such as GBK-EUC-H and four-byte UTF-16 encodings out
+/// of this fallback until it becomes codespace-aware.
+pub(crate) fn is_fixed_two_byte_unicode_encoding(encoding: &[u8]) -> bool {
+    let name = std::str::from_utf8(encoding).unwrap_or("");
+    name.starts_with("Uni")
+        && name.contains("-UCS2-")
+        && (name.ends_with("-H") || name.ends_with("-V"))
 }
 
 fn build_fallback_tounicode_from_encoding(
@@ -1791,7 +1925,7 @@ fn parse_binary_cmap_encoding(data: &[u8]) -> Result<EncodingCMap, String> {
             }
             continue;
         }
-        let _sequence = (b & 0x10) != 0;
+        let sequence = (b & 0x10) != 0;
         let data_size = (b & 0x0f) as usize;
         if data_size + 1 > 16 {
             return Err("invalid dataSize in bcmap".to_string());
@@ -1799,51 +1933,89 @@ fn parse_binary_cmap_encoding(data: &[u8]) -> Result<EncodingCMap, String> {
         max_code_size = max_code_size.max((data_size + 1) as u8);
         let subitems = stream.read_number()? as usize;
         match typ {
+            0 | 1 => {
+                // codespacerange / notdefrange — consume payload
+                let mut start = stream.read_hex_bytes(data_size + 1)?;
+                let mut end = start.clone();
+                let end_delta = stream.read_hex_number(data_size)?;
+                add_hex(&mut end, &end_delta);
+                if typ == 1 {
+                    let _ = stream.read_number()?;
+                }
+                for _ in 1..subitems {
+                    inc_hex(&mut end);
+                    let start_delta = stream.read_hex_number(data_size)?;
+                    start = end.clone();
+                    add_hex(&mut start, &start_delta);
+                    let end_delta = stream.read_hex_number(data_size)?;
+                    end = start.clone();
+                    add_hex(&mut end, &end_delta);
+                    if typ == 1 {
+                        let _ = stream.read_number()?;
+                    }
+                }
+            }
             2 => {
-                // cidchar
-                let mut prev_code: u32 = 0;
-                for i in 0..subitems {
-                    let code_bytes = stream.read_hex_number(data_size)?;
-                    let code = hex_to_u32(&code_bytes);
-                    let cid = stream.read_number()? as u16;
-                    if i == 0 {
-                        prev_code = code;
-                        map.insert(code as u16, cid);
-                        continue;
+                // cidchar: first char raw, first code varint; subsequent use
+                // sequence/delta + signed code delta (pdf.js BinaryCMapReader).
+                let mut char_bytes = stream.read_hex_bytes(data_size + 1)?;
+                let mut code = stream.read_number()?;
+                map.insert(hex_to_u32(&char_bytes) as u16, code as u16);
+                for _ in 1..subitems {
+                    inc_hex(&mut char_bytes);
+                    if !sequence {
+                        let tmp = stream.read_hex_number(data_size)?;
+                        add_hex(&mut char_bytes, &tmp);
                     }
-                    if _sequence {
-                        prev_code = prev_code.saturating_add(1);
-                        map.insert(prev_code as u16, cid);
-                    } else {
-                        map.insert(code as u16, cid);
-                        prev_code = code;
-                    }
+                    code = stream
+                        .read_signed()?
+                        .checked_add(i64::from(code) + 1)
+                        .ok_or("overflow in cidchar code")? as u32;
+                    map.insert(hex_to_u32(&char_bytes) as u16, code as u16);
                 }
             }
             3 => {
                 // cidrange
-                for _ in 0..subitems {
-                    let start = stream.read_hex_number(data_size)?;
+                let mut start = stream.read_hex_bytes(data_size + 1)?;
+                let mut end = start.clone();
+                let end_delta = stream.read_hex_number(data_size)?;
+                add_hex(&mut end, &end_delta);
+                let mut cid = stream.read_number()? as u16;
+                let start_code = hex_to_u32(&start) as u16;
+                let end_code = hex_to_u32(&end) as u16;
+                for code in start_code..=end_code {
+                    map.insert(code, cid);
+                    cid = cid.saturating_add(1);
+                }
+                for _ in 1..subitems {
+                    inc_hex(&mut end);
+                    if !sequence {
+                        let start_delta = stream.read_hex_number(data_size)?;
+                        start = end.clone();
+                        add_hex(&mut start, &start_delta);
+                    } else {
+                        start = end.clone();
+                    }
                     let end_delta = stream.read_hex_number(data_size)?;
-                    let mut end = start.clone();
+                    end = start.clone();
                     add_hex(&mut end, &end_delta);
-                    let cid_start = stream.read_number()? as u16;
+                    let mut cid = stream.read_number()? as u16;
                     let start_code = hex_to_u32(&start) as u16;
                     let end_code = hex_to_u32(&end) as u16;
-                    let mut cid = cid_start;
                     for code in start_code..=end_code {
                         map.insert(code, cid);
                         cid = cid.saturating_add(1);
                     }
                 }
             }
+            4 | 5 => {
+                // bfchar/bfrange shouldn't appear in encoding CMaps; skip via UCS2 rules.
+                return Err(format!(
+                    "unexpected ToUnicode-only type {typ} in encoding bcmap"
+                ));
+            }
             _ => {
-                // Skip other types
-                for _ in 0..subitems {
-                    let _ = stream.read_hex_number(data_size)?;
-                    let _ = stream.read_hex_number(data_size)?;
-                    let _ = stream.read_number()?;
-                }
+                return Err(format!("unsupported encoding bcmap type {typ}"));
             }
         }
     }
@@ -1858,6 +2030,7 @@ fn parse_binary_cmap_encoding(data: &[u8]) -> Result<EncodingCMap, String> {
                 is_identity: false,
             });
         }
+        warn!("encoding bcmap usecmap={} could not be loaded", name);
     }
 
     Ok(EncodingCMap {
@@ -2017,6 +2190,53 @@ fn build_cmap_from_cid_system_info(
     }
 }
 
+/// Look up the predefined (builtin) ToUnicode map for a Type0/CID font's
+/// CIDSystemInfo when the font has no ToUnicode of its own.
+///
+/// For Identity-H/V this is the Adobe-*-UCS2 map from CIDSystemInfo.
+/// For named encodings (e.g. UniGB-UCS2-H) this composes the encoding CMap
+/// with Adobe-*-UCS2, matching the extraction fallback path.
+pub(crate) fn predefined_cmap_for_font(
+    font_dict: &lopdf::Dictionary,
+    doc: &Document,
+) -> Option<ToUnicodeCMap> {
+    if font_dict.get(b"ToUnicode").is_ok() {
+        return None;
+    }
+    let encoding = font_dict
+        .get(b"Encoding")
+        .ok()
+        .and_then(|o| o.as_name().ok())?;
+    if encoding == b"Identity-H" || encoding == b"Identity-V" {
+        let desc_fonts = font_dict.get(b"DescendantFonts").ok()?;
+        let desc_fonts = match desc_fonts {
+            Object::Array(arr) => arr.clone(),
+            Object::Reference(r) => match doc.get_object(*r) {
+                Ok(Object::Array(arr)) => arr.clone(),
+                _ => return None,
+            },
+            _ => return None,
+        };
+        let cid_font_dict = match desc_fonts.first() {
+            Some(Object::Reference(r)) => doc.get_dictionary(*r).ok()?,
+            Some(Object::Dictionary(d)) => d,
+            _ => return None,
+        };
+        return build_cmap_from_cid_system_info(cid_font_dict, doc);
+    }
+    if !is_fixed_two_byte_unicode_encoding(encoding) {
+        return None;
+    }
+    // Fixed-width Uni*-UCS2-* encoding → compose with Adobe-*-UCS2, with
+    // direct UCS-2 passthrough as a safe fallback when bcmaps are unavailable.
+    build_fallback_tounicode_from_encoding(font_dict, doc).or_else(|| {
+        let mut cmap = ToUnicodeCMap::new();
+        cmap.code_byte_length = 2;
+        cmap.cid_passthrough = true;
+        Some(cmap)
+    })
+}
+
 /// Collection of ToUnicode CMaps indexed by ToUnicode stream object number
 #[derive(Debug, Default, Clone)]
 pub struct FontCMaps {
@@ -2087,8 +2307,9 @@ impl FontCMaps {
     }
 
     /// Parse ToUnicode CMaps from a set of font dictionaries.
-    /// Also handles Identity-H/V CID fonts without ToUnicode by parsing
-    /// the embedded TrueType cmap from FontFile2.
+    /// Also handles Type0 CID fonts without ToUnicode: Identity-H/V (TrueType
+    /// cmap / CIDSystemInfo / passthrough) and fixed-width named encodings such
+    /// as UniGB-UCS2-H (builtin encoding CMap + Adobe-*-UCS2, or UCS-2 passthrough).
     fn collect_cmaps_from_fonts(
         fonts: &std::collections::BTreeMap<Vec<u8>, &lopdf::Dictionary>,
         doc: &Document,
@@ -2205,12 +2426,17 @@ impl FontCMaps {
             }
         }
 
-        // Second pass: Identity-H/V fonts without ToUnicode
-        // Try: (1) embedded TrueType/OpenType cmap, (2) predefined CID→Unicode mapping
-        // Skip entirely in fast mode — these fonts require expensive TrueType parsing.
-        if skip_truetype_fallback {
-            return;
-        }
+        // Second pass: Type0 fonts without ToUnicode.
+        // - Identity-H/V: embedded TrueType cmap, predefined CIDSystemInfo, or
+        //   CID-as-Unicode passthrough heuristics.
+        // - Fixed-width named encodings (UniGB-UCS2-H, UniCNS-UCS2-V, …):
+        //   compose the builtin encoding CMap with Adobe-*-UCS2; their
+        //   character codes are already Unicode so passthrough is a safe last
+        //   resort. Mixed-width and four-byte encodings are intentionally
+        //   excluded because ToUnicodeCMap is not codespace-aware.
+        // In fast mode skip only the expensive TrueType/OpenType font-file
+        // parse; cheap builtin bcmap / fixed-width named fallbacks still run so
+        // region APIs can decode Adobe-GB1/Japan1/CNS1 and Uni*-UCS2-* fonts.
         for font_dict in fonts.values() {
             if font_dict.get(b"ToUnicode").is_ok() {
                 continue;
@@ -2223,9 +2449,8 @@ impl FontCMaps {
                 Some(name) => name,
                 None => continue,
             };
-            if encoding != b"Identity-H" && encoding != b"Identity-V" {
-                continue;
-            }
+            let is_identity = encoding == b"Identity-H" || encoding == b"Identity-V";
+
             // Navigate: DescendantFonts[0]
             let desc_fonts_obj = match font_dict.get(b"DescendantFonts").ok() {
                 Some(obj) => obj,
@@ -2287,16 +2512,40 @@ impl FontCMaps {
                 continue;
             }
 
-            // Try parsing embedded TrueType/OpenType cmap
-            if let Some(ff_ref) = font_file_ref {
-                if let Ok(stream) = doc.get_object(ff_ref).and_then(Object::as_stream) {
-                    let data = match stream.decompressed_content() {
-                        Ok(d) => d,
-                        Err(_) => stream.content.clone(),
-                    };
-                    if let Some(cmap) = build_cmap_from_truetype(&data) {
+            if is_identity {
+                // Try parsing embedded TrueType/OpenType cmap (expensive; skip in fast mode)
+                if !skip_truetype_fallback {
+                    if let Some(ff_ref) = font_file_ref {
+                        if let Ok(stream) = doc.get_object(ff_ref).and_then(Object::as_stream) {
+                            let data = match stream.decompressed_content() {
+                                Ok(d) => d,
+                                Err(_) => stream.content.clone(),
+                            };
+                            if let Some(cmap) = build_cmap_from_truetype(&data) {
+                                debug!(
+                                    "TrueType CMap obj={:<6} (embedded font) char_map={}",
+                                    lookup_key,
+                                    cmap.char_map.len()
+                                );
+                                by_obj_num.insert(
+                                    lookup_key,
+                                    CMapEntry {
+                                        primary: cmap,
+                                        remapped: None,
+                                        fallback: None,
+                                    },
+                                );
+                                resolved = true;
+                            }
+                        }
+                    }
+                }
+
+                // Fallback: predefined CID→Unicode mapping from CIDSystemInfo
+                if !resolved {
+                    if let Some(cmap) = build_cmap_from_cid_system_info(cid_font_dict, doc) {
                         debug!(
-                            "TrueType CMap obj={:<6} (embedded font) char_map={}",
+                            "Predefined CMap obj={:<6} (CIDSystemInfo) char_map={}",
                             lookup_key,
                             cmap.char_map.len()
                         );
@@ -2311,14 +2560,43 @@ impl FontCMaps {
                         resolved = true;
                     }
                 }
-            }
 
-            // Fallback: predefined CID→Unicode mapping from CIDSystemInfo
-            if !resolved {
-                if let Some(cmap) = build_cmap_from_cid_system_info(cid_font_dict, doc) {
+                // Last resort: CID-as-Unicode passthrough.
+                if !resolved {
+                    if cid_values_look_like_unicode(cid_font_dict) {
+                        debug!(
+                            "Identity-H font obj={}: W array CIDs look like Unicode — using passthrough",
+                            lookup_key
+                        );
+                        let mut cmap = ToUnicodeCMap::new();
+                        cmap.code_byte_length = 2;
+                        cmap.cid_passthrough = true;
+                        by_obj_num.insert(
+                            lookup_key,
+                            CMapEntry {
+                                primary: cmap,
+                                remapped: None,
+                                fallback: None,
+                            },
+                        );
+                    } else {
+                        debug!(
+                            "Identity-H font obj={}: no decoding possible (stripped cmap, GID-based CIDs)",
+                            lookup_key
+                        );
+                    }
+                }
+            } else {
+                if !is_fixed_two_byte_unicode_encoding(encoding) {
+                    continue;
+                }
+
+                // Fixed-width named predefined encoding (UniGB-UCS2-H, …).
+                if let Some(cmap) = build_fallback_tounicode_from_encoding(font_dict, doc) {
                     debug!(
-                        "Predefined CMap obj={:<6} (CIDSystemInfo) char_map={}",
+                        "Named encoding CMap obj={:<6} enc={} char_map={}",
                         lookup_key,
+                        String::from_utf8_lossy(encoding),
                         cmap.char_map.len()
                     );
                     by_obj_num.insert(
@@ -2331,19 +2609,13 @@ impl FontCMaps {
                     );
                     resolved = true;
                 }
-            }
 
-            // Last resort: CID-as-Unicode passthrough.
-            // Many PDF generators (Chromium, wkhtmltopdf) use Identity-H encoding where
-            // CID values ARE Unicode codepoints, but strip the cmap table and omit
-            // ToUnicode. We detect this by checking the /W (widths) array: if CID values
-            // fall in typical Unicode letter/digit ranges (0x41+), CIDs are likely Unicode.
-            // If CIDs are low values (< 0x41), they're GIDs in a subset font.
-            if !resolved {
-                if cid_values_look_like_unicode(cid_font_dict) {
+                // Uni*-UCS2-* character codes are already UCS-2 Unicode.
+                if !resolved {
                     debug!(
-                        "Identity-H font obj={}: W array CIDs look like Unicode — using passthrough",
-                        lookup_key
+                        "UCS2 encoding font obj={}: treating charcodes as Unicode (enc={})",
+                        lookup_key,
+                        String::from_utf8_lossy(encoding)
                     );
                     let mut cmap = ToUnicodeCMap::new();
                     cmap.code_byte_length = 2;
@@ -2356,16 +2628,15 @@ impl FontCMaps {
                             fallback: None,
                         },
                     );
-                } else {
-                    debug!(
-                        "Identity-H font obj={}: no decoding possible (stripped cmap, GID-based CIDs)",
-                        lookup_key
-                    );
                 }
             }
         }
 
-        // Third pass: simple fonts without ToUnicode (use embedded font cmap as fallback)
+        // Third pass: simple fonts without ToUnicode (use embedded font cmap as fallback).
+        // Expensive TrueType parsing — skip in fast mode.
+        if skip_truetype_fallback {
+            return;
+        }
         for font_dict in fonts.values() {
             if font_dict.get(b"ToUnicode").is_ok() {
                 continue;
@@ -3479,5 +3750,73 @@ endbfrange
         assert!(enc.map.len() <= MAX_CID_W_EXPANSION);
         assert_eq!(enc.map.get(&0), Some(&0));
         assert_eq!(enc.map.get(&65535), Some(&65535));
+    }
+
+    #[test]
+    fn test_parse_real_ucs2_bcmaps() {
+        // Bundled Adobe UCS2 bcmaps (from pdf.js) must parse. A broken binary
+        // parser silently disables the CIDSystemInfo fallback for CJK fonts.
+        let cases = [
+            ("Adobe-CNS1-UCS2.bcmap", 15_000, 500),
+            ("Adobe-GB1-UCS2.bcmap", 10_000, 3_000),
+            ("Adobe-Japan1-UCS2.bcmap", 16_000, 1_000),
+            ("Adobe-Korea1-UCS2.bcmap", 6_000, 1_900),
+        ];
+        for (name, min_char, min_ranges) in cases {
+            let data = read_builtin_cmap_file(name)
+                .unwrap_or_else(|| panic!("missing bundled bcmap {}", name));
+            let cmap = parse_binary_cmap(&data)
+                .unwrap_or_else(|e| panic!("{} failed to parse: {}", name, e));
+            assert!(
+                cmap.char_map.len() >= min_char,
+                "{} char_map too small: {}",
+                name,
+                cmap.char_map.len()
+            );
+            assert!(
+                cmap.ranges.len() >= min_ranges,
+                "{} ranges too small: {}",
+                name,
+                cmap.ranges.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unigb_ucs2_h_encoding_maps_cjk() {
+        let enc =
+            load_builtin_encoding_cmap("UniGB-UCS2-H").expect("UniGB-UCS2-H.bcmap should parse");
+        assert!(enc.map.len() > 10_000, "map too small: {}", enc.map.len());
+        assert_eq!(enc.code_byte_length, 2);
+        // 电 U+7535, 一 U+4E00 must be present as charcodes.
+        assert!(enc.map.contains_key(&0x7535), "missing 电");
+        assert!(enc.map.contains_key(&0x4E00), "missing 一");
+    }
+
+    #[test]
+    fn test_gb1_sample_roundtrip_via_unigb() {
+        let enc = load_builtin_encoding_cmap("UniGB-UCS2-H").expect("UniGB");
+        let ucs2 = build_cmap_from_builtin_cmap("GB1").expect("Adobe-GB1-UCS2");
+        for cp in [0x7535u16, 0x5B50, 0x53D1, 0x7968, 0x4E00] {
+            let cid = *enc
+                .map
+                .get(&cp)
+                .unwrap_or_else(|| panic!("no cid for {cp:04X}"));
+            let got = ucs2
+                .lookup(cid)
+                .unwrap_or_else(|| panic!("no unicode for cid {cid}"));
+            let expected = char::from_u32(cp as u32).unwrap().to_string();
+            assert_eq!(got, expected, "roundtrip U+{cp:04X}");
+        }
+    }
+
+    #[test]
+    fn test_is_fixed_two_byte_unicode_encoding() {
+        assert!(is_fixed_two_byte_unicode_encoding(b"UniGB-UCS2-H"));
+        assert!(is_fixed_two_byte_unicode_encoding(b"UniCNS-UCS2-V"));
+        assert!(is_fixed_two_byte_unicode_encoding(b"UniJIS-UCS2-HW-H"));
+        assert!(!is_fixed_two_byte_unicode_encoding(b"UniJIS-UTF16-H"));
+        assert!(!is_fixed_two_byte_unicode_encoding(b"Identity-H"));
+        assert!(!is_fixed_two_byte_unicode_encoding(b"GBK-EUC-H"));
     }
 }

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use crate::glyph_names::glyph_to_char;
 
@@ -1197,19 +1198,50 @@ fn build_gid_to_unicode(face: &ttf_parser::Face<'_>) -> Option<HashMap<u16, char
 /// Build a ToUnicodeCMap from pdf.js built-in binary CMaps (bcmaps).
 fn build_cmap_from_builtin_cmap(ordering: &str) -> Option<ToUnicodeCMap> {
     let name = format!("Adobe-{}-UCS2.bcmap", ordering);
-    let data = read_builtin_cmap_file(&name)?;
-    let mut cmap = parse_binary_cmap(&data).ok()?;
-    if cmap.char_map.is_empty() && cmap.ranges.is_empty() {
-        return None;
+    static CACHE: OnceLock<Mutex<HashMap<String, Option<ToUnicodeCMap>>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache_key = builtin_cmap_cache_key(&name);
+    if let Some(cached) = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&cache_key)
+        .cloned()
+    {
+        return cached;
     }
-    cmap.code_byte_length = 2;
-    debug!(
-        "Built-in CMap {}: char_map={} ranges={}",
-        name,
-        cmap.char_map.len(),
-        cmap.ranges.len()
-    );
-    Some(cmap)
+
+    let parsed = (|| {
+        let data = read_builtin_cmap_file(&name)?;
+        let mut cmap = parse_binary_cmap(&data).ok()?;
+        if cmap.char_map.is_empty() && cmap.ranges.is_empty() {
+            return None;
+        }
+        cmap.code_byte_length = 2;
+        debug!(
+            "Built-in CMap {}: char_map={} ranges={}",
+            name,
+            cmap.char_map.len(),
+            cmap.ranges.len()
+        );
+        Some(cmap)
+    })();
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(cache_key, parsed.clone());
+    parsed
+}
+
+fn builtin_cmap_cache_key(name: &str) -> String {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let directory = find_bcmaps_dir()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        format!("{directory}/{name}")
+    }
+    #[cfg(target_arch = "wasm32")]
+    name.to_string()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1239,6 +1271,16 @@ fn read_builtin_cmap_file(name: &str) -> Option<Cow<'static, [u8]>> {
 fn read_builtin_cmap_file(name: &str) -> Option<Cow<'static, [u8]>> {
     let file = BUILTIN_CMAPS.get_file(name)?;
     Some(Cow::Borrowed(file.contents()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn builtin_cmap_file_exists(name: &str) -> bool {
+    find_bcmaps_dir().is_some_and(|directory| directory.join(name).is_file())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn builtin_cmap_file_exists(name: &str) -> bool {
+    BUILTIN_CMAPS.get_file(name).is_some()
 }
 
 fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
@@ -1274,29 +1316,7 @@ fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
         let subitems = stream.read_number()? as usize;
         match typ {
             0 | 1 => {
-                // codespacerange (0) / notdefrange (1).
-                // First start is raw bytes; every end/start after that is a
-                // varint delta added to the previous value. Type 1 reads an
-                // extra code that we discard.
-                let mut start = stream.read_hex_bytes(data_size + 1)?;
-                let mut end = start.clone();
-                let end_delta = stream.read_hex_number(data_size)?;
-                add_hex(&mut end, &end_delta);
-                if typ == 1 {
-                    let _ = stream.read_number()?;
-                }
-                for _ in 1..subitems {
-                    inc_hex(&mut end);
-                    let start_delta = stream.read_hex_number(data_size)?;
-                    start = end.clone();
-                    add_hex(&mut start, &start_delta);
-                    let end_delta = stream.read_hex_number(data_size)?;
-                    end = start.clone();
-                    add_hex(&mut end, &end_delta);
-                    if typ == 1 {
-                        let _ = stream.read_number()?;
-                    }
-                }
+                consume_codespace_or_notdef(&mut stream, data_size, typ, subitems)?;
             }
             2 | 3 => {
                 // cidchar (2) / cidrange (3): CID→CID maps, irrelevant to
@@ -1403,6 +1423,37 @@ fn parse_binary_cmap(data: &[u8]) -> Result<ToUnicodeCMap, String> {
         }
     }
     Ok(cmap)
+}
+
+fn consume_codespace_or_notdef(
+    stream: &mut BinaryCMapStream<'_>,
+    data_size: usize,
+    typ: u8,
+    subitems: usize,
+) -> Result<(), String> {
+    // First start is raw bytes; every end/start after that is a varint delta
+    // added to the previous value. notdefrange (type 1) carries one extra
+    // code per subitem that neither parser needs.
+    let mut start = stream.read_hex_bytes(data_size + 1)?;
+    let mut end = start.clone();
+    let end_delta = stream.read_hex_number(data_size)?;
+    add_hex(&mut end, &end_delta);
+    if typ == 1 {
+        let _ = stream.read_number()?;
+    }
+    for _ in 1..subitems {
+        inc_hex(&mut end);
+        let start_delta = stream.read_hex_number(data_size)?;
+        start = end.clone();
+        add_hex(&mut start, &start_delta);
+        let end_delta = stream.read_hex_number(data_size)?;
+        end = start.clone();
+        add_hex(&mut end, &end_delta);
+        if typ == 1 {
+            let _ = stream.read_number()?;
+        }
+    }
+    Ok(())
 }
 
 /// Insert a single bfrange entry into the CMap. Single-char destinations go
@@ -1629,6 +1680,13 @@ fn build_fallback_tounicode_from_encoding(
 
 fn get_cid_system_info_ordering(font_dict: &lopdf::Dictionary, doc: &Document) -> Option<String> {
     let cid_font_dict = get_descendant_cid_font(font_dict, doc)?;
+    get_cid_system_info_ordering_from_descendant(cid_font_dict, doc)
+}
+
+fn get_cid_system_info_ordering_from_descendant(
+    cid_font_dict: &lopdf::Dictionary,
+    doc: &Document,
+) -> Option<String> {
     let csi_obj = cid_font_dict.get(b"CIDSystemInfo").ok()?;
     let csi_dict = match csi_obj {
         Object::Reference(r) => doc.get_dictionary(*r).ok()?,
@@ -1685,8 +1743,26 @@ fn parse_encoding_cmap_object(obj: &Object, doc: &Document) -> Option<EncodingCM
 }
 
 fn load_builtin_encoding_cmap(name: &str) -> Option<EncodingCMap> {
-    let data = read_builtin_cmap_file(&format!("{}.bcmap", name))?;
-    parse_binary_cmap_encoding(&data).ok()
+    static CACHE: OnceLock<Mutex<HashMap<String, Option<EncodingCMap>>>> = OnceLock::new();
+    let file_name = format!("{}.bcmap", name);
+    let cache_key = builtin_cmap_cache_key(&file_name);
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(cached) = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&cache_key)
+        .cloned()
+    {
+        return cached;
+    }
+
+    let parsed =
+        read_builtin_cmap_file(&file_name).and_then(|data| parse_binary_cmap_encoding(&data).ok());
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(cache_key, parsed.clone());
+    parsed
 }
 
 fn parse_encoding_cmap_stream(data: &[u8]) -> Option<EncodingCMap> {
@@ -1934,26 +2010,7 @@ fn parse_binary_cmap_encoding(data: &[u8]) -> Result<EncodingCMap, String> {
         let subitems = stream.read_number()? as usize;
         match typ {
             0 | 1 => {
-                // codespacerange / notdefrange — consume payload
-                let mut start = stream.read_hex_bytes(data_size + 1)?;
-                let mut end = start.clone();
-                let end_delta = stream.read_hex_number(data_size)?;
-                add_hex(&mut end, &end_delta);
-                if typ == 1 {
-                    let _ = stream.read_number()?;
-                }
-                for _ in 1..subitems {
-                    inc_hex(&mut end);
-                    let start_delta = stream.read_hex_number(data_size)?;
-                    start = end.clone();
-                    add_hex(&mut start, &start_delta);
-                    let end_delta = stream.read_hex_number(data_size)?;
-                    end = start.clone();
-                    add_hex(&mut end, &end_delta);
-                    if typ == 1 {
-                        let _ = stream.read_number()?;
-                    }
-                }
+                consume_codespace_or_notdef(&mut stream, data_size, typ, subitems)?;
             }
             2 => {
                 // cidchar: first char raw, first code varint; subsequent use
@@ -2237,6 +2294,46 @@ pub(crate) fn predefined_cmap_for_font(
     })
 }
 
+/// Cheap detection-side equivalent of `predefined_cmap_for_font`.
+///
+/// Classification only needs to know whether extraction has a fallback; it
+/// must not read and parse a multi-thousand-entry Adobe CMap for every font.
+pub(crate) fn predefined_cmap_is_available(font_dict: &lopdf::Dictionary, doc: &Document) -> bool {
+    if font_dict.get(b"ToUnicode").is_ok() {
+        return false;
+    }
+    let Some(encoding) = font_dict
+        .get(b"Encoding")
+        .ok()
+        .and_then(|object| object.as_name().ok())
+    else {
+        return false;
+    };
+    if is_fixed_two_byte_unicode_encoding(encoding) {
+        // Extraction can always use the explicit UCS-2 passthrough even when
+        // an optional composed Adobe mapping is unavailable.
+        return true;
+    }
+    if encoding != b"Identity-H" && encoding != b"Identity-V" {
+        return false;
+    }
+
+    let Some(cid_font) = get_descendant_cid_font(font_dict, doc) else {
+        return false;
+    };
+    let Some(ordering) = get_cid_system_info_ordering_from_descendant(cid_font, doc) else {
+        return false;
+    };
+    match ordering.as_str() {
+        "Korea1" => true,
+        "Japan1" | "GB1" | "CNS1" => {
+            let name = format!("Adobe-{ordering}-UCS2.bcmap");
+            builtin_cmap_file_exists(&name)
+        }
+        _ => false,
+    }
+}
+
 /// Collection of ToUnicode CMaps indexed by ToUnicode stream object number
 #[derive(Debug, Default, Clone)]
 pub struct FontCMaps {
@@ -2250,6 +2347,75 @@ pub struct CMapEntry {
     pub primary: ToUnicodeCMap,
     pub remapped: Option<ToUnicodeCMap>,
     pub fallback: Option<ToUnicodeCMap>,
+}
+
+/// Build a CMap that must be scoped to a concrete font resource rather than
+/// stored under a shared PDF object number.
+///
+/// Named Uni*-UCS2-* encodings are properties of the parent Type0 font, so
+/// two parents may legally share one embedded FontFile while requiring
+/// different mappings. Inline descendant CIDFont dictionaries likewise have
+/// no object number that the document-wide CMap table can safely use.
+pub(crate) fn build_resource_scoped_cmap_entry(
+    font_dict: &lopdf::Dictionary,
+    doc: &Document,
+) -> Option<CMapEntry> {
+    if font_dict.get(b"ToUnicode").is_ok()
+        || font_dict
+            .get(b"Subtype")
+            .ok()
+            .and_then(|object| object.as_name().ok())
+            != Some(b"Type0")
+    {
+        return None;
+    }
+
+    let encoding = font_dict
+        .get(b"Encoding")
+        .ok()
+        .and_then(|object| object.as_name().ok())?;
+    let is_named_ucs2 = is_fixed_two_byte_unicode_encoding(encoding);
+    let is_identity = encoding == b"Identity-H" || encoding == b"Identity-V";
+    if !(is_named_ucs2 || is_identity && has_inline_descendant_font(font_dict, doc)) {
+        return None;
+    }
+
+    let primary = if is_named_ucs2 {
+        predefined_cmap_for_font(font_dict, doc)?
+    } else {
+        build_fallback_cmap_for_type0(font_dict, doc).or_else(|| {
+            let cid_font = get_descendant_cid_font(font_dict, doc)?;
+            if cid_values_look_like_unicode(cid_font) {
+                let mut cmap = ToUnicodeCMap::new();
+                cmap.code_byte_length = 2;
+                cmap.cid_passthrough = true;
+                Some(cmap)
+            } else {
+                None
+            }
+        })?
+    };
+
+    Some(CMapEntry {
+        primary,
+        remapped: None,
+        fallback: None,
+    })
+}
+
+fn has_inline_descendant_font(font_dict: &lopdf::Dictionary, doc: &Document) -> bool {
+    let Ok(descendants) = font_dict.get(b"DescendantFonts") else {
+        return false;
+    };
+    let descendants = match descendants {
+        Object::Array(array) => array,
+        Object::Reference(reference) => match doc.get_object(*reference) {
+            Ok(Object::Array(array)) => array,
+            _ => return false,
+        },
+        _ => return false,
+    };
+    matches!(descendants.first(), Some(Object::Dictionary(_)))
 }
 
 impl FontCMaps {
@@ -2426,17 +2592,12 @@ impl FontCMaps {
             }
         }
 
-        // Second pass: Type0 fonts without ToUnicode.
-        // - Identity-H/V: embedded TrueType cmap, predefined CIDSystemInfo, or
-        //   CID-as-Unicode passthrough heuristics.
-        // - Fixed-width named encodings (UniGB-UCS2-H, UniCNS-UCS2-V, …):
-        //   compose the builtin encoding CMap with Adobe-*-UCS2; their
-        //   character codes are already Unicode so passthrough is a safe last
-        //   resort. Mixed-width and four-byte encodings are intentionally
-        //   excluded because ToUnicodeCMap is not codespace-aware.
+        // Second pass: Identity-H/V Type0 fonts without ToUnicode. Named
+        // Uni*-UCS2-* maps are resource-scoped because the encoding belongs to
+        // the parent Type0 font and must not be keyed by a shared FontFile.
         // In fast mode skip only the expensive TrueType/OpenType font-file
-        // parse; cheap builtin bcmap / fixed-width named fallbacks still run so
-        // region APIs can decode Adobe-GB1/Japan1/CNS1 and Uni*-UCS2-* fonts.
+        // parse; cheap CIDSystemInfo fallbacks still run. Named encodings are
+        // installed later under their concrete page/Form resource name.
         for font_dict in fonts.values() {
             if font_dict.get(b"ToUnicode").is_ok() {
                 continue;
@@ -2500,14 +2661,13 @@ impl FontCMaps {
                     })
             });
 
-            // The lookup key must match what get_font_file2_obj_num() returns:
-            // font file obj_num if present, else CIDFont dict obj_num
-            let lookup_key = font_file_ref
-                .map(|r| r.0)
-                .unwrap_or_else(|| match &desc_fonts[0] {
-                    Object::Reference(r) => r.0,
-                    _ => 0,
-                });
+            // The lookup key must match get_font_file2_obj_num(). A Type0
+            // mapping depends on the CIDFont's collection/CIDToGIDMap, not
+            // solely on an embedded FontFile that multiple CIDFonts may share.
+            let lookup_key = match &desc_fonts[0] {
+                Object::Reference(r) => r.0,
+                _ => 0,
+            };
             if lookup_key == 0 || by_obj_num.contains_key(&lookup_key) {
                 continue;
             }
@@ -2585,49 +2745,6 @@ impl FontCMaps {
                             lookup_key
                         );
                     }
-                }
-            } else {
-                if !is_fixed_two_byte_unicode_encoding(encoding) {
-                    continue;
-                }
-
-                // Fixed-width named predefined encoding (UniGB-UCS2-H, …).
-                if let Some(cmap) = build_fallback_tounicode_from_encoding(font_dict, doc) {
-                    debug!(
-                        "Named encoding CMap obj={:<6} enc={} char_map={}",
-                        lookup_key,
-                        String::from_utf8_lossy(encoding),
-                        cmap.char_map.len()
-                    );
-                    by_obj_num.insert(
-                        lookup_key,
-                        CMapEntry {
-                            primary: cmap,
-                            remapped: None,
-                            fallback: None,
-                        },
-                    );
-                    resolved = true;
-                }
-
-                // Uni*-UCS2-* character codes are already UCS-2 Unicode.
-                if !resolved {
-                    debug!(
-                        "UCS2 encoding font obj={}: treating charcodes as Unicode (enc={})",
-                        lookup_key,
-                        String::from_utf8_lossy(encoding)
-                    );
-                    let mut cmap = ToUnicodeCMap::new();
-                    cmap.code_byte_length = 2;
-                    cmap.cid_passthrough = true;
-                    by_obj_num.insert(
-                        lookup_key,
-                        CMapEntry {
-                            primary: cmap,
-                            remapped: None,
-                            fallback: None,
-                        },
-                    );
                 }
             }
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1501,55 +1501,41 @@ fn test_extract_structure_elements_untagged_pdf_empty() {
 }
 
 #[test]
-fn test_identity_h_no_tounicode_suppresses_garbage() {
+fn test_identity_h_yugothic_decoded_via_builtin_japan1() {
     // shinagawa_identity_h.pdf uses YuGothic with Identity-H encoding and no
-    // usable ToUnicode CMap. The raw CID bytes (e.g. 0x08 0x37, 0x0E 0x0F)
-    // contain non-ASCII high bytes and previously fell through to the
-    // per-byte Latin-1 fallback, producing high-Latin-1 mojibake that
-    // `is_cid_garbage` flagged. The Type0/CID guard in
-    // `extract_text_from_operand` now emits one U+FFFD per CID instead of
-    // mojibake; `detect_encoding_issues` trips on that and suppresses the
-    // markdown / flags the page for OCR — so we still pass this test, but
-    // via the deliberate marker path rather than by accident.
+    // ToUnicode CMap. Its CIDSystemInfo Ordering is Japan1, so the bundled
+    // Adobe-Japan1-UCS2.bcmap predefined map decodes it (poppler does the
+    // same). Before the binary-CMap fix this map failed to parse and the
+    // font fell through to U+FFFD garbage / OCR routing.
     let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
 
-    // Pre-suppression check: the raw text items must contain the U+FFFD
-    // markers that prove the Type0/CID fallback fired. This pins the
-    // mechanism so a future regression that re-enables Latin-1 mojibake
-    // would fail loudly here, not just silently change the suppression
-    // chain to one that depends on `is_cid_garbage` + high-Latin-1 chars.
+    // The text must decode to real Japanese, with no U+FFFD markers.
     let items = pdf_inspector::extractor::extract_text_with_positions_mem(&buf).unwrap();
     let combined: String = items.iter().map(|i| i.text.as_str()).collect();
     assert!(
-        combined.contains('\u{FFFD}'),
-        "Type0/CID font with unparseable ToUnicode CMap should emit U+FFFD per CID; \
-         got {} chars: {:?}",
-        combined.len(),
-        &combined[..combined.len().min(100)]
+        !combined.contains('\u{FFFD}'),
+        "Japan1 Identity-H font should decode via builtin CMap, got U+FFFD: {:?}",
+        combined.chars().take(120).collect::<String>()
     );
     assert!(
-        !combined
-            .chars()
-            .any(|c| ('\u{0080}'..='\u{00FF}').contains(&c)),
-        "Latin-1 mojibake (high bytes) must not leak from Type0/CID fallback; got: {:?}",
-        &combined[..combined.len().min(100)]
+        combined.contains("羽田空港"),
+        "Should extract real Japanese title, got: {:?}",
+        combined.chars().take(120).collect::<String>()
     );
 
     let result = pdf_inspector::process_pdf_mem(&buf).unwrap();
 
-    // Page 1 should be flagged for OCR
+    // The page is now decodable, so it should NOT be flagged for OCR and the
+    // markdown should contain real Japanese.
     assert!(
-        result.pages_needing_ocr.contains(&1),
-        "Page with Identity-H font without ToUnicode should be flagged for OCR"
+        !result.pages_needing_ocr.contains(&1),
+        "Decodable Japan1 page should not be flagged for OCR"
     );
-
-    // Markdown should be empty (garbage suppressed)
     let md = result.markdown.unwrap_or_default();
     assert!(
-        md.trim().is_empty(),
-        "Garbage CID text should be suppressed, got {} chars: {:?}",
-        md.len(),
-        &md[..md.len().min(100)]
+        md.contains("羽田空港"),
+        "Markdown should contain real Japanese, got: {:?}",
+        md.chars().take(120).collect::<String>()
     );
 }
 
@@ -1931,14 +1917,18 @@ fn test_extract_regions_mem_visible_layer_unchanged() {
 }
 
 #[test]
-fn test_extract_regions_mem_identity_h_needs_ocr() {
+fn test_extract_regions_mem_identity_h_decodes() {
     let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
     let regions =
         extract_text_in_regions_mem(&buf, &[(0, vec![[0.0, 0.0, 1200.0, 1200.0]])]).unwrap();
     assert_eq!(regions.len(), 1);
     assert!(
-        regions[0].regions[0].needs_ocr,
-        "Identity-H font without ToUnicode should trigger needs_ocr"
+        !regions[0].regions[0].needs_ocr,
+        "Japan1 Identity-H font should decode via builtin CMap"
+    );
+    assert!(
+        regions[0].regions[0].text.contains("羽田空港"),
+        "region text should contain Japanese title"
     );
 }
 
@@ -2199,14 +2189,18 @@ fn test_extract_tables_in_regions_empty_region() {
 }
 
 #[test]
-fn test_extract_tables_in_regions_identity_h_needs_ocr() {
+fn test_extract_tables_in_regions_identity_h_non_table_needs_ocr() {
     let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
     let results =
         extract_tables_in_regions_mem(&buf, &[(0, vec![[0.0, 0.0, 1200.0, 1200.0]])]).unwrap();
 
     assert_eq!(results.len(), 1);
     let region = &results[0].regions[0];
-    assert!(region.needs_ocr, "Identity-H font should trigger needs_ocr");
+    assert!(
+        region.needs_ocr,
+        "a decodable but non-table region should still request table OCR"
+    );
+    assert!(region.text.is_empty(), "non-table region should be empty");
 }
 
 #[test]
@@ -3595,14 +3589,17 @@ fn test_extract_pages_markdown_invalid_buffer() {
 }
 
 #[test]
-fn test_extract_pages_markdown_gid_pages_need_ocr() {
-    // shinagawa_identity_h.pdf has GID-encoded fonts
+fn test_extract_pages_markdown_japan1_decodes_no_ocr() {
+    // shinagawa_identity_h.pdf uses Japan1 CID fonts (YuGothic). With the
+    // bundled Adobe-Japan1-UCS2.bcmap predefined map these now decode to real
+    // Japanese, so the page must NOT be flagged for OCR (poppler agrees).
     let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
     let result = extract_pages_markdown_mem(&buf, Some(&[0])).unwrap();
 
     assert_eq!(result.pages.len(), 1);
-    assert!(result.pages[0].needs_ocr);
-    assert!(result.pages_needing_ocr.contains(&1)); // 1-indexed
+    assert!(!result.pages[0].needs_ocr);
+    assert!(result.pages[0].markdown.contains("羽田空港"));
+    assert!(!result.pages_needing_ocr.contains(&1)); // 1-indexed
 }
 
 #[test]
@@ -4397,5 +4394,150 @@ fn test_extract_pages_markdown_agrees_with_classify_on_scan_with_native_header()
         "a page flagged needs_ocr must not return markdown as if extraction were \
          trustworthy, got: {:?}",
         page.markdown
+    );
+}
+
+fn make_named_type0_pdf(encoding: &str, ordering: &str, encoded_text: &[u8]) -> Vec<u8> {
+    let tj = format!(
+        "<{}> Tj",
+        encoded_text
+            .iter()
+            .map(|byte| format!("{byte:02X}"))
+            .collect::<String>()
+    );
+    let content = format!("BT\n/F1 24 Tf\n50 700 Td\n{tj}\nET\n");
+
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        4,
+        &format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content.len(),
+            content
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        &format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /SimSun \
+             /Encoding /{encoding} /DescendantFonts [6 0 R] >>"
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        6,
+        &format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /SimSun \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering ({ordering}) /Supplement 4 >> \
+             /FontDescriptor 7 0 R /DW 1000 \
+             /W [32 126 500 19968 40959 1000] >>"
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        7,
+        "<< /Type /FontDescriptor /FontName /SimSun /Flags 4 \
+         /FontBBox [0 -200 1000 800] /ItalicAngle 0 \
+         /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 >>",
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
+fn extracted_text(pdf: &[u8]) -> String {
+    extract_text_with_positions_mem(pdf)
+        .expect("extract")
+        .into_iter()
+        .map(|it| it.text)
+        .collect()
+}
+
+/// Type0 + UniGB-UCS2-H, no ToUnicode, no embedded font — the pattern used by
+/// Chinese OFD→PDF e-tickets (e.g. Suwell OFD convertor railway tickets).
+/// Character codes are UCS-2 Unicode; pdftotext decodes them correctly.
+#[test]
+fn extract_unigb_ucs2_h_without_tounicode() {
+    let chars = "电子发票 G342 郴州西";
+    let encoded: Vec<u8> = chars.encode_utf16().flat_map(u16::to_be_bytes).collect();
+    let pdf = make_named_type0_pdf("UniGB-UCS2-H", "GB1", &encoded);
+    let text = extracted_text(&pdf);
+
+    assert!(
+        !text.contains('\u{FFFD}'),
+        "should not emit replacement chars, got {text:?}"
+    );
+    assert!(text.contains("电子发票"), "missing 电子发票 in {text:?}");
+    assert!(text.contains("郴州西"), "missing 郴州西 in {text:?}");
+    assert!(text.contains("G342"), "missing G342 in {text:?}");
+}
+
+/// GBK-EUC-H mixes one-byte ASCII with two-byte CJK. Until the decoder is
+/// codespace-aware, it must fail loudly instead of returning plausible but
+/// incomplete text with identifiers such as train numbers silently removed.
+#[test]
+fn mixed_width_named_cmap_does_not_emit_partial_text() {
+    let gbk = [
+        0xB5, 0xE7, 0xD7, 0xD3, 0xB7, 0xA2, 0xC6, 0xB1, 0x20, 0x47, 0x33, 0x34, 0x32, 0x20, 0xB3,
+        0xBB, 0xD6, 0xDD, 0xCE, 0xF7,
+    ];
+    let pdf = make_named_type0_pdf("GBK-EUC-H", "GB1", &gbk);
+    let text = extracted_text(&pdf);
+
+    assert!(
+        text.contains('\u{FFFD}'),
+        "unsupported mixed-width CMap must signal decoding failure, got {text:?}"
+    );
+    assert!(
+        !text.contains("电子发票郴州西"),
+        "must not return the previously observed partial text: {text:?}"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4501,6 +4501,153 @@ fn extracted_text(pdf: &[u8]) -> String {
         .collect()
 }
 
+fn make_resource_scoped_named_type0_pdf(
+    inline_descendant: bool,
+    shared_font_file: bool,
+) -> Vec<u8> {
+    use lopdf::content::{Content, Operation};
+    use lopdf::{dictionary, Document, Object, Stream, StringFormat};
+
+    let mut doc = Document::with_version("1.7");
+    let pages_id = doc.new_object_id();
+    let page_id = doc.new_object_id();
+    let content_id = doc.new_object_id();
+    let font1_id = doc.new_object_id();
+    let font2_id = doc.new_object_id();
+    let cid1_id = doc.new_object_id();
+    let cid2_id = doc.new_object_id();
+    let descriptor1_id = doc.new_object_id();
+    let descriptor2_id = doc.new_object_id();
+    let font_file_id = doc.new_object_id();
+
+    let chars = "电子发票 G342 郴州西";
+    let encoded: Vec<u8> = chars.encode_utf16().flat_map(u16::to_be_bytes).collect();
+    let mut operations = vec![
+        Operation::new("BT", vec![]),
+        Operation::new("Tf", vec!["F1".into(), 20.into()]),
+        Operation::new("Td", vec![50.into(), 700.into()]),
+        Operation::new(
+            "Tj",
+            vec![Object::String(encoded.clone(), StringFormat::Hexadecimal)],
+        ),
+    ];
+    if shared_font_file {
+        operations.extend([
+            Operation::new("Td", vec![0.into(), Object::Integer(-40)]),
+            Operation::new("Tf", vec!["F2".into(), 20.into()]),
+            Operation::new(
+                "Tj",
+                vec![Object::String(encoded, StringFormat::Hexadecimal)],
+            ),
+        ]);
+    }
+    operations.push(Operation::new("ET", vec![]));
+    let content = Content { operations }.encode().unwrap();
+    doc.objects
+        .insert(content_id, Stream::new(dictionary! {}, content).into());
+
+    let descriptor = |font_name: &'static str| {
+        dictionary! {
+            "Type" => "FontDescriptor",
+            "FontName" => font_name,
+            "Flags" => 4,
+            "FontBBox" => vec![0.into(), Object::Integer(-200), 1000.into(), 800.into()],
+            "ItalicAngle" => 0,
+            "Ascent" => 800,
+            "Descent" => Object::Integer(-200),
+            "CapHeight" => 700,
+            "StemV" => 80,
+            "FontFile2" => font_file_id,
+        }
+    };
+    doc.objects
+        .insert(descriptor1_id, descriptor("SyntheticGB").into());
+    doc.objects
+        .insert(descriptor2_id, descriptor("SyntheticJIS").into());
+    doc.objects.insert(
+        font_file_id,
+        Stream::new(dictionary! {}, b"not-a-real-font".to_vec()).into(),
+    );
+
+    let cid_font = |ordering: &'static str, descriptor_id| {
+        dictionary! {
+            "Type" => "Font",
+            "Subtype" => "CIDFontType2",
+            "CIDSystemInfo" => dictionary! {
+                "Registry" => Object::string_literal("Adobe"),
+                "Ordering" => Object::string_literal(ordering),
+                "Supplement" => 4,
+            },
+            "FontDescriptor" => descriptor_id,
+            "DW" => 1000,
+            "W" => vec![32.into(), 126.into(), 500.into(), 19968.into(), 40959.into(), 1000.into()],
+        }
+    };
+    let cid1 = cid_font("GB1", descriptor1_id);
+    let cid2 = cid_font("Japan1", descriptor2_id);
+    if !inline_descendant {
+        doc.objects.insert(cid1_id, cid1.clone().into());
+    }
+    doc.objects.insert(cid2_id, cid2.into());
+
+    doc.objects.insert(
+        font1_id,
+        dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type0",
+            "Encoding" => "UniGB-UCS2-H",
+            "DescendantFonts" => if inline_descendant {
+                vec![Object::Dictionary(cid1)]
+            } else {
+                vec![cid1_id.into()]
+            },
+        }
+        .into(),
+    );
+    doc.objects.insert(
+        font2_id,
+        dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type0",
+            "Encoding" => "UniJIS-UCS2-H",
+            "DescendantFonts" => vec![cid2_id.into()],
+        }
+        .into(),
+    );
+
+    let fonts = if shared_font_file {
+        dictionary! { "F1" => font1_id, "F2" => font2_id }
+    } else {
+        dictionary! { "F1" => font1_id }
+    };
+    doc.objects.insert(
+        page_id,
+        dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+            "Resources" => dictionary! { "Font" => fonts },
+            "Contents" => content_id,
+        }
+        .into(),
+    );
+    doc.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1,
+        }
+        .into(),
+    );
+    let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    bytes
+}
+
 /// Type0 + UniGB-UCS2-H, no ToUnicode, no embedded font — the pattern used by
 /// Chinese OFD→PDF e-tickets (e.g. Suwell OFD convertor railway tickets).
 /// Character codes are UCS-2 Unicode; pdftotext decodes them correctly.
@@ -4518,6 +4665,33 @@ fn extract_unigb_ucs2_h_without_tounicode() {
     assert!(text.contains("电子发票"), "missing 电子发票 in {text:?}");
     assert!(text.contains("郴州西"), "missing 郴州西 in {text:?}");
     assert!(text.contains("G342"), "missing G342 in {text:?}");
+}
+
+#[test]
+fn inline_cidfont_uses_resource_scoped_predefined_cmap() {
+    let pdf = make_resource_scoped_named_type0_pdf(true, false);
+    let text = extracted_text(&pdf);
+
+    assert_eq!(text, "电子发票 G342 郴州西");
+    assert!(!text.contains('\u{FFFD}'));
+}
+
+#[test]
+fn shared_fontfile_does_not_collide_named_encoding_cmaps() {
+    let pdf = make_resource_scoped_named_type0_pdf(false, true);
+    let items = extract_text_with_positions_mem(&pdf).expect("extract");
+
+    assert_eq!(
+        items.len(),
+        2,
+        "expected one item per named font: {items:?}"
+    );
+    assert_eq!(items[0].text, "电子发票 G342 郴州西");
+    assert_ne!(
+        items[1].text, items[0].text,
+        "UniJIS must not reuse the UniGB mapping from a shared FontFile"
+    );
+    assert!(!items[1].text.contains('\u{FFFD}'));
 }
 
 /// GBK-EUC-H mixes one-byte ASCII with two-byte CJK. Until the decoder is


### PR DESCRIPTION
## Summary

- parse bundled binary Adobe CMaps using the pdf.js binary format semantics
- compose fixed-width Uni*-UCS2-* encoding CMaps with Adobe collection UCS2 maps for Type0 fonts without ToUnicode
- register the fallback under the same font key used by text extraction and OCR detection
- keep mixed-width and four-byte named CMaps out of the fixed-width decoder so unsupported inputs fail explicitly instead of silently dropping text
- decode the existing Japan1 Identity-H fixture through the bundled predefined map

Fixes #364.

## Why

OFD-to-PDF converters commonly emit Chinese e-tickets and invoices with a Type0 font using UniGB-UCS2-H, no ToUnicode stream, and no embedded font program. The character codes are recoverable, but the previous no-ToUnicode path only wired Identity-H/V fonts, so extraction emitted replacement characters.

## Testing

- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test (875 unit, 164 integration, 2 doc tests)
- cargo build --release
- release smoke test extracts: 电子发票 G342 郴州西
- mixed-width GBK-EUC-H regression confirms unsupported input no longer returns plausible partial text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode Type0 CJK fonts without ToUnicode by composing fixed‑width `Uni*-UCS2-*` encodings with bundled Adobe UCS2 CMaps and by using CIDSystemInfo for Identity‑H/V. Previously only Identity‑H/V via embedded cmap was handled, which produced U+FFFD/mojibake and flagged pages for OCR; now UniGB/UniJIS UCS2 and Japan1 Identity‑H decode correctly. Fixes #364.

- Parse and cache pdf.js binary CMaps with full varint/signed semantics; add tests for real `Adobe-*-UCS2.bcmap` files.
- Compose `Uni*-UCS2-*-H/V` with `Adobe-*-UCS2`; if bcmaps are unavailable, use safe UCS‑2 passthrough. Exclude mixed‑width and UTF‑16 named encodings (e.g., `GBK-EUC-H`, `UniJIS-UTF16-H`) so unsupported inputs fail loudly.
- Scope predefined CMaps by font resource for named encodings and inline CIDFonts; key Identity‑H/V by the CIDFont object to prevent collisions when fonts share a `FontFile`.
- Detection uses a cheap availability check to avoid OCR false positives; in fast mode we skip TrueType parsing but still apply builtin CMap fallbacks.

<sup>Written for commit 4b7b7878e38e9fe54092e68bd569210d836ee069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

