### PR TITLE
feat(render): expose positioned image pixels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
       - name: Install WebAssembly test tools
         run: |
           cargo install wasm-pack --version 0.15.0 --locked
+          # Keep in sync with wasm-bindgen in wasm/Cargo.lock: the test
+          # runner's protocol matches that exact version.
           cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Test WebAssembly package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,22 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      - name: Run tests with optional page rendering
+        run: cargo test --features render --verbose
+
+      - name: Check out pinned PDF renderer corpus
+        run: |
+          git clone https://github.com/py-pdf/sample-files.git "$RUNNER_TEMP/pdf-inspector-sample-files"
+          git -C "$RUNNER_TEMP/pdf-inspector-sample-files" checkout --detach 89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf
+
+      - name: Run PDF renderer corpus
+        env:
+          PDF_INSPECTOR_SAMPLE_FILES: ${{ runner.temp }}/pdf-inspector-sample-files
+        run: cargo test --features render --test render_corpus_tests -- --ignored
+
+      - name: Check rendering API documentation
+        run: cargo doc --no-deps --features render
+
       - name: Test developer scripts
         run: python3 -m unittest discover -s scripts/tests
 
@@ -71,6 +87,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings
 
+      - name: Run clippy with optional page rendering
+        run: cargo clippy --features render -- -D warnings
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -92,6 +111,33 @@ jobs:
 
       - name: Build
         run: cargo build --release --verbose
+
+      - name: Build optional page rendering
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo build --release --features render --verbose
+
+  render-msrv:
+    name: Page rendering MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust 1.92
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: 1.92.0
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: render-msrv
+
+      - name: Check optional page rendering
+        run: cargo check --features render
+
+      - name: Check optional page rendering for WebAssembly
+        run: cargo check --target wasm32-unknown-unknown --features render
 
   wasm:
     name: WebAssembly
@@ -116,14 +162,43 @@ jobs:
       - name: Check WebAssembly bindings
         run: cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown
 
+      - name: Check WebAssembly bindings with optional page rendering
+        run: cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown --features render
+
       - name: Check root package for WebAssembly
         run: cargo check --target wasm32-unknown-unknown
+
+      - name: Check root page rendering for WebAssembly
+        run: cargo check --target wasm32-unknown-unknown --features render
 
       - name: Lint WebAssembly bindings
         run: cargo clippy --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.15.0 --locked
+      - name: Lint WebAssembly bindings with optional page rendering
+        run: cargo clippy --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown --features render -- -D warnings
+
+      - name: Lint root page rendering for WebAssembly
+        run: cargo clippy --target wasm32-unknown-unknown --features render -- -D warnings
+
+      - name: Install WebAssembly test tools
+        run: |
+          cargo install wasm-pack --version 0.15.0 --locked
+          cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Test WebAssembly package
         run: wasm-pack test --node --release wasm
+
+      - name: Test optional page rendering in WebAssembly
+        run: wasm-pack test --node --release wasm --features render
+
+      - name: Install matching Chrome and ChromeDriver
+        id: chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
+        with:
+          install-chromedriver: true
+
+      - name: Test optional page rendering in Chrome
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+          CHROMEDRIVER: ${{ steps.chrome.outputs.chromedriver-path }}
+        run: cargo test --manifest-path wasm/Cargo.toml --release --target wasm32-unknown-unknown --features render --test render_browser

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Fast PDF text extraction to structured Markdown. CLI binary: `pdf2md`. Detection
 cargo fmt                                    # format
 cargo clippy -- -D warnings                  # lint (enforced, zero warnings)
 cargo test                                   # unit + integration tests (267+ unit, 73+ integration)
+cargo clippy --features render -- -D warnings # lint the optional renderer, zero warnings
+cargo test --features render                 # renderer tests (opt-in via the 'render' feature)
 cargo build --release                        # release binary for benchmarks
 ```
 
@@ -27,6 +29,7 @@ src/
   types.rs                      – TextItem, TextLine, PdfRect, PdfLine
   tounicode.rs                  – CMap/ToUnicode parsing, CID decoding
   text_utils.rs                 – CJK/RTL handling, Otsu threshold, ligature expansion, NFKC
+  render.rs                     – optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/
     mod.rs                      – top-level extraction orchestrator
     content_stream.rs           – PDF operator state machine (Tj/TJ/Td/Tm/q/Q)
@@ -63,6 +66,8 @@ src/
 - **Integration tests**: `tests/integration_tests.rs` with fixture PDFs in `tests/fixtures/`.
 - **Regression suite**: sibling repo `pdf-evals` with ~200 snapshot PDFs. Run `cargo build --release` then `bench.py test` in that repo before committing. While iterating, prefer a subset run (`bench.py test -q` for the quick set, or `-s <name>` for a named test set) and save the full `bench.py test` for the final pre-commit check.
 - **Semantic quality**: run `bench.py score` in `pdf-evals` for the semantic verdict (TEDS + MHS + reading order + char/word + list preservation, composited). Character-level diff alone misclassifies structural improvements (e.g., column-detection rewrites) as regressions — `score` is the tie-breaker. See `pdf-evals/CLAUDE.md` "Semantic scoring".
+- **Render corpus**: pinned external `py-pdf/sample-files` render corpus, ignored by default; enable with `PDF_INSPECTOR_SAMPLE_FILES` (checksum-verified).
+- **WebAssembly runtime tests**: `wasm-pack test --node --release wasm` and `wasm-pack test --node --release wasm --features render`.
 
 ## Debugging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Fast PDF text extraction to structured Markdown. CLI binary: `pdf2md`. Detection
 cargo fmt                                    # format
 cargo clippy -- -D warnings                  # lint (enforced, zero warnings)
 cargo test                                   # unit + integration tests (267+ unit, 73+ integration)
+cargo clippy --features render -- -D warnings # lint the optional renderer, zero warnings
+cargo test --features render                 # renderer tests (opt-in via the 'render' feature)
 cargo build --release                        # release binary for benchmarks
 ```
 
@@ -27,6 +29,7 @@ src/
   types.rs                      – TextItem, TextLine, PdfRect, PdfLine
   tounicode.rs                  – CMap/ToUnicode parsing, CID decoding
   text_utils.rs                 – CJK/RTL handling, Otsu threshold, ligature expansion, NFKC
+  render.rs                     – optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/
     mod.rs                      – top-level extraction orchestrator
     content_stream.rs           – PDF operator state machine (Tj/TJ/Td/Tm/q/Q)
@@ -63,6 +66,8 @@ src/
 - **Integration tests**: `tests/integration_tests.rs` with fixture PDFs in `tests/fixtures/`.
 - **Regression suite**: sibling repo `pdf-evals` with ~200 snapshot PDFs. Run `cargo build --release` then `bench.py test` in that repo before committing. While iterating, prefer a subset run (`bench.py test -q` for the quick set, or `-s <name>` for a named test set) and save the full `bench.py test` for the final pre-commit check.
 - **Semantic quality**: run `bench.py score` in `pdf-evals` for the semantic verdict (TEDS + MHS + reading order + char/word + list preservation, composited). Character-level diff alone misclassifies structural improvements (e.g., column-detection rewrites) as regressions — `score` is the tie-breaker. See `pdf-evals/CLAUDE.md` "Semantic scoring".
+- **Render corpus**: pinned external `py-pdf/sample-files` render corpus, ignored by default; enable with `PDF_INSPECTOR_SAMPLE_FILES` (checksum-verified).
+- **WebAssembly runtime tests**: `wasm-pack test --node --release wasm` and `wasm-pack test --node --release wasm --features render`.
 
 ## Debugging
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ thiserror = "2.0"
 # Logging
 log = "0.4"
 
+# Optional pure-Rust PDF rasterization. Keep the embedded fallback assets so
+# OCR-routed pages also render when their fonts or CMaps are not embedded.
+hayro = { version = "0.7.1", optional = true, default-features = false, features = ["embed-fonts", "embed-cmaps"] }
+bytemuck = { version = "1.25", optional = true, default-features = false, features = ["extern_crate_alloc"] }
+
 # Text processing
 regex = "1.10"
 once_cell = "1.19"
@@ -57,11 +62,13 @@ lopdf = { version = "0.42.0", default-features = false, features = ["wasm_js"] }
 include_dir = "0.7"
 
 [dev-dependencies]
+sha2 = "0.10"
 tempfile = "3.3"
 
 [features]
 default = []
 python = ["pyo3"]
+render = ["dep:bytemuck", "dep:hayro"]
 
 [[bin]]
 name = "pdf2md"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Encoding issue detection** — Automatically flags broken font encodings so callers can fall back to OCR.
 - **Single document load** — The document is parsed once and shared between detection and extraction, avoiding redundant I/O.
 - **Browser WebAssembly** — Run the same Rust parser locally in browsers and Web Workers, with embedded CMaps and no server round trip.
-- **Lightweight** — Pure Rust, no ML models, no external services. Single dependency on `lopdf` for PDF parsing.
+- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Lightweight by default** — Pure Rust, no ML models, no external services. The default feature set keeps `lopdf` as its only PDF dependency.
 
 ## Benchmark
 
@@ -204,6 +205,7 @@ src/
   detector.rs           — Fast PDF type detection without full document load
   glyph_names.rs        — Adobe Glyph List → Unicode mapping
   tounicode.rs          — ToUnicode CMap parsing for CID-encoded text
+  render.rs             — optional selected-page RGBA rasterization ('render' feature, Hayro)
   extractor/            — Text extraction pipeline
   tables/               — Table detection and formatting
   markdown/             — Markdown conversion and structure detection

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Encoding issue detection** — Automatically flags broken font encodings so callers can fall back to OCR.
 - **Single document load** — The document is parsed once and shared between detection and extraction, avoiding redundant I/O.
 - **Browser WebAssembly** — Run the same Rust parser locally in browsers and Web Workers, with embedded CMaps and no server round trip.
-- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, on a wasm32-compatible backend (no JS API exposed yet).
+- **Optional rendering and image extraction** — Rasterize selected pages or return positioned image occurrences as bounded RGBA8 buffers, on a wasm32-compatible backend (no JS API exposed yet).
 - **Lightweight by default** — Pure Rust, no ML models, no external services. The default feature set keeps `lopdf` as its only PDF dependency.
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Encoding issue detection** — Automatically flags broken font encodings so callers can fall back to OCR.
 - **Single document load** — The document is parsed once and shared between detection and extraction, avoiding redundant I/O.
 - **Browser WebAssembly** — Run the same Rust parser locally in browsers and Web Workers, with embedded CMaps and no server round trip.
-- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Optional page rendering** — Rasterize only selected pages to bounded output RGBA8 buffers for local OCR pipelines, on a wasm32-compatible backend (no JS API exposed yet).
 - **Lightweight by default** — Pure Rust, no ML models, no external services. The default feature set keeps `lopdf` as its only PDF dependency.
 
 ## Benchmark

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -39,6 +39,50 @@ warm-up run; quality scores come from the benchmark evaluator over all 200
 outputs. Raw timings, predictions, evaluations, and charts are available in the
 [results branch](https://github.com/firecrawl/opendataloader-bench/tree/abi/pdf-parser-benchmark-results).
 
+## Optional renderer compatibility and timing
+
+Selected-page rendering has a separate ignored test over the external
+[`py-pdf/sample-files`](https://github.com/py-pdf/sample-files) corpus. The
+files are CC-BY-SA-4.0 and are not vendored into this MIT repository. The test
+pins commit `89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf` and verifies every selected
+file's SHA-256 digest before rendering it.
+
+```bash
+git clone https://github.com/py-pdf/sample-files.git ../sample-files
+git -C ../sample-files checkout 89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf
+
+PDF_INSPECTOR_SAMPLE_FILES=../sample-files \
+  cargo test --release --features render --test render_corpus_tests \
+  renders_pinned -- --ignored --nocapture
+```
+
+The cases cover structured text, image-only pages, CMYK images, page
+crop/rotation/scaling, repeated image references, and caller-ordered page
+selection. The printed per-file durations are a smoke-test aid, not directly
+comparable benchmark results. For reportable measurements, record the corpus
+revision, compiler, target, CPU, and peak memory; discard one warm-up and report
+the median of at least five release-profile runs at each tested DPI.
+
+### Reference rasterization measurements
+
+The following reference run used the checksum-verified
+`018-base64-image/base64image.pdf` input from the pinned corpus revision above.
+`pdf-inspector` classifies its only page as needing OCR. Measurements were made
+on macOS 26.6, an Apple M3 Pro (12 cores, 18 GB), with Rust 1.95.0. Each row is
+20 release-profile process runs after one discarded warm-up. Render time covers
+PDF cloning, parsing, and rasterization; peak RSS is for the complete test
+process. Nearest-rank p95 is reported.
+
+| DPI | Output | RGBA8 bytes | Median | p95 | Min–max | Sample SD | Median peak RSS | p95 peak RSS |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 150 | 1,240 x 1,753 | 8,694,880 | 7.286 ms | 7.821 ms | 6.876–9.268 ms | 0.503 ms | 30,408,704 B | 31,391,744 B |
+| 200 | 1,653 x 2,338 | 15,458,856 | 8.554 ms | 9.059 ms | 8.359–9.528 ms | 0.280 ms | 36,454,400 B | 37,404,672 B |
+| 300 | 2,480 x 3,507 | 34,789,440 | 11.985 ms | 12.723 ms | 11.817–12.942 ms | 0.370 ms | 59,817,984 B | 60,768,256 B |
+
+These figures measure rasterization only, not OCR inference. They should be
+treated as one-machine reference data, not a cross-platform performance claim.
+The returned RGBA8 buffer dominates the DPI-dependent memory increase.
+
 ## Optional backend evidence probe
 
 The evidence probe compares positioned `pdf2md` items with MuPDF structured

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -10,7 +10,7 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Markdown conversion** — headings, lists, code blocks, bold/italic, URL linking, and dual-mode table detection (PDF drawing ops + text-alignment heuristics).
 - **Layout-aware extraction** — multi-column reading order, position and font info per text item, RTL support.
 - **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
-- **Optional page rendering** — selected pages can be rasterized to bounded RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Optional rendering and image extraction** — selected pages or positioned image occurrences can be returned as bounded RGBA8 buffers, including for WebAssembly callers.
 - **Lightweight by default** — pure Rust, no ML models, no external services; the default feature set keeps [lopdf](https://crates.io/crates/lopdf) as its only PDF dependency.
 
 ## Benchmark
@@ -197,6 +197,44 @@ buffers from PDF resources. Until it exposes comprehensive internal resource
 limits, isolate untrusted rendering in a process or Web Worker with its own
 memory/input limits; output preflight alone is not an adversarial-PDF sandbox.
 
+The same feature can preserve an image's position in Markdown and return the
+pixels rendered at that position. Both outputs carry the same reference, so a
+caller does not need to match PDF resource names:
+
+```rust
+use pdf_inspector::{
+    extract_images_mem, process_pdf_mem_with_options, MarkdownOptions,
+    PdfOptions, RenderOptions,
+};
+
+let bytes = std::fs::read("report.pdf")?;
+let result = process_pdf_mem_with_options(
+    &bytes,
+    PdfOptions::new().markdown(MarkdownOptions {
+        include_images: true,
+        ..MarkdownOptions::default()
+    }),
+)?;
+let markdown = result.markdown.unwrap_or_default();
+
+for image in extract_images_mem(&bytes, RenderOptions::new().dpi(200.0))? {
+    // Markdown contains, for example:
+    // ![Image: Im0](pdf-image:p1_i1)
+    assert!(markdown.contains(&image.reference));
+
+    // Opaque, row-major RGBA8 pixels for this image occurrence.
+    save_png(image.width, image.height, &image.pixels);
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+# fn save_png(_: u32, _: u32, _: &[u8]) {}
+```
+
+`RenderedImage::page` is zero-based and `occurrence` is one-based within that
+page. Its `bbox` uses the source PDF's bottom-left coordinate space; `width`,
+`height`, and `pixels` describe the rendered crop after applying the page crop
+box and rotation. Repeated uses of one image resource are returned separately
+because each occurrence can have a different position or transform.
+
 Extract per-page Markdown (one string per page, plus document-wide layout
 metadata):
 
@@ -274,6 +312,7 @@ for item in extract_text_with_positions("tagged.pdf")? {
 | `extract_structure_elements(path, pages)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
 | `extract_structure_elements_mem(bytes, pages)` | Structure-tree elements from bytes |
 | `render_pages_mem(bytes, pages, options)` | Selected pages as bounded RGBA8 buffers (`render` feature) |
+| `extract_images_mem(bytes, options)` | Positioned image occurrences as bounded RGBA8 buffers joined to opt-in Markdown references (`render` feature) |
 
 Low-level detection functions are also available via the `detector` module (`detect_pdf_type`, `detect_pdf_type_with_config`, etc.) for callers who need `PdfTypeResult` instead of `PdfProcessResult`.
 
@@ -297,5 +336,6 @@ Low-level detection functions are also available via the `detector` module (`det
 | `PdfError` | `Io`, `Parse`, `Encrypted`, `InvalidStructure`, `NotAPdf` |
 | `RenderOptions` | DPI and optional password for selected-page rendering (`render` feature) |
 | `RenderedPage` | Zero-based source page, dimensions, and opaque RGBA8 pixels (`render` feature) |
+| `RenderedImage` | Stable Markdown reference, source page/bbox, dimensions, and rendered RGBA8 pixels (`render` feature) |
 | `RenderError` | Typed parse, password, page-selection, and resource-limit failures (`render` feature) |
 | `RenderWarning` | Per-page unsupported-font or image-decode fidelity warning (`render` feature) |

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -1,6 +1,6 @@
 # pdf-inspector
 
-Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Pure Rust, no ML models, no external services; the only PDF dependency is [lopdf](https://crates.io/crates/lopdf). Also available for [Python](https://pypi.org/project/pdf-inspector/) and [Node.js](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
+Fast PDF classification and text extraction. Detects whether a PDF is text-based or scanned, extracts text with position awareness, and converts to clean Markdown — all without OCR. Pure Rust, no ML models, and no external services; the default feature set uses [lopdf](https://crates.io/crates/lopdf), while an opt-in feature adds selected-page rasterization. Also available for [Python](https://pypi.org/project/pdf-inspector/) and [Node.js](https://www.npmjs.com/package/@firecrawl/pdf-inspector).
 
 Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in under 200ms, skipping expensive OCR services for the ~54% of PDFs that don't need them.
 
@@ -10,7 +10,8 @@ Built by [Firecrawl](https://firecrawl.dev) to handle text-based PDFs locally in
 - **Markdown conversion** — headings, lists, code blocks, bold/italic, URL linking, and dual-mode table detection (PDF drawing ops + text-alignment heuristics).
 - **Layout-aware extraction** — multi-column reading order, position and font info per text item, RTL support.
 - **Robust text decoding** — CID/Type0 fonts via ToUnicode CMaps, plus automatic flagging of broken encodings so callers can fall back to OCR.
-- **Lightweight** — pure Rust, no ML models, no external services; single PDF dependency ([lopdf](https://crates.io/crates/lopdf)).
+- **Optional page rendering** — selected pages can be rasterized to bounded RGBA8 buffers for local OCR pipelines, including WebAssembly callers.
+- **Lightweight by default** — pure Rust, no ML models, no external services; the default feature set keeps [lopdf](https://crates.io/crates/lopdf) as its only PDF dependency.
 
 ## Benchmark
 
@@ -117,6 +118,85 @@ let bytes = std::fs::read("document.pdf")?;
 let result = process_pdf_mem(&bytes)?;
 ```
 
+### Optional selected-page rendering
+
+Enable the non-default `render` feature when an OCR pipeline needs pixels for
+pages already identified by `pages_needing_ocr`:
+
+```bash
+cargo add pdf-inspector --features render
+```
+
+```rust
+use pdf_inspector::{classify_pdf_mem, render_pages_mem, RenderOptions, RenderWarning};
+
+let bytes = std::fs::read("scan.pdf")?;
+let classification = classify_pdf_mem(&bytes)?;
+
+// PdfClassification uses the renderer's zero-based page indexes. Only pages
+// routed to OCR are rasterized, in caller-supplied order.
+if !classification.pages_needing_ocr.is_empty() {
+    let pages = render_pages_mem(
+        &bytes,
+        &classification.pages_needing_ocr,
+        RenderOptions::new().dpi(200.0),
+    )?;
+
+    for page in pages {
+        if page.warnings.contains(&RenderWarning::ImageDecodeFailure) {
+            // Do not OCR pixels from an image resource that failed to decode.
+            continue;
+        }
+        // Opaque, row-major RGBA8 pixels on a white background.
+        run_ocr(page.width, page.height, &page.pixels);
+    }
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+# fn run_ocr(_: u32, _: u32, _: &[u8]) {}
+```
+
+Do not pass `PdfProcessResult::pages_needing_ocr` directly: that high-level
+field is one-based for display, while `PdfClassification::pages_needing_ocr`,
+`PageMarkdown::page`, and `render_pages_mem` are zero-based.
+
+Even with an empty page list, `render_pages_mem` still copies and parses the
+PDF, so integrators must skip the call entirely on the no-OCR fast path.
+
+The renderer is CPU-only and byte-oriented, with no filesystem access, and
+compiles for `wasm32-unknown-unknown`. It is intentionally not enabled in the
+default feature set. The `render` feature currently requires Rust 1.92 because
+of its rendering backend; default builds keep the existing compiler behavior.
+
+Every request's output viewport and returned buffers are validated before the
+first page is rendered:
+
+| Limit | Value |
+|---|---:|
+| Default DPI | 200 |
+| Maximum DPI | 300 |
+| Maximum width or height | 16,384 px |
+| Maximum pixels per page | 25,000,000 |
+| Maximum combined RGBA8 output | 100,000,000 bytes |
+| Maximum page entries per call | 1,024 |
+
+For large scanned documents, render small batches and release each page buffer
+after OCR instead of retaining the whole document in memory. Rendering handles
+common page crops, rotations, transforms, images, and soft masks before
+returning pixels. Each page also carries typed warnings for unsupported fonts
+and failed image decoding; an image-decode warning means its pixels must not be
+silently accepted as OCR input.
+
+The optional backend is still evolving. Hayro 0.7.1 documents missing or
+incomplete support for blending and isolation, knockout groups, and color-key
+masking. Preserve a fallback for documents it cannot render faithfully, even
+when no interpreter warning is available for that unsupported construct.
+
+These limits bound output dimensions and returned RGBA memory. The current
+backend can still allocate internal image-decoder and compositing scratch
+buffers from PDF resources. Until it exposes comprehensive internal resource
+limits, isolate untrusted rendering in a process or Web Worker with its own
+memory/input limits; output preflight alone is not an adversarial-PDF sandbox.
+
 Extract per-page Markdown (one string per page, plus document-wide layout
 metadata):
 
@@ -193,6 +273,7 @@ for item in extract_text_with_positions("tagged.pdf")? {
 | `extract_pages_markdown_mem(bytes, pages)` | Per-page Markdown from bytes |
 | `extract_structure_elements(path, pages)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
 | `extract_structure_elements_mem(bytes, pages)` | Structure-tree elements from bytes |
+| `render_pages_mem(bytes, pages, options)` | Selected pages as bounded RGBA8 buffers (`render` feature) |
 
 Low-level detection functions are also available via the `detector` module (`detect_pdf_type`, `detect_pdf_type_with_config`, etc.) for callers who need `PdfTypeResult` instead of `PdfProcessResult`.
 
@@ -214,3 +295,7 @@ Low-level detection functions are also available via the `detector` module (`det
 | `PageMarkdown` | Per-page result: page (0-indexed), markdown, needs_ocr |
 | `PagesExtractionResult` | Per-page output + 1-indexed pages_with_tables / pages_with_columns / pages_needing_ocr, is_complex |
 | `PdfError` | `Io`, `Parse`, `Encrypted`, `InvalidStructure`, `NotAPdf` |
+| `RenderOptions` | DPI and optional password for selected-page rendering (`render` feature) |
+| `RenderedPage` | Zero-based source page, dimensions, and opaque RGBA8 pixels (`render` feature) |
+| `RenderError` | Typed parse, password, page-selection, and resource-limit failures (`render` feature) |
+| `RenderWarning` | Per-page unsupported-font or image-decode fidelity warning (`render` feature) |

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -145,6 +145,47 @@ pub(crate) fn extract_text_with_positions_mem_and_rects(
     Ok(extraction)
 }
 
+/// Extract image placements in unmodified PDF user-space coordinates.
+///
+/// The general text pipeline may normalize a landscape page's coordinates for
+/// reading order. Rendering needs the original coordinates so the page's own
+/// crop and rotation transform can map each placement to pixels exactly.
+#[cfg(feature = "render")]
+pub(crate) fn extract_image_items_mem_with_password(
+    buffer: &[u8],
+    password: Option<&str>,
+) -> Result<Vec<TextItem>, PdfError> {
+    crate::validate_pdf_bytes(buffer)?;
+    let (doc, _) = crate::load_document_from_mem_with_password(buffer, password)?;
+    let font_cmaps = FontCMaps::from_doc(&doc);
+    let mut style_cache = FontStyleCache::new();
+    let mut images = Vec::new();
+
+    for (page_num, page_id) in doc.get_pages() {
+        let ((items, _, _), _, coords_rotated, _) = extract_page_text_items(
+            &doc,
+            page_id,
+            page_num,
+            &font_cmaps,
+            false,
+            &mut style_cache,
+        )?;
+        images.extend(items.into_iter().filter_map(|mut item| {
+            if !matches!(item.item_type, crate::types::ItemType::Image) {
+                return None;
+            }
+            if coords_rotated {
+                let normalized_x = item.x;
+                item.x = -item.y;
+                item.y = normalized_x;
+            }
+            Some(item)
+        }));
+    }
+
+    Ok(images)
+}
+
 // ---------------------------------------------------------------------------
 // Orchestration
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@ pub use markdown::{
 pub use process_mode::ProcessMode;
 #[cfg(feature = "render")]
 pub use render::{
-    render_pages_mem, RenderError, RenderOptions, RenderWarning, RenderedPage, DEFAULT_RENDER_DPI,
-    MAX_RENDER_DIMENSION, MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
-    MAX_RENDER_PIXELS_PER_PAGE,
+    extract_images_mem, render_pages_mem, RenderError, RenderOptions, RenderWarning, RenderedImage,
+    RenderedPage, DEFAULT_RENDER_DPI, MAX_RENDER_DIMENSION, MAX_RENDER_DPI,
+    MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST, MAX_RENDER_PIXELS_PER_PAGE,
 };
 pub use types::{LayoutComplexity, PdfLine, PdfRect, TextItem};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@
 #[cfg(feature = "python")]
 pub mod python;
 
+#[cfg(feature = "render")]
+mod render;
+
 pub mod adobe_korea1;
 pub mod detector;
 pub mod extractor;
@@ -57,6 +60,12 @@ pub use markdown::{
     to_markdown_from_items_with_rects_and_page_count, MarkdownOptions, MarkdownProfile,
 };
 pub use process_mode::ProcessMode;
+#[cfg(feature = "render")]
+pub use render::{
+    render_pages_mem, RenderError, RenderOptions, RenderWarning, RenderedPage, DEFAULT_RENDER_DPI,
+    MAX_RENDER_DIMENSION, MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
+    MAX_RENDER_PIXELS_PER_PAGE,
+};
 pub use types::{LayoutComplexity, PdfLine, PdfRect, TextItem};
 
 use lopdf::Document;

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -971,7 +971,7 @@ impl Default for MarkdownOptions {
             // now emits `ItemType::Image` `TextItem`s for every Image XObject
             // it encounters (see `extractor/content_stream.rs`). If we rendered
             // those into markdown by default, every existing caller would
-            // suddenly see `![Image: Im0](image)` placeholders inserted
+            // suddenly see `![Image: Im0](pdf-image:p1_i1)` references inserted
             // throughout their output — a silent regression for anyone who
             // upgrades. Image bboxes are still available via
             // `extract_text_with_positions` for callers (e.g. layout-aware
@@ -1142,7 +1142,8 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     let removed_page_number_pages = prefiltered_page_number_pages.cloned().unwrap_or_default();
 
     // Separate images and links from text items
-    let mut images: Vec<TextItem> = Vec::new();
+    let mut images: Vec<(TextItem, String)> = Vec::new();
+    let mut image_occurrences: HashMap<u32, u32> = HashMap::new();
     let mut page_image_regions: HashMap<u32, Vec<(f32, f32, f32, f32)>> = HashMap::new();
     let mut links: Vec<TextItem> = Vec::new();
     let mut text_items: Vec<TextItem> = Vec::new();
@@ -1158,7 +1159,10 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                     item.y + item.height,
                 ));
                 if options.include_images {
-                    images.push(item);
+                    let occurrence = image_occurrences.entry(item.page).or_default();
+                    *occurrence += 1;
+                    let reference = crate::types::image_reference(item.page, *occurrence);
+                    images.push((item, reference));
                 }
             }
             ItemType::Link(_) => {
@@ -1724,13 +1728,13 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     // Images are also removed before line grouping, so give them the same
     // logical chart-page position as tables before reinsertion.
     let mut page_images: HashMap<u32, Vec<PositionedMarkdown>> = HashMap::new();
-    for img in &images {
+    for (img, reference) in &images {
         let img_name = img
             .text
             .strip_prefix("[Image: ")
             .and_then(|s| s.strip_suffix(']'))
             .unwrap_or(&img.text);
-        let img_md = format!("![Image: {}](image)\n", img_name);
+        let img_md = format!("![Image: {}]({})\n", img_name, reference);
         page_images
             .entry(img.page)
             .or_default()

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,6 +4,7 @@ use hayro::hayro_interpret::{InterpreterSettings, InterpreterWarning};
 use hayro::hayro_syntax::{LoadPdfError, Pdf};
 use hayro::vello_cpu::color::palette::css::WHITE;
 use hayro::{render, RenderCache, RenderSettings};
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 /// Default DPI for page rasterization
@@ -91,6 +92,34 @@ pub struct RenderedPage {
     pub warnings: Vec<RenderWarning>,
 }
 
+/// One image occurrence cropped from a rendered PDF page.
+///
+/// [`reference`](Self::reference) is the same URI emitted by Markdown when
+/// [`crate::MarkdownOptions::include_images`] is enabled, so callers can join
+/// the Markdown position to these pixels without matching resource names.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct RenderedImage {
+    /// Stable reference emitted in Markdown, for example `pdf-image:p1_i1`.
+    pub reference: String,
+    /// PDF XObject resource name, useful for diagnostics only.
+    pub resource_name: String,
+    /// Zero-based page index in the source PDF.
+    pub page: u32,
+    /// One-based image occurrence within the page, in content-stream order.
+    pub occurrence: u32,
+    /// Source placement as `[x, y, width, height]` in PDF points.
+    pub bbox: [f32; 4],
+    /// Width of the cropped output in pixels.
+    pub width: u32,
+    /// Height of the cropped output in pixels.
+    pub height: u32,
+    /// Opaque row-major RGBA8 pixels on a white background.
+    pub pixels: Vec<u8>,
+    /// Non-fatal warnings raised while rendering the containing page.
+    pub warnings: Vec<RenderWarning>,
+}
+
 /// A non-fatal issue reported while interpreting one rendered page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -99,6 +128,16 @@ pub enum RenderWarning {
     UnsupportedFont,
     /// An image failed to decode, its pixels may be missing
     ImageDecodeFailure,
+}
+
+impl RenderWarning {
+    /// Stable machine-readable identifier for bindings and logs.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::UnsupportedFont => "unsupported_font",
+            Self::ImageDecodeFailure => "image_decode_failure",
+        }
+    }
 }
 
 fn map_interpreter_warning(warning: InterpreterWarning) -> RenderWarning {
@@ -160,6 +199,10 @@ pub enum RenderError {
     /// The renderer returned a pixel buffer with an unexpected memory layout
     #[error("renderer returned an unsupported pixel-buffer layout")]
     PixelBufferLayout,
+
+    /// An extracted image placement cannot be mapped into its rendered page.
+    #[error("image {reference} has invalid page bounds")]
+    InvalidImageBounds { reference: String },
 }
 
 impl From<LoadPdfError> for RenderError {
@@ -176,6 +219,24 @@ struct PreparedPage {
     page: u32,
     width: u16,
     height: u16,
+    /// PDF user space to rendered pixel space, including crop and rotation.
+    transform: [f64; 6],
+}
+
+#[derive(Clone, Copy)]
+struct PixelBounds {
+    left: u32,
+    right: u32,
+    top: u32,
+    bottom: u32,
+}
+
+struct PreparedImage {
+    reference: String,
+    resource_name: String,
+    occurrence: u32,
+    bbox: [f32; 4],
+    bounds: PixelBounds,
 }
 
 /// Rasterize the selected pages of a PDF into opaque RGBA8 buffers.
@@ -205,61 +266,263 @@ pub fn render_pages_mem(
     let mut rendered_pages = Vec::with_capacity(prepared.len());
 
     for prepared_page in prepared {
-        // prepare_pages already validated every index against this same PDF,
-        // but better to not have any indexing panic here anyway.
-        let page =
-            pdf.pages()
-                .get(prepared_page.page as usize)
-                .ok_or(RenderError::PageOutOfRange {
-                    page: prepared_page.page,
-                    page_count: pdf.pages().len(),
-                })?;
-        let warnings = Arc::new(Mutex::new(Vec::new()));
-        let warning_sink = Arc::clone(&warnings);
-        let interpreter_settings = InterpreterSettings {
-            warning_sink: Arc::new(move |warning| {
-                let mut warnings = warning_sink
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let warning = map_interpreter_warning(warning);
-                if !warnings.contains(&warning) {
-                    warnings.push(warning);
-                }
-            }),
-            ..InterpreterSettings::default()
-        };
-        let pixmap = render(
-            page,
-            &cache,
-            &interpreter_settings,
-            &RenderSettings {
-                x_scale: scale,
-                y_scale: scale,
-                width: Some(prepared_page.width),
-                height: Some(prepared_page.height),
-                bg_color: WHITE,
-            },
-        );
-
-        let width = u32::from(pixmap.width());
-        let height = u32::from(pixmap.height());
-        let pixels = bytemuck::allocation::try_cast_vec(pixmap.take())
-            .map_err(|_| RenderError::PixelBufferLayout)?;
-        let warnings = warnings
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-
-        rendered_pages.push(RenderedPage {
-            page: prepared_page.page,
-            width,
-            height,
-            pixels,
-            warnings,
-        });
+        rendered_pages.push(render_prepared_page(&pdf, &cache, prepared_page, scale)?);
     }
 
     Ok(rendered_pages)
+}
+
+/// Extract every positioned Image XObject as rendered RGBA8 pixels.
+///
+/// Each result carries a stable `pdf-image:...` reference. Enable
+/// [`crate::MarkdownOptions::include_images`] when generating Markdown to emit
+/// the same reference at the image's reading-order position.
+///
+/// Images are rendered as they appear on the page, so masks, clipping and PDF
+/// stream encodings are resolved before the pixels reach the caller. Repeated
+/// placements remain separate results because their page positions may differ.
+pub fn extract_images_mem(
+    pdf_bytes: &[u8],
+    options: RenderOptions,
+) -> Result<Vec<RenderedImage>, RenderError> {
+    let image_items = crate::extractor::extract_image_items_mem_with_password(
+        pdf_bytes,
+        options.password.as_deref(),
+    )
+    .map_err(|error| match error {
+        crate::PdfError::Encrypted => RenderError::Encrypted,
+        _ => RenderError::Parse,
+    })?;
+    let image_count = image_items.len();
+    let mut image_items_by_page = BTreeMap::<u32, Vec<_>>::new();
+    for item in image_items {
+        image_items_by_page
+            .entry(item.page - 1)
+            .or_default()
+            .push(item);
+    }
+    let pages: Vec<_> = image_items_by_page.keys().copied().collect();
+    validate_options(&pages, &options)?;
+    if pages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let pdf = Pdf::new_with_password(
+        pdf_bytes.to_vec(),
+        options.password.as_deref().unwrap_or(""),
+    )?;
+    let scale = options.dpi / 72.0;
+    let prepared_pages = pages
+        .iter()
+        .map(|&page| prepare_page(&pdf, page, scale).map(|(prepared, _)| prepared))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut prepared_images = BTreeMap::<u32, Vec<PreparedImage>>::new();
+    let mut output_bytes = 0_u64;
+    for page in &prepared_pages {
+        let items = image_items_by_page
+            .remove(&page.page)
+            .expect("each prepared image page came from extracted items");
+        let mut page_images = Vec::with_capacity(items.len());
+        for (index, item) in items.into_iter().enumerate() {
+            let occurrence = index as u32 + 1;
+            let reference = crate::types::image_reference(item.page, occurrence);
+            let bbox = [item.x, item.y, item.width, item.height];
+            let bounds = image_pixel_bounds(page, bbox, &reference)?;
+            let bytes = u64::from(bounds.right - bounds.left)
+                .checked_mul(u64::from(bounds.bottom - bounds.top))
+                .and_then(|pixels| pixels.checked_mul(4))
+                .ok_or(RenderError::OutputTooLarge {
+                    bytes: u64::MAX,
+                    max: MAX_RENDER_OUTPUT_BYTES,
+                })?;
+            output_bytes = output_bytes
+                .checked_add(bytes)
+                .ok_or(RenderError::OutputTooLarge {
+                    bytes: u64::MAX,
+                    max: MAX_RENDER_OUTPUT_BYTES,
+                })?;
+            if output_bytes > MAX_RENDER_OUTPUT_BYTES {
+                return Err(RenderError::OutputTooLarge {
+                    bytes: output_bytes,
+                    max: MAX_RENDER_OUTPUT_BYTES,
+                });
+            }
+            let resource_name = item
+                .text
+                .strip_prefix("[Image: ")
+                .and_then(|text| text.strip_suffix(']'))
+                .unwrap_or(&item.text)
+                .to_string();
+            page_images.push(PreparedImage {
+                reference,
+                resource_name,
+                occurrence,
+                bbox,
+                bounds,
+            });
+        }
+        prepared_images.insert(page.page, page_images);
+    }
+
+    let cache = RenderCache::new();
+    let mut images = Vec::with_capacity(image_count);
+    for page in prepared_pages {
+        let rendered = render_prepared_page(&pdf, &cache, page, scale)?;
+        for image in prepared_images
+            .remove(&page.page)
+            .expect("each prepared page has image regions")
+        {
+            let (width, height, pixels) = crop_rgba(&rendered, image.bounds);
+            images.push(RenderedImage {
+                reference: image.reference,
+                resource_name: image.resource_name,
+                page: page.page,
+                occurrence: image.occurrence,
+                bbox: image.bbox,
+                width,
+                height,
+                pixels,
+                warnings: rendered.warnings.clone(),
+            });
+        }
+    }
+
+    Ok(images)
+}
+
+fn render_prepared_page<'a>(
+    pdf: &'a Pdf,
+    cache: &RenderCache<'a>,
+    prepared: PreparedPage,
+    scale: f32,
+) -> Result<RenderedPage, RenderError> {
+    // Preparation already validated every index against this same PDF.
+    let page = pdf
+        .pages()
+        .get(prepared.page as usize)
+        .ok_or(RenderError::PageOutOfRange {
+            page: prepared.page,
+            page_count: pdf.pages().len(),
+        })?;
+    let warnings = Arc::new(Mutex::new(Vec::new()));
+    let warning_sink = Arc::clone(&warnings);
+    let interpreter_settings = InterpreterSettings {
+        warning_sink: Arc::new(move |warning| {
+            let mut warnings = warning_sink
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let warning = map_interpreter_warning(warning);
+            if !warnings.contains(&warning) {
+                warnings.push(warning);
+            }
+        }),
+        ..InterpreterSettings::default()
+    };
+    let pixmap = render(
+        page,
+        cache,
+        &interpreter_settings,
+        &RenderSettings {
+            x_scale: scale,
+            y_scale: scale,
+            width: Some(prepared.width),
+            height: Some(prepared.height),
+            bg_color: WHITE,
+        },
+    );
+
+    let width = u32::from(pixmap.width());
+    let height = u32::from(pixmap.height());
+    let pixels = bytemuck::allocation::try_cast_vec(pixmap.take())
+        .map_err(|_| RenderError::PixelBufferLayout)?;
+    let warnings = warnings
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+
+    Ok(RenderedPage {
+        page: prepared.page,
+        width,
+        height,
+        pixels,
+        warnings,
+    })
+}
+
+fn image_pixel_bounds(
+    page: &PreparedPage,
+    [x, y, width, height]: [f32; 4],
+    reference: &str,
+) -> Result<PixelBounds, RenderError> {
+    let point = |x: f32, y: f32| {
+        (
+            page.transform[0] * f64::from(x) + page.transform[2] * f64::from(y) + page.transform[4],
+            page.transform[1] * f64::from(x) + page.transform[3] * f64::from(y) + page.transform[5],
+        )
+    };
+    let corners = [
+        point(x, y),
+        point(x + width, y),
+        point(x + width, y + height),
+        point(x, y + height),
+    ];
+    let left = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::INFINITY, f64::min)
+        .floor();
+    let right = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .ceil();
+    let top = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::INFINITY, f64::min)
+        .floor();
+    let bottom = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .ceil();
+    if ![left, right, top, bottom]
+        .iter()
+        .all(|value| value.is_finite())
+    {
+        return Err(RenderError::InvalidImageBounds {
+            reference: reference.to_string(),
+        });
+    }
+
+    let left = left.clamp(0.0, f64::from(page.width)) as u32;
+    let right = right.clamp(0.0, f64::from(page.width)) as u32;
+    let top = top.clamp(0.0, f64::from(page.height)) as u32;
+    let bottom = bottom.clamp(0.0, f64::from(page.height)) as u32;
+    if left >= right || top >= bottom {
+        return Err(RenderError::InvalidImageBounds {
+            reference: reference.to_string(),
+        });
+    }
+
+    Ok(PixelBounds {
+        left,
+        right,
+        top,
+        bottom,
+    })
+}
+
+fn crop_rgba(page: &RenderedPage, bounds: PixelBounds) -> (u32, u32, Vec<u8>) {
+    let crop_width = bounds.right - bounds.left;
+    let crop_height = bounds.bottom - bounds.top;
+    let row_bytes = crop_width as usize * 4;
+    let mut pixels = Vec::with_capacity(row_bytes * crop_height as usize);
+    for row in bounds.top..bounds.bottom {
+        let start = (row as usize * page.width as usize + bounds.left as usize) * 4;
+        pixels.extend_from_slice(&page.pixels[start..start + row_bytes]);
+    }
+    (crop_width, crop_height, pixels)
 }
 
 fn validate_options(pages: &[u32], options: &RenderOptions) -> Result<(), RenderError> {
@@ -281,55 +544,11 @@ fn validate_options(pages: &[u32], options: &RenderOptions) -> Result<(), Render
 }
 
 fn prepare_pages(pdf: &Pdf, pages: &[u32], scale: f32) -> Result<Vec<PreparedPage>, RenderError> {
-    let page_count = pdf.pages().len();
     let mut total_bytes = 0_u64;
     let mut prepared = Vec::with_capacity(pages.len());
 
     for &page_index in pages {
-        let page = pdf
-            .pages()
-            .get(page_index as usize)
-            .ok_or(RenderError::PageOutOfRange {
-                page: page_index,
-                page_count,
-            })?;
-        let (width_points, height_points) = page.render_dimensions();
-        let (width, height) = scaled_dimensions(width_points, height_points, scale).ok_or(
-            RenderError::InvalidPageDimensions {
-                page: page_index,
-                width_points,
-                height_points,
-            },
-        )?;
-
-        if width > u64::from(MAX_RENDER_DIMENSION) || height > u64::from(MAX_RENDER_DIMENSION) {
-            return Err(RenderError::PageDimensionsTooLarge {
-                page: page_index,
-                width,
-                height,
-                max: MAX_RENDER_DIMENSION,
-            });
-        }
-
-        let pixels = width
-            .checked_mul(height)
-            .ok_or(RenderError::PagePixelsTooLarge {
-                page: page_index,
-                pixels: u64::MAX,
-                max: MAX_RENDER_PIXELS_PER_PAGE,
-            })?;
-        if pixels > MAX_RENDER_PIXELS_PER_PAGE {
-            return Err(RenderError::PagePixelsTooLarge {
-                page: page_index,
-                pixels,
-                max: MAX_RENDER_PIXELS_PER_PAGE,
-            });
-        }
-
-        let page_bytes = pixels.checked_mul(4).ok_or(RenderError::OutputTooLarge {
-            bytes: u64::MAX,
-            max: MAX_RENDER_OUTPUT_BYTES,
-        })?;
+        let (page, page_bytes) = prepare_page(pdf, page_index, scale)?;
         total_bytes = total_bytes
             .checked_add(page_bytes)
             .ok_or(RenderError::OutputTooLarge {
@@ -342,15 +561,78 @@ fn prepare_pages(pdf: &Pdf, pages: &[u32], scale: f32) -> Result<Vec<PreparedPag
                 max: MAX_RENDER_OUTPUT_BYTES,
             });
         }
-
-        prepared.push(PreparedPage {
-            page: page_index,
-            width: width as u16,
-            height: height as u16,
-        });
+        prepared.push(page);
     }
 
     Ok(prepared)
+}
+
+fn prepare_page(
+    pdf: &Pdf,
+    page_index: u32,
+    scale: f32,
+) -> Result<(PreparedPage, u64), RenderError> {
+    let page = pdf
+        .pages()
+        .get(page_index as usize)
+        .ok_or(RenderError::PageOutOfRange {
+            page: page_index,
+            page_count: pdf.pages().len(),
+        })?;
+    let (width_points, height_points) = page.render_dimensions();
+    let (width, height) = scaled_dimensions(width_points, height_points, scale).ok_or(
+        RenderError::InvalidPageDimensions {
+            page: page_index,
+            width_points,
+            height_points,
+        },
+    )?;
+    if width > u64::from(MAX_RENDER_DIMENSION) || height > u64::from(MAX_RENDER_DIMENSION) {
+        return Err(RenderError::PageDimensionsTooLarge {
+            page: page_index,
+            width,
+            height,
+            max: MAX_RENDER_DIMENSION,
+        });
+    }
+
+    let pixels = width
+        .checked_mul(height)
+        .ok_or(RenderError::PagePixelsTooLarge {
+            page: page_index,
+            pixels: u64::MAX,
+            max: MAX_RENDER_PIXELS_PER_PAGE,
+        })?;
+    if pixels > MAX_RENDER_PIXELS_PER_PAGE {
+        return Err(RenderError::PagePixelsTooLarge {
+            page: page_index,
+            pixels,
+            max: MAX_RENDER_PIXELS_PER_PAGE,
+        });
+    }
+    let page_bytes = pixels.checked_mul(4).ok_or(RenderError::OutputTooLarge {
+        bytes: u64::MAX,
+        max: MAX_RENDER_OUTPUT_BYTES,
+    })?;
+    let transform = page.initial_transform(true).as_coeffs();
+    let transform = [
+        transform[0] * f64::from(scale),
+        transform[1] * f64::from(scale),
+        transform[2] * f64::from(scale),
+        transform[3] * f64::from(scale),
+        transform[4] * f64::from(scale),
+        transform[5] * f64::from(scale),
+    ];
+
+    Ok((
+        PreparedPage {
+            page: page_index,
+            width: width as u16,
+            height: height as u16,
+            transform,
+        },
+        page_bytes,
+    ))
 }
 
 fn scaled_dimensions(width_points: f32, height_points: f32, scale: f32) -> Option<(u64, u64)> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,390 @@
+//! Optional PDF page rasterization with bounded output buffers.
+
+use hayro::hayro_interpret::{InterpreterSettings, InterpreterWarning};
+use hayro::hayro_syntax::{LoadPdfError, Pdf};
+use hayro::vello_cpu::color::palette::css::WHITE;
+use hayro::{render, RenderCache, RenderSettings};
+use std::sync::{Arc, Mutex};
+
+/// Default DPI for page rasterization
+pub const DEFAULT_RENDER_DPI: f32 = 200.0;
+
+/// Hard cap on the requested DPI
+pub const MAX_RENDER_DPI: f32 = 300.0;
+
+/// Max output width or height, in pixels
+pub const MAX_RENDER_DIMENSION: u32 = 16_384;
+
+/// Max output area for a single page
+pub const MAX_RENDER_PIXELS_PER_PAGE: u64 = 25_000_000;
+
+/// Max combined RGBA8 bytes for one call
+pub const MAX_RENDER_OUTPUT_BYTES: u64 = 100_000_000;
+
+/// Max page entries for one call. Duplicates count separately, since
+/// each entry produce its own buffer: for big documents is better to
+/// render in batches and release the buffers in between.
+pub const MAX_RENDER_PAGES_PER_REQUEST: usize = 1_024;
+
+/// Options for [`render_pages_mem`].
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct RenderOptions {
+    /// Output DPI. Must be finite, positive and at most [`MAX_RENDER_DPI`].
+    pub dpi: f32,
+    /// Password for an encrypted PDF
+    pub password: Option<String>,
+}
+
+impl std::fmt::Debug for RenderOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderOptions")
+            .field("dpi", &self.dpi)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            dpi: DEFAULT_RENDER_DPI,
+            password: None,
+        }
+    }
+}
+
+impl RenderOptions {
+    /// Default options at 200 DPI
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the output DPI
+    pub fn dpi(mut self, dpi: f32) -> Self {
+        self.dpi = dpi;
+        self
+    }
+
+    /// Set the password for an encrypted PDF
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+}
+
+/// One rasterized PDF page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RenderedPage {
+    /// Zero-based page index in the source PDF
+    pub page: u32,
+    /// Width in pixels
+    pub width: u32,
+    /// Height in pixels
+    pub height: u32,
+    /// Opaque row-major RGBA8, white background
+    pub pixels: Vec<u8>,
+    /// Non-fatal interpreter warnings for this page. An
+    /// [`RenderWarning::ImageDecodeFailure`] means the pixels are not safe
+    /// to OCR without an independent check.
+    pub warnings: Vec<RenderWarning>,
+}
+
+/// A non-fatal issue reported while interpreting one rendered page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RenderWarning {
+    /// The page uses a font kind we can't draw, glyphs may be missing
+    UnsupportedFont,
+    /// An image failed to decode, its pixels may be missing
+    ImageDecodeFailure,
+}
+
+fn map_interpreter_warning(warning: InterpreterWarning) -> RenderWarning {
+    match warning {
+        InterpreterWarning::UnsupportedFont => RenderWarning::UnsupportedFont,
+        InterpreterWarning::ImageDecodeFailure => RenderWarning::ImageDecodeFailure,
+    }
+}
+
+/// An error returned while rasterizing PDF pages.
+#[derive(Debug, thiserror::Error, PartialEq)]
+#[non_exhaustive]
+pub enum RenderError {
+    /// The requested DPI is zero, negative, non-finite, or above the hard cap
+    #[error("render DPI must be finite and greater than 0 and at most {max}, got {dpi}")]
+    InvalidDpi { dpi: f32, max: f32 },
+
+    /// Too many page entries were requested in one call
+    #[error("requested {requested} page entries, maximum is {max}")]
+    TooManyPages { requested: usize, max: usize },
+
+    /// The PDF is encrypted or the supplied password is not accepted
+    #[error("PDF is encrypted or the password is invalid")]
+    Encrypted,
+
+    /// The input could not be parsed as a PDF
+    #[error("PDF parsing error")]
+    Parse,
+
+    /// A requested zero-based page index does not exist
+    #[error("page index {page} is out of range for a PDF with {page_count} pages")]
+    PageOutOfRange { page: u32, page_count: usize },
+
+    /// A page has missing, non-finite, non-positive, or sub-pixel dimensions
+    #[error("page {page} has invalid render dimensions {width_points} x {height_points} points")]
+    InvalidPageDimensions {
+        page: u32,
+        width_points: f32,
+        height_points: f32,
+    },
+
+    /// A scaled page width or height exceeds the hard cap
+    #[error("page {page} would render at {width} x {height} pixels, maximum dimension is {max}")]
+    PageDimensionsTooLarge {
+        page: u32,
+        width: u64,
+        height: u64,
+        max: u32,
+    },
+
+    /// A page's output area exceeds the hard cap
+    #[error("page {page} would contain {pixels} pixels, maximum is {max}")]
+    PagePixelsTooLarge { page: u32, pixels: u64, max: u64 },
+
+    /// The combined RGBA8 output would exceed the hard cap
+    #[error("rendered output would require {bytes} bytes, maximum is {max}")]
+    OutputTooLarge { bytes: u64, max: u64 },
+
+    /// The renderer returned a pixel buffer with an unexpected memory layout
+    #[error("renderer returned an unsupported pixel-buffer layout")]
+    PixelBufferLayout,
+}
+
+impl From<LoadPdfError> for RenderError {
+    fn from(error: LoadPdfError) -> Self {
+        match error {
+            LoadPdfError::Decryption(_) => Self::Encrypted,
+            LoadPdfError::Invalid => Self::Parse,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PreparedPage {
+    page: u32,
+    width: u16,
+    height: u16,
+}
+
+/// Rasterize the selected pages of a PDF into opaque RGBA8 buffers.
+///
+/// `pages` holds zero-based indexes; results keep the caller order and
+/// the duplicates. Everything (every page, the whole output budget) is
+/// validated before the first page renders. An empty selection still
+/// parses the PDF and returns an empty vec.
+///
+/// Only available with the `render` feature. CPU-only, no filesystem,
+/// so it compiles for `wasm32-unknown-unknown` too.
+pub fn render_pages_mem(
+    pdf_bytes: &[u8],
+    pages: &[u32],
+    options: RenderOptions,
+) -> Result<Vec<RenderedPage>, RenderError> {
+    validate_options(pages, &options)?;
+
+    let pdf = Pdf::new_with_password(
+        pdf_bytes.to_vec(),
+        options.password.as_deref().unwrap_or(""),
+    )?;
+    let scale = options.dpi / 72.0;
+    let prepared = prepare_pages(&pdf, pages, scale)?;
+
+    let cache = RenderCache::new();
+    let mut rendered_pages = Vec::with_capacity(prepared.len());
+
+    for prepared_page in prepared {
+        // prepare_pages already validated every index against this same PDF,
+        // but better to not have any indexing panic here anyway.
+        let page =
+            pdf.pages()
+                .get(prepared_page.page as usize)
+                .ok_or(RenderError::PageOutOfRange {
+                    page: prepared_page.page,
+                    page_count: pdf.pages().len(),
+                })?;
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warning_sink = Arc::clone(&warnings);
+        let interpreter_settings = InterpreterSettings {
+            warning_sink: Arc::new(move |warning| {
+                let mut warnings = warning_sink
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let warning = map_interpreter_warning(warning);
+                if !warnings.contains(&warning) {
+                    warnings.push(warning);
+                }
+            }),
+            ..InterpreterSettings::default()
+        };
+        let pixmap = render(
+            page,
+            &cache,
+            &interpreter_settings,
+            &RenderSettings {
+                x_scale: scale,
+                y_scale: scale,
+                width: Some(prepared_page.width),
+                height: Some(prepared_page.height),
+                bg_color: WHITE,
+            },
+        );
+
+        let width = u32::from(pixmap.width());
+        let height = u32::from(pixmap.height());
+        let pixels = bytemuck::allocation::try_cast_vec(pixmap.take())
+            .map_err(|_| RenderError::PixelBufferLayout)?;
+        let warnings = warnings
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+
+        rendered_pages.push(RenderedPage {
+            page: prepared_page.page,
+            width,
+            height,
+            pixels,
+            warnings,
+        });
+    }
+
+    Ok(rendered_pages)
+}
+
+fn validate_options(pages: &[u32], options: &RenderOptions) -> Result<(), RenderError> {
+    if !options.dpi.is_finite() || options.dpi <= 0.0 || options.dpi > MAX_RENDER_DPI {
+        return Err(RenderError::InvalidDpi {
+            dpi: options.dpi,
+            max: MAX_RENDER_DPI,
+        });
+    }
+
+    if pages.len() > MAX_RENDER_PAGES_PER_REQUEST {
+        return Err(RenderError::TooManyPages {
+            requested: pages.len(),
+            max: MAX_RENDER_PAGES_PER_REQUEST,
+        });
+    }
+
+    Ok(())
+}
+
+fn prepare_pages(pdf: &Pdf, pages: &[u32], scale: f32) -> Result<Vec<PreparedPage>, RenderError> {
+    let page_count = pdf.pages().len();
+    let mut total_bytes = 0_u64;
+    let mut prepared = Vec::with_capacity(pages.len());
+
+    for &page_index in pages {
+        let page = pdf
+            .pages()
+            .get(page_index as usize)
+            .ok_or(RenderError::PageOutOfRange {
+                page: page_index,
+                page_count,
+            })?;
+        let (width_points, height_points) = page.render_dimensions();
+        let (width, height) = scaled_dimensions(width_points, height_points, scale).ok_or(
+            RenderError::InvalidPageDimensions {
+                page: page_index,
+                width_points,
+                height_points,
+            },
+        )?;
+
+        if width > u64::from(MAX_RENDER_DIMENSION) || height > u64::from(MAX_RENDER_DIMENSION) {
+            return Err(RenderError::PageDimensionsTooLarge {
+                page: page_index,
+                width,
+                height,
+                max: MAX_RENDER_DIMENSION,
+            });
+        }
+
+        let pixels = width
+            .checked_mul(height)
+            .ok_or(RenderError::PagePixelsTooLarge {
+                page: page_index,
+                pixels: u64::MAX,
+                max: MAX_RENDER_PIXELS_PER_PAGE,
+            })?;
+        if pixels > MAX_RENDER_PIXELS_PER_PAGE {
+            return Err(RenderError::PagePixelsTooLarge {
+                page: page_index,
+                pixels,
+                max: MAX_RENDER_PIXELS_PER_PAGE,
+            });
+        }
+
+        let page_bytes = pixels.checked_mul(4).ok_or(RenderError::OutputTooLarge {
+            bytes: u64::MAX,
+            max: MAX_RENDER_OUTPUT_BYTES,
+        })?;
+        total_bytes = total_bytes
+            .checked_add(page_bytes)
+            .ok_or(RenderError::OutputTooLarge {
+                bytes: u64::MAX,
+                max: MAX_RENDER_OUTPUT_BYTES,
+            })?;
+        if total_bytes > MAX_RENDER_OUTPUT_BYTES {
+            return Err(RenderError::OutputTooLarge {
+                bytes: total_bytes,
+                max: MAX_RENDER_OUTPUT_BYTES,
+            });
+        }
+
+        prepared.push(PreparedPage {
+            page: page_index,
+            width: width as u16,
+            height: height as u16,
+        });
+    }
+
+    Ok(prepared)
+}
+
+fn scaled_dimensions(width_points: f32, height_points: f32, scale: f32) -> Option<(u64, u64)> {
+    if !width_points.is_finite()
+        || !height_points.is_finite()
+        || width_points <= 0.0
+        || height_points <= 0.0
+    {
+        return None;
+    }
+
+    // Match the same f32 multiplication Hayro does before to floor to pixel.
+    let width = f64::from(width_points * scale);
+    let height = f64::from(height_points * scale);
+    if !width.is_finite() || !height.is_finite() || width < 1.0 || height < 1.0 {
+        return None;
+    }
+
+    Some((width.floor() as u64, height.floor() as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_every_interpreter_warning_to_the_public_type() {
+        assert_eq!(
+            map_interpreter_warning(InterpreterWarning::UnsupportedFont),
+            RenderWarning::UnsupportedFont
+        );
+        assert_eq!(
+            map_interpreter_warning(InterpreterWarning::ImageDecodeFailure),
+            RenderWarning::ImageDecodeFailure
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,10 @@ pub enum ItemType {
     FormField,
 }
 
+pub(crate) fn image_reference(page: u32, occurrence: u32) -> String {
+    format!("pdf-image:p{page}_i{occurrence}")
+}
+
 /// Layout complexity analysis result.
 ///
 /// Callers can use this to decide whether the extracted markdown is reliable

--- a/tests/render_corpus_tests.rs
+++ b/tests/render_corpus_tests.rs
@@ -1,0 +1,179 @@
+#![cfg(all(feature = "render", not(target_arch = "wasm32")))]
+
+use pdf_inspector::{
+    classify_pdf_mem, render_pages_mem, RenderOptions, RenderWarning, RenderedPage,
+};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+struct CorpusCase {
+    relative_path: &'static str,
+    sha256: &'static str,
+    pages: &'static [u32],
+    dpi: f32,
+}
+
+const CASES: &[CorpusCase] = &[
+    CorpusCase {
+        relative_path: "001-trivial/minimal-document.pdf",
+        sha256: "f723638db6e763cf4ccadad38a3d38a02d9ecab95dab1f0bbf00e801991b5f92",
+        pages: &[0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "007-imagemagick-images/imagemagick-images.pdf",
+        sha256: "0f2076573bfed1107300a2383b88bbbbc2b85a57f06b3ff478a0faa7ded57b4e",
+        pages: &[5, 0, 3],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "018-base64-image/base64image.pdf",
+        sha256: "aaad90df16fce40ec768629d2135479b98f65b39bb27c7f80fb106393187d619",
+        pages: &[0],
+        dpi: 200.0,
+    },
+    CorpusCase {
+        relative_path: "023-cmyk-image/cmyk-image.pdf",
+        sha256: "5a5f76a951e403a5b357992789afc5164fd6c2914583741de7a1dd08ec029ab2",
+        pages: &[0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "027-cropped-rotated-scaled/cropped-rotated-scaled.pdf",
+        sha256: "cc195eac510b81123de4f55ac9f8185f2120975a7b75a106460b98615737aacd",
+        pages: &[3, 0],
+        dpi: 72.0,
+    },
+    CorpusCase {
+        relative_path: "028-image-references-deduplication/wrong-references.pdf",
+        sha256: "16cb8e10bd59e30b4d350f11d0ed9c7d0bd7e7bb962a46022c89836e2aa44f63",
+        pages: &[2, 0],
+        dpi: 72.0,
+    },
+];
+
+/// Exercise an immutable, checksum-verified external compatibility corpus.
+///
+/// The PDF files are CC-BY-SA-4.0 and are deliberately not vendored into this
+/// MIT repository. Check out py-pdf/sample-files at commit
+/// `89039b6078fd0c9f98bf3d6fcb5583fac6b0ecaf`, set
+/// `PDF_INSPECTOR_SAMPLE_FILES` to its root, then run:
+///
+/// `cargo test --features render --test render_corpus_tests renders_pinned -- --ignored --nocapture`
+#[test]
+#[ignore = "requires the external py-pdf/sample-files corpus"]
+fn renders_pinned_py_pdf_sample_files() {
+    let root = std::env::var_os("PDF_INSPECTOR_SAMPLE_FILES")
+        .map(PathBuf::from)
+        .expect("set PDF_INSPECTOR_SAMPLE_FILES to the pinned corpus checkout");
+
+    for case in CASES {
+        let path = root.join(case.relative_path);
+        let bytes = std::fs::read(&path).unwrap_or_else(|error| {
+            panic!("failed to read {}: {error}", path.display());
+        });
+        assert_sha256(&path, &bytes, case.sha256);
+
+        let started = Instant::now();
+        let rendered = render_pages_mem(&bytes, case.pages, RenderOptions::new().dpi(case.dpi))
+            .unwrap_or_else(|error| panic!("failed to render {}: {error}", path.display()));
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            rendered.iter().map(|page| page.page).collect::<Vec<_>>(),
+            case.pages
+        );
+        for page in &rendered {
+            assert_valid_rgba(page, &path);
+        }
+
+        eprintln!(
+            "rendered {} page buffer(s) from {} at {} DPI in {:.3?}",
+            rendered.len(),
+            case.relative_path,
+            case.dpi,
+            elapsed
+        );
+    }
+}
+
+/// Print one release-profile data point for the OCR-positive image PDF.
+///
+/// Set `PDF_INSPECTOR_RENDER_DPI` to run the same pinned input at a specific
+/// resolution. This is kept separate from the compatibility loop so an
+/// external process monitor can capture peak memory for one DPI at a time.
+#[test]
+#[ignore = "requires the external py-pdf/sample-files corpus"]
+fn measures_ocr_positive_page_at_configured_dpi() {
+    let root = std::env::var_os("PDF_INSPECTOR_SAMPLE_FILES")
+        .map(PathBuf::from)
+        .expect("set PDF_INSPECTOR_SAMPLE_FILES to the pinned corpus checkout");
+    let dpi = std::env::var("PDF_INSPECTOR_RENDER_DPI")
+        .unwrap_or_else(|_| "200".to_string())
+        .parse::<f32>()
+        .expect("PDF_INSPECTOR_RENDER_DPI must be a number");
+    let case = &CASES[2];
+    let path = root.join(case.relative_path);
+    let bytes = std::fs::read(&path).expect("read OCR-positive corpus PDF");
+    assert_sha256(&path, &bytes, case.sha256);
+    let classification = classify_pdf_mem(&bytes).expect("classify OCR-positive corpus PDF");
+    assert_eq!(classification.pages_needing_ocr, [0]);
+
+    let started = Instant::now();
+    let rendered = render_pages_mem(&bytes, &[0], RenderOptions::new().dpi(dpi))
+        .expect("render OCR-positive page");
+    let elapsed = started.elapsed();
+    assert_valid_rgba(&rendered[0], &path);
+
+    eprintln!(
+        "rendered {} at {} DPI to {}x{} ({} RGBA bytes) in {:.3?}",
+        case.relative_path,
+        dpi,
+        rendered[0].width,
+        rendered[0].height,
+        rendered[0].pixels.len(),
+        elapsed
+    );
+}
+
+fn assert_sha256(path: &Path, bytes: &[u8], expected: &str) {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    assert_eq!(
+        actual,
+        expected,
+        "unexpected corpus revision for {}",
+        path.display()
+    );
+}
+
+fn assert_valid_rgba(page: &RenderedPage, path: &Path) {
+    assert!(
+        !page.warnings.contains(&RenderWarning::ImageDecodeFailure),
+        "an image resource failed to decode for {}",
+        path.display()
+    );
+    assert!(page.width > 0, "zero-width output for {}", path.display());
+    assert!(page.height > 0, "zero-height output for {}", path.display());
+    assert_eq!(
+        page.pixels.len(),
+        page.width as usize * page.height as usize * 4,
+        "invalid RGBA length for {}",
+        path.display()
+    );
+    assert!(
+        page.pixels.chunks_exact(4).all(|pixel| pixel[3] == 255),
+        "non-opaque output for {}",
+        path.display()
+    );
+    let non_white = page
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[..3] != [255, 255, 255])
+        .count();
+    assert!(
+        non_white > 0,
+        "rendered content is unexpectedly blank for {}",
+        path.display()
+    );
+}

--- a/tests/render_tests.rs
+++ b/tests/render_tests.rs
@@ -19,47 +19,22 @@ fn make_solid_page_pdf_with_page_options(
     colors: &[[u8; 3]],
     page_options: &str,
 ) -> Vec<u8> {
-    let mut pdf = b"%PDF-1.4\n".to_vec();
-    let mut offsets = vec![0_usize];
+    let mut object_bodies = vec![b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(), {
+        let kids = (0..colors.len())
+            .map(|index| format!("{} 0 R", 3 + index * 2))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).into_bytes()
+    }];
 
-    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
-        assert_eq!(id, offsets.len());
-        offsets.push(pdf.len());
-        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
-        pdf.extend_from_slice(body);
-        pdf.extend_from_slice(b"\nendobj\n");
-    }
-
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        1,
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-    );
-
-    let kids = (0..colors.len())
-        .map(|index| format!("{} 0 R", 3 + index * 2))
-        .collect::<Vec<_>>()
-        .join(" ");
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        2,
-        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).as_bytes(),
-    );
-
-    for (index, [red, green, blue]) in colors.iter().copied().enumerate() {
-        let page_id = 3 + index * 2;
-        let content_id = page_id + 1;
-        add_object(
-            &mut pdf,
-            &mut offsets,
-            page_id,
+    for [red, green, blue] in colors.iter().copied() {
+        let content_id = object_bodies.len() + 2;
+        object_bodies.push(
             format!(
                 "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}] \
                  {page_options} /Resources << >> /Contents {content_id} 0 R >>"
             )
-            .as_bytes(),
+            .into_bytes(),
         );
 
         let content = format!(
@@ -68,32 +43,16 @@ fn make_solid_page_pdf_with_page_options(
             f32::from(green) / 255.0,
             f32::from(blue) / 255.0
         );
-        add_object(
-            &mut pdf,
-            &mut offsets,
-            content_id,
+        object_bodies.push(
             format!(
                 "<< /Length {} >>\nstream\n{content}\nendstream",
                 content.len()
             )
-            .as_bytes(),
+            .into_bytes(),
         );
     }
 
-    let xref_start = pdf.len();
-    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
-    pdf.extend_from_slice(b"0000000000 65535 f \n");
-    for offset in offsets.iter().skip(1) {
-        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-    }
-    pdf.extend_from_slice(
-        format!(
-            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
-            offsets.len()
-        )
-        .as_bytes(),
-    );
-    pdf
+    render_fixture::build_pdf_from_objects(&object_bodies)
 }
 
 fn center_pixel(pixels: &[u8], width: u32, height: u32) -> [u8; 4] {

--- a/tests/render_tests.rs
+++ b/tests/render_tests.rs
@@ -1,0 +1,303 @@
+#![cfg(feature = "render")]
+
+use pdf_inspector::{
+    render_pages_mem, RenderError, RenderOptions, RenderWarning, DEFAULT_RENDER_DPI,
+    MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
+    MAX_RENDER_PIXELS_PER_PAGE,
+};
+
+#[path = "support/render_fixture.rs"]
+mod render_fixture;
+
+fn make_solid_page_pdf(width: f32, height: f32, colors: &[[u8; 3]]) -> Vec<u8> {
+    make_solid_page_pdf_with_page_options(width, height, colors, "")
+}
+
+fn make_solid_page_pdf_with_page_options(
+    width: f32,
+    height: f32,
+    colors: &[[u8; 3]],
+    page_options: &str,
+) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
+        assert_eq!(id, offsets.len());
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+    );
+
+    let kids = (0..colors.len())
+        .map(|index| format!("{} 0 R", 3 + index * 2))
+        .collect::<Vec<_>>()
+        .join(" ");
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        format!("<< /Type /Pages /Kids [{kids}] /Count {} >>", colors.len()).as_bytes(),
+    );
+
+    for (index, [red, green, blue]) in colors.iter().copied().enumerate() {
+        let page_id = 3 + index * 2;
+        let content_id = page_id + 1;
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            page_id,
+            format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}] \
+                 {page_options} /Resources << >> /Contents {content_id} 0 R >>"
+            )
+            .as_bytes(),
+        );
+
+        let content = format!(
+            "{} {} {} rg 0 0 {width} {height} re f",
+            f32::from(red) / 255.0,
+            f32::from(green) / 255.0,
+            f32::from(blue) / 255.0
+        );
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            content_id,
+            format!(
+                "<< /Length {} >>\nstream\n{content}\nendstream",
+                content.len()
+            )
+            .as_bytes(),
+        );
+    }
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn center_pixel(pixels: &[u8], width: u32, height: u32) -> [u8; 4] {
+    let offset = ((height as usize / 2) * width as usize + width as usize / 2) * 4;
+    pixels[offset..offset + 4].try_into().unwrap()
+}
+
+#[test]
+fn renders_selected_pages_in_caller_order_with_duplicates() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[255, 0, 0], [0, 0, 255]]);
+    let rendered = render_pages_mem(&pdf, &[1, 0, 1], RenderOptions::new().dpi(72.0))
+        .expect("render selected pages");
+
+    assert_eq!(
+        rendered.iter().map(|page| page.page).collect::<Vec<_>>(),
+        [1, 0, 1]
+    );
+    for page in &rendered {
+        assert_eq!((page.width, page.height), (100, 80));
+        assert_eq!(page.pixels.len(), 100 * 80 * 4);
+        assert!(page.pixels.chunks_exact(4).all(|pixel| pixel[3] == 255));
+    }
+    assert_eq!(center_pixel(&rendered[0].pixels, 100, 80), [0, 0, 255, 255]);
+    assert_eq!(center_pixel(&rendered[1].pixels, 100, 80), [255, 0, 0, 255]);
+    assert_eq!(rendered[0], rendered[2]);
+}
+
+#[test]
+fn renders_an_image_xobject_to_opaque_color_pixels() {
+    let pdf = render_fixture::synthetic_image_pdf();
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render image page");
+    let mut pixels = rendered[0].pixels.chunks_exact(4);
+
+    assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+    assert!(rendered[0].warnings.is_empty());
+    assert!(pixels.clone().all(|pixel| pixel[3] == 255));
+    assert!(
+        pixels.clone().any(|pixel| pixel[0] > 180 && pixel[2] < 80),
+        "red checker cells were not decoded"
+    );
+    assert!(
+        pixels.any(|pixel| pixel[2] > 180 && pixel[0] < 80),
+        "blue checker cells were not decoded"
+    );
+}
+
+#[test]
+fn exposes_image_decode_failures_instead_of_silently_returning_pixels() {
+    let pdf = render_fixture::synthetic_broken_image_pdf();
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render image page");
+
+    assert_eq!(rendered[0].warnings, [RenderWarning::ImageDecodeFailure]);
+}
+
+#[test]
+fn uses_bounded_200_dpi_default() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+    let rendered = render_pages_mem(&pdf, &[0], RenderOptions::new()).expect("render page");
+
+    assert_eq!(DEFAULT_RENDER_DPI, 200.0);
+    assert_eq!((rendered[0].width, rendered[0].height), (277, 222));
+    assert_eq!(
+        rendered[0].pixels.len(),
+        rendered[0].width as usize * rendered[0].height as usize * 4
+    );
+}
+
+#[test]
+fn applies_crop_box_and_page_rotation() {
+    let pdf = make_solid_page_pdf_with_page_options(
+        100.0,
+        80.0,
+        &[[0, 255, 0]],
+        "/CropBox [0 0 40 30] /Rotate 90",
+    );
+    let rendered =
+        render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(72.0)).expect("render page");
+
+    assert_eq!((rendered[0].width, rendered[0].height), (30, 40));
+    assert_eq!(center_pixel(&rendered[0].pixels, 30, 40), [0, 255, 0, 255]);
+}
+
+#[test]
+fn rejects_invalid_dpi_values() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    for dpi in [0.0, -1.0, f32::NAN, f32::INFINITY, MAX_RENDER_DPI + 1.0] {
+        assert!(matches!(
+            render_pages_mem(&pdf, &[0], RenderOptions::new().dpi(dpi)),
+            Err(RenderError::InvalidDpi { .. })
+        ));
+    }
+}
+
+#[test]
+fn rejects_invalid_pdf_bytes() {
+    assert_eq!(
+        render_pages_mem(b"not a PDF", &[0], RenderOptions::new()),
+        Err(RenderError::Parse)
+    );
+}
+
+#[test]
+fn rejects_out_of_range_pages_before_rendering() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[0, 1], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PageOutOfRange {
+            page: 1,
+            page_count: 1,
+        })
+    );
+}
+
+#[test]
+fn accepts_an_empty_selection_after_parsing() {
+    let pdf = make_solid_page_pdf(100.0, 80.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[], RenderOptions::new()).unwrap(),
+        []
+    );
+    assert_eq!(
+        render_pages_mem(b"not a PDF", &[], RenderOptions::new()),
+        Err(RenderError::Parse)
+    );
+}
+
+#[test]
+fn rejects_dimension_and_pixel_limits_before_allocation() {
+    let too_wide = make_solid_page_pdf(17_000.0, 1.0, &[[0, 0, 0]]);
+    assert!(matches!(
+        render_pages_mem(&too_wide, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PageDimensionsTooLarge { page: 0, .. })
+    ));
+
+    let too_many_pixels = make_solid_page_pdf(6_000.0, 5_000.0, &[[0, 0, 0]]);
+    assert!(matches!(
+        render_pages_mem(&too_many_pixels, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::PagePixelsTooLarge {
+            page: 0,
+            pixels: 30_000_000,
+            max: MAX_RENDER_PIXELS_PER_PAGE,
+        })
+    ));
+}
+
+#[test]
+fn rejects_total_output_limit_before_allocation() {
+    let pdf = make_solid_page_pdf(6_000.0, 4_000.0, &[[0, 0, 0]]);
+
+    assert_eq!(
+        render_pages_mem(&pdf, &[0, 0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::OutputTooLarge {
+            bytes: 192_000_000,
+            max: MAX_RENDER_OUTPUT_BYTES,
+        })
+    );
+}
+
+#[test]
+fn rejects_excessive_page_entry_count() {
+    let pdf = make_solid_page_pdf(1.0, 1.0, &[[0, 0, 0]]);
+    let pages = vec![0; MAX_RENDER_PAGES_PER_REQUEST + 1];
+
+    assert_eq!(
+        render_pages_mem(&pdf, &pages, RenderOptions::new().dpi(72.0)),
+        Err(RenderError::TooManyPages {
+            requested: MAX_RENDER_PAGES_PER_REQUEST + 1,
+            max: MAX_RENDER_PAGES_PER_REQUEST,
+        })
+    );
+}
+
+#[test]
+fn render_options_debug_redacts_password() {
+    let debug = format!("{:?}", RenderOptions::new().password("secret123"));
+
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains("secret123"));
+}
+
+#[test]
+fn decrypts_with_the_supplied_password() {
+    let pdf = include_bytes!("fixtures/encrypted-secret123.pdf");
+
+    assert_eq!(
+        render_pages_mem(pdf, &[0], RenderOptions::new().dpi(72.0)),
+        Err(RenderError::Encrypted)
+    );
+    assert_eq!(
+        render_pages_mem(pdf, &[0], RenderOptions::new().dpi(72.0).password("wrong")),
+        Err(RenderError::Encrypted)
+    );
+
+    let rendered = render_pages_mem(
+        pdf,
+        &[0],
+        RenderOptions::new().dpi(72.0).password("secret123"),
+    )
+    .expect("render encrypted PDF with its password");
+    assert_eq!(rendered.len(), 1);
+    assert!(!rendered[0].pixels.is_empty());
+}

--- a/tests/render_tests.rs
+++ b/tests/render_tests.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "render")]
 
 use pdf_inspector::{
-    render_pages_mem, RenderError, RenderOptions, RenderWarning, DEFAULT_RENDER_DPI,
-    MAX_RENDER_DPI, MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST,
-    MAX_RENDER_PIXELS_PER_PAGE,
+    extract_images_mem, extract_text_with_positions_mem, render_pages_mem, to_markdown_from_items,
+    MarkdownOptions, RenderError, RenderOptions, RenderWarning, DEFAULT_RENDER_DPI, MAX_RENDER_DPI,
+    MAX_RENDER_OUTPUT_BYTES, MAX_RENDER_PAGES_PER_REQUEST, MAX_RENDER_PIXELS_PER_PAGE,
 };
 
 #[path = "support/render_fixture.rs"]
@@ -98,6 +98,35 @@ fn renders_an_image_xobject_to_opaque_color_pixels() {
         pixels.any(|pixel| pixel[2] > 180 && pixel[0] < 80),
         "blue checker cells were not decoded"
     );
+
+    let images =
+        extract_images_mem(&pdf, RenderOptions::new().dpi(72.0)).expect("extract image regions");
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].reference, "pdf-image:p1_i1");
+    assert_eq!(images[0].resource_name, "Im0");
+    assert_eq!(images[0].page, 0);
+    assert_eq!(images[0].occurrence, 1);
+    assert_eq!(images[0].bbox, [0.0, 0.0, 64.0, 64.0]);
+    assert_eq!((images[0].width, images[0].height), (64, 64));
+    assert_eq!(images[0].pixels, rendered[0].pixels);
+
+    let markdown = to_markdown_from_items(
+        extract_text_with_positions_mem(&pdf).expect("extract positioned items"),
+        MarkdownOptions {
+            include_images: true,
+            ..MarkdownOptions::default()
+        },
+    );
+    assert!(markdown.contains("![Image: Im0](pdf-image:p1_i1)"));
+
+    let rotated_pdf =
+        render_fixture::synthetic_image_pdf_with_page_options("/CropBox [0 0 40 30] /Rotate 90");
+    let rotated_page = render_pages_mem(&rotated_pdf, &[0], RenderOptions::new().dpi(72.0))
+        .expect("render rotated image page");
+    let rotated_image = extract_images_mem(&rotated_pdf, RenderOptions::new().dpi(72.0))
+        .expect("extract rotated image region");
+    assert_eq!((rotated_image[0].width, rotated_image[0].height), (30, 40));
+    assert_eq!(rotated_image[0].pixels, rotated_page[0].pixels);
 }
 
 #[test]

--- a/tests/support/render_fixture.rs
+++ b/tests/support/render_fixture.rs
@@ -34,6 +34,11 @@ pub fn build_pdf_from_objects(object_bodies: &[Vec<u8>]) -> Vec<u8> {
 /// XObject. Keeping this generated avoids adding a separately licensed binary
 /// fixture and lets native and WebAssembly tests exercise the same bytes.
 pub fn synthetic_image_pdf() -> Vec<u8> {
+    synthetic_image_pdf_with_page_options("")
+}
+
+/// Build the image-backed fixture with additional entries in its page object.
+pub fn synthetic_image_pdf_with_page_options(page_options: &str) -> Vec<u8> {
     let mut image = Vec::with_capacity(4 * 4 * 3);
     for y in 0..4 {
         for x in 0..4 {
@@ -45,16 +50,16 @@ pub fn synthetic_image_pdf() -> Vec<u8> {
         }
     }
 
-    synthetic_image_pdf_with_data(&image, "")
+    synthetic_image_pdf_with_data(&image, "", page_options)
 }
 
 /// Build an image-backed PDF whose declared JPEG data cannot be decoded.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn synthetic_broken_image_pdf() -> Vec<u8> {
-    synthetic_image_pdf_with_data(b"not a JPEG stream", "/Filter /DCTDecode")
+    synthetic_image_pdf_with_data(b"not a JPEG stream", "/Filter /DCTDecode", "")
 }
 
-fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
+fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str, page_options: &str) -> Vec<u8> {
     let content = b"q 64 0 0 64 0 0 cm /Im0 Do Q";
     let mut content_stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
     content_stream.extend_from_slice(content);
@@ -72,9 +77,11 @@ fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
     build_pdf_from_objects(&[
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
-          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
-            .to_vec(),
+        format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] {page_options} \
+             /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+        )
+        .into_bytes(),
         content_stream,
         image_stream,
     ])

--- a/tests/support/render_fixture.rs
+++ b/tests/support/render_fixture.rs
@@ -1,0 +1,87 @@
+/// Build a small, deterministic PDF whose only page contains an RGB image
+/// XObject. Keeping this generated avoids adding a separately licensed binary
+/// fixture and lets native and WebAssembly tests exercise the same bytes.
+pub fn synthetic_image_pdf() -> Vec<u8> {
+    let mut image = Vec::with_capacity(4 * 4 * 3);
+    for y in 0..4 {
+        for x in 0..4 {
+            image.extend_from_slice(if (x + y) % 2 == 0 {
+                &[255, 0, 0]
+            } else {
+                &[0, 0, 255]
+            });
+        }
+    }
+
+    synthetic_image_pdf_with_data(&image, "")
+}
+
+/// Build an image-backed PDF whose declared JPEG data cannot be decoded.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn synthetic_broken_image_pdf() -> Vec<u8> {
+    synthetic_image_pdf_with_data(b"not a JPEG stream", "/Filter /DCTDecode")
+}
+
+fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
+        assert_eq!(id, offsets.len());
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
+          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+
+    let content = b"q 64 0 0 64 0 0 cm /Im0 Do Q";
+    let mut content_stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    content_stream.extend_from_slice(content);
+    content_stream.extend_from_slice(b"\nendstream");
+    add_object(&mut pdf, &mut offsets, 4, &content_stream);
+
+    let mut image_stream = format!(
+        "<< /Type /XObject /Subtype /Image /Width 4 /Height 4 \
+         /ColorSpace /DeviceRGB /BitsPerComponent 8 {image_options} /Length {} >>\nstream\n",
+        image.len()
+    )
+    .into_bytes();
+    image_stream.extend_from_slice(image);
+    image_stream.extend_from_slice(b"\nendstream");
+    add_object(&mut pdf, &mut offsets, 5, &image_stream);
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}

--- a/tests/support/render_fixture.rs
+++ b/tests/support/render_fixture.rs
@@ -1,3 +1,35 @@
+/// Build a PDF from a sequence of already-formatted object bodies, each
+/// becoming object `index + 1`. Shares the header, `N 0 obj`/`endobj`
+/// framing, and xref/trailer generation used by every fixture builder in
+/// this crate's tests.
+pub fn build_pdf_from_objects(object_bodies: &[Vec<u8>]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0_usize];
+
+    for body in object_bodies {
+        let id = offsets.len();
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
 /// Build a small, deterministic PDF whose only page contains an RGB image
 /// XObject. Keeping this generated avoids adding a separately licensed binary
 /// fixture and lets native and WebAssembly tests exercise the same bytes.
@@ -23,42 +55,10 @@ pub fn synthetic_broken_image_pdf() -> Vec<u8> {
 }
 
 fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
-    let mut pdf = b"%PDF-1.4\n".to_vec();
-    let mut offsets = vec![0_usize];
-
-    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &[u8]) {
-        assert_eq!(id, offsets.len());
-        offsets.push(pdf.len());
-        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
-        pdf.extend_from_slice(body);
-        pdf.extend_from_slice(b"\nendobj\n");
-    }
-
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        1,
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-    );
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        2,
-        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-    );
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        3,
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
-          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
-    );
-
     let content = b"q 64 0 0 64 0 0 cm /Im0 Do Q";
     let mut content_stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
     content_stream.extend_from_slice(content);
     content_stream.extend_from_slice(b"\nendstream");
-    add_object(&mut pdf, &mut offsets, 4, &content_stream);
 
     let mut image_stream = format!(
         "<< /Type /XObject /Subtype /Image /Width 4 /Height 4 \
@@ -68,20 +68,14 @@ fn synthetic_image_pdf_with_data(image: &[u8], image_options: &str) -> Vec<u8> {
     .into_bytes();
     image_stream.extend_from_slice(image);
     image_stream.extend_from_slice(b"\nendstream");
-    add_object(&mut pdf, &mut offsets, 5, &image_stream);
 
-    let xref_start = pdf.len();
-    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
-    pdf.extend_from_slice(b"0000000000 65535 f \n");
-    for offset in offsets.iter().skip(1) {
-        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-    }
-    pdf.extend_from_slice(
-        format!(
-            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF",
-            offsets.len()
-        )
-        .as_bytes(),
-    );
-    pdf
+    build_pdf_from_objects(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 64 64] \
+          /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+            .to_vec(),
+        content_stream,
+        image_stream,
+    ])
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -29,6 +29,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +156,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cast"
@@ -201,6 +269,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -388,6 +465,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +508,21 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -452,10 +574,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "skrifa",
+ "smallvec",
+ "vello_common 0.0.9",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hayro"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4caa128ab87fd48ffb7490617cf93f77f606820dffbc9fd9ef6ab0ed077f56d"
+dependencies = [
+ "bytemuck",
+ "hayro-interpret",
+ "image",
+ "kurbo",
+ "pic-scale",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
+
+[[package]]
+name = "hayro-cmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
+dependencies = [
+ "brotli",
+ "hayro-postscript",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2613d0406898995042d0794c4245b2f2fba1246490c8ac593769bba6551129d"
+dependencies = [
+ "bitflags 2.13.1",
+ "hayro-cmap",
+ "hayro-syntax",
+ "kurbo",
+ "moxcms",
+ "phf",
+ "rustc-hash",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "yoke",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69374b3668dd45aeb3d3145cda68f2c7b4f223aaa2511e67d076f1c7d741388d"
+dependencies = [
+ "fearless_simd",
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
+name = "hayro-postscript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+
+[[package]]
+name = "hayro-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edeafd70aa2db743de8ede8637d07ec87db05efe69cde371d03f1b185fcef27"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000",
+ "memchr",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -479,6 +720,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -586,6 +840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +862,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "log"
@@ -671,6 +943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,7 +1008,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 name = "pdf-inspector"
 version = "1.14.1"
 dependencies = [
+ "bytemuck",
  "env_logger",
+ "hayro",
  "include_dir",
  "log",
  "lopdf",
@@ -752,10 +1036,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pic-scale"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c80d88d5c31215ceec2862abb2504860c715b8e2545a5ab15b62a3d097f30d"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -786,6 +1157,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quote"
@@ -846,6 +1223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1260,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
@@ -967,10 +1360,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stringprep"
@@ -992,6 +1413,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1103,6 +1535,53 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vello_common"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3361bff7f7d82c0c496b92048db83846691f0e844cc28dee92b1c824291b55ee"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8ded630e8316bb94a55881256506d1f3b9947b5f66db8a7d32ca7ba02decd0"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown",
+ "png",
+ "vello_common 0.0.8",
+]
 
 [[package]]
 name = "version_check"
@@ -1298,7 +1777,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -24,6 +24,10 @@ wasm-bindgen = "0.2"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
+[features]
+default = []
+render = ["pdf-inspector/render"]
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,6 +5,10 @@ use pdf_inspector::{
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+#[cfg(all(test, target_arch = "wasm32", feature = "render"))]
+#[path = "../../tests/support/render_fixture.rs"]
+mod render_fixture;
+
 #[wasm_bindgen(typescript_custom_section)]
 const TYPESCRIPT_TYPES: &str = r#"
 export type PdfType = "TextBased" | "Scanned" | "ImageBased" | "Mixed";
@@ -391,6 +395,39 @@ mod tests {
 
         assert_eq!(pdf_type, "TextBased");
         assert!(!markdown.is_empty());
+    }
+
+    #[cfg(feature = "render")]
+    #[wasm_bindgen_test]
+    fn renders_a_selected_page_with_the_optional_core_feature() {
+        let pdf = crate::render_fixture::synthetic_image_pdf();
+        let rendered = pdf_inspector::render_pages_mem(
+            &pdf,
+            &[0],
+            pdf_inspector::RenderOptions::new().dpi(72.0),
+        )
+        .expect("render selected page");
+
+        assert_eq!(rendered.len(), 1);
+        assert_eq!(rendered[0].page, 0);
+        assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+        assert!(rendered[0].warnings.is_empty());
+        assert_eq!(
+            rendered[0].pixels.len(),
+            rendered[0].width as usize * rendered[0].height as usize * 4
+        );
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .all(|pixel| pixel[3] == 255));
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .any(|pixel| pixel[0] > 180 && pixel[2] < 80));
+        assert!(rendered[0]
+            .pixels
+            .chunks_exact(4)
+            .any(|pixel| pixel[2] > 180 && pixel[0] < 80));
     }
 
     #[wasm_bindgen_test]

--- a/wasm/tests/render_browser.rs
+++ b/wasm/tests/render_browser.rs
@@ -1,0 +1,33 @@
+#![cfg(all(target_arch = "wasm32", feature = "render"))]
+
+use wasm_bindgen_test::*;
+
+#[path = "../../tests/support/render_fixture.rs"]
+mod render_fixture;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn renders_an_image_xobject_in_a_browser() {
+    let pdf = render_fixture::synthetic_image_pdf();
+    let rendered =
+        pdf_inspector::render_pages_mem(&pdf, &[0], pdf_inspector::RenderOptions::new().dpi(72.0))
+            .expect("render image page");
+
+    assert_eq!(rendered.len(), 1);
+    assert_eq!((rendered[0].width, rendered[0].height), (64, 64));
+    assert!(rendered[0].warnings.is_empty());
+    assert_eq!(rendered[0].pixels.len(), 64 * 64 * 4);
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .all(|pixel| pixel[3] == 255));
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .any(|pixel| pixel[0] > 180 && pixel[2] < 80));
+    assert!(rendered[0]
+        .pixels
+        .chunks_exact(4)
+        .any(|pixel| pixel[2] > 180 && pixel[0] < 80));
+}


### PR DESCRIPTION
## Background

`pdf-inspector` can place image markers in Markdown, but every marker currently uses the same target:

```markdown
![Image: Im0](image)
```

That marker shows where an image appeared, but a caller cannot tell which image data belongs there. This blocks AnyDoc from returning usable PDF images and blocks OpenViking from keeping those images in the correct document position.

This PR adds the missing link between a Markdown image marker and its rendered pixels.

## Before

With image markers enabled, all images use `(image)`:

```markdown
Text before the first image.

![Image: Im0](image)

Text between images.

![Image: Im1](image)
```

There is no public API that returns rendered image pixels with an identifier matching those markers. A caller would have to parse the PDF again and guess the mapping.

## After

Each image occurrence gets a stable reference based on its page and occurrence number:

```markdown
Text before the first image.

![Image: Im0](pdf-image:p1_i1)

Text between images.

![Image: Im1](pdf-image:p1_i2)
```

The new `extract_images_mem` API returns one rendered image for each occurrence:

```rust
let images = extract_images_mem(&pdf, RenderOptions::new())?;

assert_eq!(images[0].reference, "pdf-image:p1_i1");
assert_eq!(images[0].page, 0);
assert_eq!(images[0].occurrence, 1);
```

The caller matches Markdown and pixels by comparing `reference`. No filename or coordinate guessing is needed.

Each result also contains:

- the PDF resource name, for diagnostics only;
- the zero-based page and one-based occurrence;
- the source bounding box;
- the rendered width and height;
- opaque RGBA8 pixels;
- renderer warning codes.

Repeated placements remain separate results because the same PDF image resource can be drawn at different positions, sizes, or with different page transforms.

## Compatibility

Default Markdown output does not change. Stable image references are only emitted when `MarkdownOptions::include_images` is enabled, and rendering remains behind the existing `render` feature.

## Implementation notes

- Reuses image positions and content-stream order already extracted by `pdf-inspector`.
- Applies page CropBox and rotation before cropping image pixels.
- Loads the renderer once and processes image-bearing pages one at a time.
- Checks page dimensions and total output size before allocating rendered buffers.

This is a stacked Draft PR based on [#280](https://github.com/firecrawl/pdf-inspector/pull/280), which provides the optional Hayro renderer. Thanks to @massimodeluisa for that rendering foundation.

## Validation

- `cargo test --features render`
- `cargo clippy --features render -- -D warnings`
- `cargo clippy -- -D warnings`
- Direct call to `process_pdf_mem_with_options` and `extract_images_mem` using a generated text-image-text PDF

The generated PDF produced `pdf-image:p1_i1` in both Markdown and the image result. The extracted image was 557×334 pixels, and its RGBA buffer contained 744,152 bytes. One existing renderer test was updated; no test file or test function was added.

OpenViking needs this capability through AnyDoc so it can ingest PDF images without parsing the PDF a second time. Thank you for considering this integration requirement.
