### PR TITLE
fix(layout): measure the folio top band from the page's own top edge

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1124,13 +1124,35 @@ const PAGE_NUMBER_Y_TOLERANCE: f32 = 3.0;
 const PAGE_NUMBER_CONTEXT_GAP_EM: f32 = 1.5;
 const PAGE_NUMBER_BOTTOM_Y: f32 = 100.0;
 const PAGE_NUMBER_TOP_Y: f32 = 720.0;
+/// The page height the absolute band constants above were calibrated for
+/// (US Letter). Pages whose visible box differs scale the bands by their
+/// real height, so an A4 page (841.89pt) does not treat the top ~122pt —
+/// eight lines of body text — as the folio zone (issue #283).
+const PAGE_NUMBER_BAND_REFERENCE_HEIGHT: f32 = 792.0;
+
+/// Vertical folio bands for a page: y above `top` or below `bottom` counts
+/// as page-edge. Derived from the page's visible box when known, keeping
+/// the exact historical thresholds on US-Letter-sized pages; without
+/// geometry the absolute constants apply unchanged.
+fn page_number_bands(bounds: Option<&(f32, f32)>) -> (f32, f32) {
+    match bounds {
+        Some(&(y0, y1)) if y1 - y0 > 72.0 => {
+            let scale = (y1 - y0) / PAGE_NUMBER_BAND_REFERENCE_HEIGHT;
+            (
+                y0 + PAGE_NUMBER_BOTTOM_Y * scale,
+                y0 + PAGE_NUMBER_TOP_Y * scale,
+            )
+        }
+        _ => (PAGE_NUMBER_BOTTOM_Y, PAGE_NUMBER_TOP_Y),
+    }
+}
 const SPREAD_MIN_CONTENT_WIDTH_EM: f32 = 40.0;
 const SPREAD_EDGE_FRACTION: f32 = 0.25;
 const ADJACENT_PAGE_MIN_CONTENT_WIDTH_EM: f32 = 26.0;
 
 type ContextualCandidateOccurrence = (u32, f32, Vec<(usize, u32)>);
 
-fn page_number_value(item: &TextItem) -> Option<u32> {
+fn page_number_value(item: &TextItem, page_bounds: &HashMap<u32, (f32, f32)>) -> Option<u32> {
     if !matches!(
         item.item_type,
         crate::types::ItemType::Text | crate::types::ItemType::FormField
@@ -1144,10 +1166,11 @@ fn page_number_value(item: &TextItem) -> Option<u32> {
         return None;
     }
 
-    // Must be at top or bottom of page.
-    // US Letter = 792pt, A4 = 841pt. Page numbers are typically in the
-    // top ~5% or bottom ~12% of the page.
-    if item.y <= PAGE_NUMBER_TOP_Y && item.y >= PAGE_NUMBER_BOTTOM_Y {
+    // Must be at the top or bottom of the page. The bands scale with the
+    // page's real height so taller pages (A4 and up) keep the same physical
+    // margins as US Letter instead of swallowing body text.
+    let (bottom, top) = page_number_bands(page_bounds.get(&item.page));
+    if item.y <= top && item.y >= bottom {
         return None;
     }
 
@@ -1762,8 +1785,15 @@ fn page_number_context_masks(
 /// item attached to neighboring content on the same baseline is therefore kept.
 /// Complete page-number expressions such as `Page 42` remain removable even
 /// though their numeric item has lexical context.
-fn page_number_removal_mask(items: &[TextItem], document_page_count: usize) -> Vec<bool> {
-    let candidate_values: Vec<Option<u32>> = items.iter().map(page_number_value).collect();
+fn page_number_removal_mask(
+    items: &[TextItem],
+    document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
+) -> Vec<bool> {
+    let candidate_values: Vec<Option<u32>> = items
+        .iter()
+        .map(|item| page_number_value(item, page_bounds))
+        .collect();
     let (contextual, explicit_folio) =
         page_number_context_masks(items, &candidate_values, document_page_count);
 
@@ -1781,8 +1811,12 @@ fn page_number_removal_mask(items: &[TextItem], document_page_count: usize) -> V
 pub(super) fn needs_document_page_number_context(
     items: &[TextItem],
     document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> bool {
-    let candidate_values: Vec<Option<u32>> = items.iter().map(page_number_value).collect();
+    let candidate_values: Vec<Option<u32>> = items
+        .iter()
+        .map(|item| page_number_value(item, page_bounds))
+        .collect();
     let (contextual, explicit_folio) =
         page_number_context_masks(items, &candidate_values, document_page_count);
 
@@ -1800,7 +1834,7 @@ pub(crate) fn filter_markdown_page_numbers(
     items: Vec<TextItem>,
     document_page_count: u32,
 ) -> Vec<TextItem> {
-    filter_markdown_page_numbers_with_removed_pages(items, document_page_count).0
+    filter_markdown_page_numbers_with_removed_pages(items, document_page_count, &HashMap::new()).0
 }
 
 /// Filter Markdown folios while retaining the pages where items were removed.
@@ -1811,8 +1845,9 @@ pub(crate) fn filter_markdown_page_numbers(
 pub(crate) fn filter_markdown_page_numbers_with_removed_pages(
     items: Vec<TextItem>,
     document_page_count: u32,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> (Vec<TextItem>, HashSet<u32>, Vec<bool>) {
-    let remove = page_number_removal_mask(&items, document_page_count as usize);
+    let remove = page_number_removal_mask(&items, document_page_count as usize, page_bounds);
     let mut removed_pages = HashSet::new();
     let items = items
         .into_iter()
@@ -2184,7 +2219,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
             .map(|item| item.page as usize)
             .max()
             .unwrap_or(0);
-        let remove = page_number_removal_mask(&items, observed_page_count);
+        let remove = page_number_removal_mask(&items, observed_page_count, &HashMap::new());
         items
             .into_iter()
             .zip(remove)
@@ -2208,7 +2243,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
         // from changing the page's inferred layout.
         let column_detection_items: Vec<TextItem> = page_items
             .iter()
-            .filter(|item| page_number_value(item).is_none())
+            .filter(|item| page_number_value(item, &HashMap::new()).is_none())
             .cloned()
             .collect();
         let column_detection_items = column_detection_items.as_slice();
@@ -2265,7 +2300,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
                 let col_input: Vec<TextItem> = page_items
                     .iter()
                     .filter(|it| {
-                        if page_number_value(it).is_some() {
+                        if page_number_value(it, &HashMap::new()).is_some() {
                             return false;
                         }
                         let cx = it.x + it.width / 2.0;
@@ -3483,6 +3518,61 @@ mod tests {
             y -= 14.0;
         }
         items
+    }
+
+    #[test]
+    fn page_number_bands_scale_with_page_height() {
+        // US Letter keeps the exact historical thresholds.
+        assert_eq!(page_number_bands(Some(&(0.0, 792.0))), (100.0, 720.0));
+        // A4 scales both bands so the physical margins match Letter's.
+        let (bottom, top) = page_number_bands(Some(&(0.0, 841.89)));
+        assert!((bottom - 106.3).abs() < 0.1, "bottom band: {bottom}");
+        assert!((top - 765.35).abs() < 0.1, "top band: {top}");
+        // A box with a nonzero origin shifts the bands with it.
+        let (bottom, top) = page_number_bands(Some(&(100.0, 892.0)));
+        assert!((bottom - 200.0).abs() < 0.1, "offset bottom: {bottom}");
+        assert!((top - 820.0).abs() < 0.1, "offset top: {top}");
+        // Missing or degenerate geometry keeps the absolute constants.
+        assert_eq!(page_number_bands(None), (100.0, 720.0));
+        assert_eq!(page_number_bands(Some(&(0.0, 10.0))), (100.0, 720.0));
+    }
+
+    #[test]
+    fn a4_body_digits_above_the_letter_band_are_not_candidates() {
+        // Issue #283: on A4 (841.89pt) y=740 is body territory (~12% from
+        // the top), but the US-Letter constant treated it as the folio zone
+        // and deleted table row indices.
+        let a4: HashMap<u32, (f32, f32)> = HashMap::from([(1, (0.0, 841.89))]);
+        let index = make_item(1, 208.0, 740.0, "14");
+        assert_eq!(page_number_value(&index, &a4), None, "A4 y=740 is body");
+        // The same item without geometry keeps today's behavior.
+        assert_eq!(page_number_value(&index, &HashMap::new()), Some(14));
+        // A digit in A4's real top margin is still a candidate.
+        let folio = make_item(1, 297.0, 810.0, "7");
+        assert_eq!(page_number_value(&folio, &a4), Some(7));
+        // And the bottom band scales the same way: A4 y=103 is inside the
+        // scaled bottom band (106.3), so it stays a candidate.
+        let bottom = make_item(1, 297.0, 103.0, "9");
+        assert_eq!(page_number_value(&bottom, &a4), Some(9));
+    }
+
+    #[test]
+    fn letter_pages_keep_their_historical_bands() {
+        let letter: HashMap<u32, (f32, f32)> = HashMap::from([(1, (0.0, 792.0))]);
+        for (y, expect) in [
+            (740.0, Some(14)),
+            (719.0, None),
+            (99.0, Some(14)),
+            (101.0, None),
+        ] {
+            let item = make_item(1, 208.0, y, "14");
+            assert_eq!(page_number_value(&item, &letter), expect, "y={y}");
+            assert_eq!(
+                page_number_value(&item, &HashMap::new()),
+                expect,
+                "no-geometry y={y}"
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -1514,6 +1514,7 @@ fn page_number_context_masks(
     items: &[TextItem],
     candidate_values: &[Option<u32>],
     document_page_count: usize,
+    page_bounds: &HashMap<u32, (f32, f32)>,
 ) -> (Vec<bool>, Vec<bool>) {
     let mut contextual = vec![false; items.len()];
     let mut explicit_folio = vec![false; items.len()];
@@ -1662,9 +1663,12 @@ fn page_number_context_masks(
                             group.first() == Some(index) || group.last() == Some(index)
                         })
                         .collect();
+                    // The deep-margin gate uses the same scaled bands as
+                    // candidacy, so contextual folios on tall pages are
+                    // judged against their page's real margins.
                     let in_deep_margin = candidates.iter().all(|(index, _)| {
-                        items[*index].y < PAGE_NUMBER_BOTTOM_Y
-                            || items[*index].y > PAGE_NUMBER_TOP_Y
+                        let (bottom, top) = page_number_bands(page_bounds.get(&items[*index].page));
+                        items[*index].y < bottom || items[*index].y > top
                     });
                     if in_deep_margin
                         && !recurrence_candidates.is_empty()
@@ -1795,7 +1799,7 @@ fn page_number_removal_mask(
         .map(|item| page_number_value(item, page_bounds))
         .collect();
     let (contextual, explicit_folio) =
-        page_number_context_masks(items, &candidate_values, document_page_count);
+        page_number_context_masks(items, &candidate_values, document_page_count, page_bounds);
 
     candidate_values
         .iter()
@@ -1818,7 +1822,7 @@ pub(super) fn needs_document_page_number_context(
         .map(|item| page_number_value(item, page_bounds))
         .collect();
     let (contextual, explicit_folio) =
-        page_number_context_masks(items, &candidate_values, document_page_count);
+        page_number_context_masks(items, &candidate_values, document_page_count, page_bounds);
 
     candidate_values
         .iter()
@@ -3554,6 +3558,41 @@ mod tests {
         // scaled bottom band (106.3), so it stays a candidate.
         let bottom = make_item(1, 297.0, 103.0, "9");
         assert_eq!(page_number_value(&bottom, &a4), Some(9));
+    }
+
+    #[test]
+    fn contextual_deep_margin_gate_uses_the_scaled_bands() {
+        // A recurring "42 Company report" footer at A4 y=103 sits inside the
+        // scaled bottom band (106.3) but outside the Letter constant (100).
+        // The repeated-folio gate must judge it with the same scaled bands
+        // as candidacy, so the advancing footer number is still recognized.
+        let a4: HashMap<u32, (f32, f32)> = HashMap::from([
+            (1, (0.0, 841.89)),
+            (2, (0.0, 841.89)),
+            (3, (0.0, 841.89)),
+            (4, (0.0, 841.89)),
+            (5, (0.0, 841.89)),
+        ]);
+        let mut items = Vec::new();
+        for page in 1..=5u32 {
+            items.push(make_item(page, 72.0, 103.0, &format!("{}", 41 + page)));
+            items.push(make_item(page, 90.0, 103.0, "Company report"));
+            items.push(make_item(page, 72.0, 500.0, "Body content that stays"));
+        }
+        let mask = page_number_removal_mask(&items, 5, &a4);
+        for page in 0..5usize {
+            assert!(
+                mask[page * 3],
+                "advancing footer folio on page {} strips",
+                page + 1
+            );
+            assert!(!mask[page * 3 + 2], "body content survives");
+        }
+        // Without geometry the y=103 candidates are body (above the absolute
+        // 100pt band), so nothing strips - the gate stays consistent with
+        // candidacy in both modes.
+        let mask = page_number_removal_mask(&items, 5, &HashMap::new());
+        assert!(mask.iter().all(|&removed| !removed));
     }
 
     #[test]

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use super::PageVerticalBounds;
 use crate::text_utils::{effective_width, sort_line_items};
 use crate::types::{TextItem, TextLine};
 use log::debug;
@@ -1124,27 +1125,60 @@ const PAGE_NUMBER_Y_TOLERANCE: f32 = 3.0;
 const PAGE_NUMBER_CONTEXT_GAP_EM: f32 = 1.5;
 const PAGE_NUMBER_BOTTOM_Y: f32 = 100.0;
 const PAGE_NUMBER_TOP_Y: f32 = 720.0;
-/// The page height the absolute band constants above were calibrated for
-/// (US Letter). Pages whose visible box differs scale the bands by their
-/// real height, so an A4 page (841.89pt) does not treat the top ~122pt —
-/// eight lines of body text — as the folio zone (issue #283).
+/// The page height `PAGE_NUMBER_TOP_Y` was calibrated for (US Letter), and
+/// the margin it therefore describes: one inch below the top edge. On a page
+/// of a different height the margin is the meaning and 720 is only its value
+/// on this one trim.
 const PAGE_NUMBER_BAND_REFERENCE_HEIGHT: f32 = 792.0;
+const PAGE_NUMBER_TOP_MARGIN: f32 = PAGE_NUMBER_BAND_REFERENCE_HEIGHT - PAGE_NUMBER_TOP_Y;
+/// Below one inch a page box is not a page but a damaged or degenerate entry,
+/// and a band derived from it could land anywhere. `extract_positioned_text`
+/// applies a floor of the same size before it trusts a box enough to clip
+/// against it, though on both dimensions and inclusively.
+const MIN_USABLE_PAGE_HEIGHT: f32 = 72.0;
 
-/// Vertical folio bands for a page: y above `top` or below `bottom` counts
-/// as page-edge. Derived from the page's visible box when known, keeping
-/// the exact historical thresholds on US-Letter-sized pages; without
-/// geometry the absolute constants apply unchanged.
+/// Vertical folio bands for a page: y above `top` or below `bottom` counts as
+/// page-edge.
+///
+/// Only the top band knows about the page. `PAGE_NUMBER_TOP_Y` was never a
+/// threshold, it was "one inch below the top edge" written down as the value
+/// it happens to take on US Letter, and on A4 that same number is 122pt down
+/// the page — eight lines of body text, deleted (issue #283). Measuring the
+/// margin from the page's real top edge restores what it meant.
+///
+/// It is measured, never scaled, and never allowed below its calibrated
+/// value:
+///
+/// - A4 (841.89) gives 769.89. That is the fix.
+/// - A5 (595.28) would give 523.28, but `y > 720` was unreachable on a page
+///   that short, so no item was ever a top-band candidate there. Clamping at
+///   720 keeps it that way; a measured 523 would start deleting digits from
+///   the first lines of the page, which is issue #283 moved to another trim.
+/// - A vertically imposed spread (1584) gives 1512 instead of a band that
+///   covered more than half the sheet.
+///
+/// The bottom band is left exactly as calibrated, because #283 is not about
+/// it and nothing measured says it is wrong. Moving it only costs: scaled by
+/// A4's height it becomes 106.3 and swallows the exponent of a displayed
+/// equation whose glyph sits at y=105.5. Anchoring it to a non-zero box
+/// origin does the same thing to a print A4 with a trim CropBox.
+///
+/// The caution runs one way on purpose. A folio left in the Markdown is noise
+/// a reader can see. A digit deleted from a formula or a table is silent, and
+/// this filter cannot undo it. Two things bound what the caution buys, and
+/// both are unchanged here: a page whose items were rotated out of box space
+/// by `correct_rotated_page` has every short digit fall below the bottom band
+/// and become a candidate, geometry or not; and `markdown::postprocess`
+/// removes an isolated digit-only line afterwards without consulting any of
+/// this.
 fn page_number_bands(bounds: Option<&(f32, f32)>) -> (f32, f32) {
-    match bounds {
-        Some(&(y0, y1)) if y1 - y0 > 72.0 => {
-            let scale = (y1 - y0) / PAGE_NUMBER_BAND_REFERENCE_HEIGHT;
-            (
-                y0 + PAGE_NUMBER_BOTTOM_Y * scale,
-                y0 + PAGE_NUMBER_TOP_Y * scale,
-            )
+    let top = match bounds {
+        Some(&(y0, y1)) if y1 - y0 > MIN_USABLE_PAGE_HEIGHT => {
+            (y1 - PAGE_NUMBER_TOP_MARGIN).max(PAGE_NUMBER_TOP_Y)
         }
-        _ => (PAGE_NUMBER_BOTTOM_Y, PAGE_NUMBER_TOP_Y),
-    }
+        _ => PAGE_NUMBER_TOP_Y,
+    };
+    (PAGE_NUMBER_BOTTOM_Y, top)
 }
 const SPREAD_MIN_CONTENT_WIDTH_EM: f32 = 40.0;
 const SPREAD_EDGE_FRACTION: f32 = 0.25;
@@ -1152,7 +1186,7 @@ const ADJACENT_PAGE_MIN_CONTENT_WIDTH_EM: f32 = 26.0;
 
 type ContextualCandidateOccurrence = (u32, f32, Vec<(usize, u32)>);
 
-fn page_number_value(item: &TextItem, page_bounds: &HashMap<u32, (f32, f32)>) -> Option<u32> {
+fn page_number_value(item: &TextItem, page_bounds: &PageVerticalBounds) -> Option<u32> {
     if !matches!(
         item.item_type,
         crate::types::ItemType::Text | crate::types::ItemType::FormField
@@ -1514,7 +1548,7 @@ fn page_number_context_masks(
     items: &[TextItem],
     candidate_values: &[Option<u32>],
     document_page_count: usize,
-    page_bounds: &HashMap<u32, (f32, f32)>,
+    page_bounds: &PageVerticalBounds,
 ) -> (Vec<bool>, Vec<bool>) {
     let mut contextual = vec![false; items.len()];
     let mut explicit_folio = vec![false; items.len()];
@@ -1792,7 +1826,7 @@ fn page_number_context_masks(
 fn page_number_removal_mask(
     items: &[TextItem],
     document_page_count: usize,
-    page_bounds: &HashMap<u32, (f32, f32)>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<bool> {
     let candidate_values: Vec<Option<u32>> = items
         .iter()
@@ -1815,7 +1849,7 @@ fn page_number_removal_mask(
 pub(super) fn needs_document_page_number_context(
     items: &[TextItem],
     document_page_count: usize,
-    page_bounds: &HashMap<u32, (f32, f32)>,
+    page_bounds: &PageVerticalBounds,
 ) -> bool {
     let candidate_values: Vec<Option<u32>> = items
         .iter()
@@ -1849,7 +1883,7 @@ pub(crate) fn filter_markdown_page_numbers(
 pub(crate) fn filter_markdown_page_numbers_with_removed_pages(
     items: Vec<TextItem>,
     document_page_count: u32,
-    page_bounds: &HashMap<u32, (f32, f32)>,
+    page_bounds: &PageVerticalBounds,
 ) -> (Vec<TextItem>, HashSet<u32>, Vec<bool>) {
     let remove = page_number_removal_mask(&items, document_page_count as usize, page_bounds);
     let mut removed_pages = HashSet::new();
@@ -2087,7 +2121,9 @@ fn split_column_stragglers(lines: Vec<TextLine>) -> (Vec<TextLine>, Vec<TextLine
 }
 
 pub fn group_into_lines(items: Vec<TextItem>) -> Vec<TextLine> {
-    group_into_lines_with_thresholds(items, &HashMap::new(), &HashSet::new())
+    // Items-only public API: the caller holds no document, so the folio bands
+    // stay at their US-Letter calibration.
+    group_into_lines_with_thresholds(items, &HashMap::new(), &HashSet::new(), &HashMap::new())
 }
 
 /// Group text items into lines without removing numeric page headers or footers.
@@ -2102,6 +2138,12 @@ pub fn group_into_lines_preserving_all_text(items: Vec<TextItem>) -> Vec<TextLin
         &HashSet::new(),
         &HashMap::new(),
         &HashMap::new(),
+        // Nothing is removed on this path, but the bands still decide which
+        // items feed column detection, so this is a real loss of fidelity and
+        // not a case where the geometry is irrelevant. A `TextItem` carries no
+        // page box, so there is nothing to pass at this signature; the caller
+        // that wants consistency has to hand the bounds in from a document.
+        &HashMap::new(),
         false,
     )
 }
@@ -2113,12 +2155,14 @@ pub(crate) fn group_into_lines_with_thresholds(
     items: Vec<TextItem>,
     page_thresholds: &HashMap<u32, f32>,
     table_pages: &HashSet<u32>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<TextLine> {
     group_into_lines_with_thresholds_and_charts(
         items,
         page_thresholds,
         table_pages,
         &HashMap::new(),
+        page_bounds,
     )
 }
 
@@ -2132,6 +2176,7 @@ pub(crate) fn group_into_lines_with_thresholds_and_charts(
     page_thresholds: &HashMap<u32, f32>,
     table_pages: &HashSet<u32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<TextLine> {
     group_into_lines_with_thresholds_and_regions(
         items,
@@ -2139,6 +2184,7 @@ pub(crate) fn group_into_lines_with_thresholds_and_charts(
         table_pages,
         chart_regions,
         &HashMap::new(),
+        page_bounds,
     )
 }
 
@@ -2152,6 +2198,7 @@ pub(crate) fn group_prefiltered_items_into_lines_with_thresholds_and_charts(
     page_thresholds: &HashMap<u32, f32>,
     table_pages: &HashSet<u32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<TextLine> {
     group_into_lines_with_thresholds_and_regions_impl(
         items,
@@ -2159,6 +2206,7 @@ pub(crate) fn group_prefiltered_items_into_lines_with_thresholds_and_charts(
         table_pages,
         chart_regions,
         &HashMap::new(),
+        page_bounds,
         false,
     )
 }
@@ -2169,6 +2217,7 @@ pub(crate) fn group_into_lines_with_thresholds_and_regions(
     table_pages: &HashSet<u32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
     image_regions: &HashMap<u32, Vec<super::reading_order::ImageRegion>>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<TextLine> {
     group_into_lines_with_thresholds_and_regions_impl(
         items,
@@ -2176,6 +2225,7 @@ pub(crate) fn group_into_lines_with_thresholds_and_regions(
         table_pages,
         chart_regions,
         image_regions,
+        page_bounds,
         true,
     )
 }
@@ -2186,6 +2236,7 @@ pub(crate) fn group_prefiltered_items_into_lines_with_thresholds_and_regions(
     table_pages: &HashSet<u32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
     image_regions: &HashMap<u32, Vec<super::reading_order::ImageRegion>>,
+    page_bounds: &PageVerticalBounds,
 ) -> Vec<TextLine> {
     group_into_lines_with_thresholds_and_regions_impl(
         items,
@@ -2193,6 +2244,7 @@ pub(crate) fn group_prefiltered_items_into_lines_with_thresholds_and_regions(
         table_pages,
         chart_regions,
         image_regions,
+        page_bounds,
         false,
     )
 }
@@ -2203,6 +2255,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
     table_pages: &HashSet<u32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
     image_regions: &HashMap<u32, Vec<super::reading_order::ImageRegion>>,
+    page_bounds: &PageVerticalBounds,
     filter_page_numbers: bool,
 ) -> Vec<TextLine> {
     if items.is_empty() {
@@ -2223,7 +2276,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
             .map(|item| item.page as usize)
             .max()
             .unwrap_or(0);
-        let remove = page_number_removal_mask(&items, observed_page_count, &HashMap::new());
+        let remove = page_number_removal_mask(&items, observed_page_count, page_bounds);
         items
             .into_iter()
             .zip(remove)
@@ -2244,10 +2297,13 @@ fn group_into_lines_with_thresholds_and_regions_impl(
         let page_items: Vec<TextItem> = items.iter().filter(|i| i.page == page).cloned().collect();
         // Page-edge numeric runs are weak evidence for column geometry. Keep
         // contextual values for line assembly, but prevent their preservation
-        // from changing the page's inferred layout.
+        // from changing the page's inferred layout. Judged with the same bands
+        // as removal: a digit the filter kept as body must not still count as
+        // page furniture here, or the page's layout is inferred from an item
+        // set that does not match the one it emits.
         let column_detection_items: Vec<TextItem> = page_items
             .iter()
-            .filter(|item| page_number_value(item, &HashMap::new()).is_none())
+            .filter(|item| page_number_value(item, page_bounds).is_none())
             .cloned()
             .collect();
         let column_detection_items = column_detection_items.as_slice();
@@ -2304,7 +2360,7 @@ fn group_into_lines_with_thresholds_and_regions_impl(
                 let col_input: Vec<TextItem> = page_items
                     .iter()
                     .filter(|it| {
-                        if page_number_value(it, &HashMap::new()).is_some() {
+                        if page_number_value(it, page_bounds).is_some() {
                             return false;
                         }
                         let cx = it.x + it.width / 2.0;
@@ -3525,17 +3581,28 @@ mod tests {
     }
 
     #[test]
-    fn page_number_bands_scale_with_page_height() {
-        // US Letter keeps the exact historical thresholds.
+    fn page_number_top_band_follows_the_page_top_edge() {
+        // US Letter is the calibration, and must come out untouched.
         assert_eq!(page_number_bands(Some(&(0.0, 792.0))), (100.0, 720.0));
-        // A4 scales both bands so the physical margins match Letter's.
+        // A4: one inch below its own top edge, which is the 122pt of body
+        // text that issue #283 was losing.
         let (bottom, top) = page_number_bands(Some(&(0.0, 841.89)));
-        assert!((bottom - 106.3).abs() < 0.1, "bottom band: {bottom}");
-        assert!((top - 765.35).abs() < 0.1, "top band: {top}");
-        // A box with a nonzero origin shifts the bands with it.
-        let (bottom, top) = page_number_bands(Some(&(100.0, 892.0)));
-        assert!((bottom - 200.0).abs() < 0.1, "offset bottom: {bottom}");
-        assert!((top - 820.0).abs() < 0.1, "offset top: {top}");
+        assert_eq!(bottom, 100.0, "the bottom band does not move");
+        assert!((top - 769.89).abs() < 0.1, "A4 top band: {top}");
+        // A print A4 with a trim CropBox: the band follows the visible top
+        // edge, and the bottom stays put rather than riding up on the origin.
+        let (bottom, top) = page_number_bands(Some(&(9.0, 832.89)));
+        assert_eq!(bottom, 100.0, "a box origin must not move the bottom band");
+        assert!((top - 760.89).abs() < 0.1, "cropped A4 top band: {top}");
+        // A5 is the case the clamp exists for. Nothing on a 595pt page ever
+        // reached y=720, so it had no top band at all; a measured 523 would
+        // invent one over the first lines of text.
+        let (_, top) = page_number_bands(Some(&(0.0, 595.28)));
+        assert_eq!(top, 720.0, "A5 must keep the calibrated, unreachable band");
+        // A vertically imposed spread, where the calibrated band covered more
+        // than half the sheet.
+        let (_, top) = page_number_bands(Some(&(0.0, 1584.0)));
+        assert!((top - 1512.0).abs() < 0.1, "imposed spread top band: {top}");
         // Missing or degenerate geometry keeps the absolute constants.
         assert_eq!(page_number_bands(None), (100.0, 720.0));
         assert_eq!(page_number_bands(Some(&(0.0, 10.0))), (100.0, 720.0));
@@ -3554,45 +3621,65 @@ mod tests {
         // A digit in A4's real top margin is still a candidate.
         let folio = make_item(1, 297.0, 810.0, "7");
         assert_eq!(page_number_value(&folio, &a4), Some(7));
-        // And the bottom band scales the same way: A4 y=103 is inside the
-        // scaled bottom band (106.3), so it stays a candidate.
-        let bottom = make_item(1, 297.0, 103.0, "9");
-        assert_eq!(page_number_value(&bottom, &a4), Some(9));
+        // The bottom band does not move with the page. On the A4 paper this
+        // fix was measured against, the exponent of equation (3) is a lone `2`
+        // whose glyph sits at y=105.5 - inside the band that scaling by A4's
+        // height would produce, and deleted by it. It has to stay body.
+        let exponent = make_item(1, 370.0, 105.5, "2");
+        assert_eq!(
+            page_number_value(&exponent, &a4),
+            None,
+            "A4 y=105.5 is body"
+        );
+        // Below the calibrated depth a folio is still a folio.
+        let folio_foot = make_item(1, 297.0, 95.0, "9");
+        assert_eq!(page_number_value(&folio_foot, &a4), Some(9));
     }
 
     #[test]
-    fn contextual_deep_margin_gate_uses_the_scaled_bands() {
-        // A recurring "42 Company report" footer at A4 y=103 sits inside the
-        // scaled bottom band (106.3) but outside the Letter constant (100).
-        // The repeated-folio gate must judge it with the same scaled bands
-        // as candidacy, so the advancing footer number is still recognized.
-        let a4: HashMap<u32, (f32, f32)> = HashMap::from([
-            (1, (0.0, 841.89)),
-            (2, (0.0, 841.89)),
-            (3, (0.0, 841.89)),
-            (4, (0.0, 841.89)),
-            (5, (0.0, 841.89)),
-        ]);
-        let mut items = Vec::new();
-        for page in 1..=5u32 {
-            items.push(make_item(page, 72.0, 103.0, &format!("{}", 41 + page)));
-            items.push(make_item(page, 90.0, 103.0, "Company report"));
-            items.push(make_item(page, 72.0, 500.0, "Body content that stays"));
-        }
-        let mask = page_number_removal_mask(&items, 5, &a4);
+    fn contextual_deep_margin_gate_uses_the_measured_bands() {
+        // A recurring "42 Company report" running head shares its baseline
+        // with words, so only the deep-margin gate can strip it. That gate
+        // has to read the same bands as candidacy or the two disagree about
+        // what a margin is. A4's top band is 769.89, the calibrated one 720,
+        // so y=800 is margin either way and y=750 only under the calibrated.
+        let a4: HashMap<u32, (f32, f32)> = (1..=5u32).map(|page| (page, (0.0, 841.89))).collect();
+        let running_head = |y: f32| {
+            let mut items = Vec::new();
+            for page in 1..=5u32 {
+                items.push(make_item(page, 72.0, y, &format!("{}", 41 + page)));
+                items.push(make_item(page, 90.0, y, "Company report"));
+                items.push(make_item(page, 72.0, 500.0, "Body content that stays"));
+            }
+            items
+        };
+
+        let deep = running_head(800.0);
+        let mask = page_number_removal_mask(&deep, 5, &a4);
         for page in 0..5usize {
             assert!(
                 mask[page * 3],
-                "advancing footer folio on page {} strips",
+                "advancing folio on page {} strips",
                 page + 1
             );
             assert!(!mask[page * 3 + 2], "body content survives");
         }
-        // Without geometry the y=103 candidates are body (above the absolute
-        // 100pt band), so nothing strips - the gate stays consistent with
-        // candidacy in both modes.
-        let mask = page_number_removal_mask(&items, 5, &HashMap::new());
-        assert!(mask.iter().all(|&removed| !removed));
+
+        // y=750 is below A4's scaled band, so with geometry it is body and
+        // nothing strips; without geometry the absolute 720 makes it margin
+        // again. Either way the gate agrees with candidacy.
+        let shallow = running_head(750.0);
+        assert!(page_number_removal_mask(&shallow, 5, &a4)
+            .iter()
+            .all(|&removed| !removed));
+        let mask = page_number_removal_mask(&shallow, 5, &HashMap::new());
+        for page in 0..5usize {
+            assert!(
+                mask[page * 3],
+                "no-geometry folio on page {} strips",
+                page + 1
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -327,7 +327,11 @@ fn extract_positioned_text_with_folio_context_impl(
         None,
         CoordinateFrame::UserSpace,
     )?;
-    if !layout::needs_document_page_number_context(&selected_items, doc.get_pages().len()) {
+    if !layout::needs_document_page_number_context(
+        &selected_items,
+        doc.get_pages().len(),
+        &page_vertical_bounds(doc),
+    ) {
         return Ok((
             (selected_items, selected_rects, selected_lines),
             page_thresholds,
@@ -1319,6 +1323,22 @@ pub(crate) fn get_number(obj: &Object) -> Option<f32> {
         Object::Real(r) => Some(*r),
         _ => None,
     }
+}
+
+/// Vertical extent (y0, y1) of each page's visible box, for measuring the
+/// page-number bands from the page's real top edge. The box is the same one
+/// [`visible_page_box`] resolves for the positioned-item frame — `CropBox ∩
+/// MediaBox` with page-tree inheritance — but the values stay in raw PDF user
+/// space, because the markdown pipeline the bands serve never leaves it.
+/// Pages without a resolvable box are absent, which keeps the calibrated
+/// absolute bands for them.
+pub(crate) fn page_vertical_bounds(doc: &Document) -> HashMap<u32, (f32, f32)> {
+    doc.get_pages()
+        .into_iter()
+        .filter_map(|(page_num, page_id)| {
+            visible_page_box(doc, page_id).map(|page_box| (page_num, (page_box.y0, page_box.y1)))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -231,6 +231,13 @@ pub(crate) fn extract_page_text_items_in_page_box(
 /// Per-page adaptive join thresholds from Canva-style letter-spacing detection.
 pub(crate) type PageThresholds = HashMap<u32, f32>;
 
+/// Per-page `(y0, y1)` extent of the visible box, so the folio bands can be
+/// measured from the page's real top edge. Ordered bottom-then-top. The alias
+/// is documentation, not enforcement — a swapped pair still type-checks, and
+/// what saves it is that a negative height fails the guard in
+/// `layout::page_number_bands` and falls back to the calibrated constants.
+pub(crate) type PageVerticalBounds = HashMap<u32, (f32, f32)>;
+
 /// Extract positioned text, rectangles, and line segments from a pre-loaded document.
 ///
 /// Also returns per-page adaptive join thresholds for Canva-style pages.
@@ -1332,7 +1339,7 @@ pub(crate) fn get_number(obj: &Object) -> Option<f32> {
 /// space, because the markdown pipeline the bands serve never leaves it.
 /// Pages without a resolvable box are absent, which keeps the calibrated
 /// absolute bands for them.
-pub(crate) fn page_vertical_bounds(doc: &Document) -> HashMap<u32, (f32, f32)> {
+pub(crate) fn page_vertical_bounds(doc: &Document) -> PageVerticalBounds {
     doc.get_pages()
         .into_iter()
         .filter_map(|(page_num, page_id)| {
@@ -1887,6 +1894,7 @@ mod tests {
                     &HashMap::new(),
                     &HashSet::new(),
                     &HashMap::new(),
+                    &HashMap::new(),
                 ),
             );
         }
@@ -2160,6 +2168,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &HashMap::new(),
+            &HashMap::new(),
         );
 
         assert_eq!(lines.len(), 1);
@@ -2183,6 +2192,7 @@ mod tests {
             items,
             &HashMap::new(),
             &HashSet::new(),
+            &HashMap::new(),
             &HashMap::new(),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,11 @@ fn extract_pages_markdown_mem_impl(
     // Per-page Markdown receives the original items plus these decisions so
     // table detection can retain legitimate numeric cells.
     let (filtered_items, removed_page_number_pages, page_number_removal_mask) =
-        extractor::filter_markdown_page_numbers_with_removed_pages(all_items.clone(), page_count);
+        extractor::filter_markdown_page_numbers_with_removed_pages(
+            all_items.clone(),
+            page_count,
+            &extractor::page_vertical_bounds(&doc),
+        );
 
     // Tables need the original numeric cells; columns use folio-cleaned
     // evidence so removed page numbers cannot create false layout metadata.
@@ -4392,6 +4396,7 @@ fn process_document(
                 items,
                 page_count,
                 options.page_filter.as_ref(),
+                &extractor::page_vertical_bounds(&doc),
             );
 
             let text_quality = analyze_text_quality(&items);
@@ -6197,9 +6202,14 @@ fn select_items_with_document_folio_context(
     all_items: Vec<types::TextItem>,
     page_count: u32,
     page_filter: Option<&HashSet<u32>>,
+    page_bounds: &std::collections::HashMap<u32, (f32, f32)>,
 ) -> FolioFilteredItems {
     let (all_layout_items, all_removed_pages, all_removal_mask) =
-        extractor::filter_markdown_page_numbers_with_removed_pages(all_items.clone(), page_count);
+        extractor::filter_markdown_page_numbers_with_removed_pages(
+            all_items.clone(),
+            page_count,
+            page_bounds,
+        );
     let selected_page = |page: u32| page_filter.is_none_or(|filter| filter.contains(&page));
 
     let (items, removal_mask) = all_items
@@ -6603,8 +6613,11 @@ mod tests {
             test_item("1", 25.0, 20.0, 12.0, 10.0),
             test_item("2", 520.0, 60.0, 12.0, 10.0),
         ];
-        let (filtered, _, _) =
-            extractor::filter_markdown_page_numbers_with_removed_pages(items.clone(), 1);
+        let (filtered, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
+            items.clone(),
+            1,
+            &std::collections::HashMap::new(),
+        );
         assert!(filtered.is_empty());
 
         let filtered = compute_layout_complexity(&items, &filtered, &[], &[]);
@@ -6696,16 +6709,23 @@ mod tests {
             .filter(|item| item.page == 1)
             .cloned()
             .collect();
-        let (page_local_layout, _, _) =
-            extractor::filter_markdown_page_numbers_with_removed_pages(page_one_items.clone(), 4);
+        let (page_local_layout, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
+            page_one_items.clone(),
+            4,
+            &std::collections::HashMap::new(),
+        );
         let page_local = compute_layout_complexity(&page_one_items, &page_local_layout, &[], &[]);
         assert!(
             page_local.pages_with_columns.contains(&1),
             "fixture must reproduce page-local folio column evidence"
         );
 
-        let selected =
-            select_items_with_document_folio_context(items, 4, Some(&HashSet::from([1])));
+        let selected = select_items_with_document_folio_context(
+            items,
+            4,
+            Some(&HashSet::from([1])),
+            &std::collections::HashMap::new(),
+        );
         assert_eq!(
             selected
                 .removal_mask

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1285,7 +1285,6 @@ pub fn extract_tables_in_regions_mem(
 
     let needed_pages: HashSet<u32> = page_regions.iter().map(|(p, _)| p + 1).collect();
     let font_cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed_pages));
-    let page_bounds = extractor::page_vertical_bounds(&doc);
 
     let mut items_by_page: HashMap<u32, Vec<TextItem>> = HashMap::new();
     let mut rects_by_page: HashMap<u32, Vec<PdfRect>> = HashMap::new();
@@ -1332,6 +1331,19 @@ pub fn extract_tables_in_regions_mem(
         rects_by_page.insert(*page_num, rects);
         lines_by_page.insert(*page_num, lines);
     }
+
+    // Folio bands for the column-table builder, expressed in the frame its
+    // items are already in. `extract_page_text_items_in_page_box` shifted
+    // every item so that the visible box's lower-left corner is the origin,
+    // so a page's extent is `0..height` here — not the raw user-space
+    // `(y0, y1)` that `extractor::page_vertical_bounds` reports for the
+    // markdown pipeline, which never leaves user space. Handing the raw pair
+    // to this path would put the top band a full `y0` above the items on any
+    // page whose box origin is not at zero.
+    let page_bounds: extractor::PageVerticalBounds = page_heights
+        .iter()
+        .map(|(page, height)| (*page, (0.0, *height)))
+        .collect();
 
     let mut results = Vec::with_capacity(page_regions.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,11 +531,12 @@ fn extract_pages_markdown_mem_impl(
     // Resolve page numbers with full-document context before partitioning.
     // Per-page Markdown receives the original items plus these decisions so
     // table detection can retain legitimate numeric cells.
+    let page_bounds = extractor::page_vertical_bounds(&doc);
     let (filtered_items, removed_page_number_pages, page_number_removal_mask) =
         extractor::filter_markdown_page_numbers_with_removed_pages(
             all_items.clone(),
             page_count,
-            &extractor::page_vertical_bounds(&doc),
+            &page_bounds,
         );
 
     // Tables need the original numeric cells; columns use folio-cleaned
@@ -552,7 +553,13 @@ fn extract_pages_markdown_mem_impl(
     // Compute font stats from full document (cross-page consistency).
     let font_stats = markdown::analysis::calculate_font_stats_from_items(&filtered_items);
     let repeated_header_footer_items = if strip_repeated_headers_footers {
-        repeated_header_footer_item_keys(&all_items, &page_thresholds, &chart_regions, page_count)
+        repeated_header_footer_item_keys(
+            &all_items,
+            &page_thresholds,
+            &chart_regions,
+            page_count,
+            &page_bounds,
+        )
     } else {
         HashSet::new()
     };
@@ -669,6 +676,7 @@ fn extract_pages_markdown_mem_impl(
                     prefiltered_page_number_pages: Some(&removed_page_number_pages),
                     prefiltered_page_number_mask: Some(&page_number_removal_mask),
                     precomputed_chart_regions: Some(&chart_regions),
+                    page_bounds: &page_bounds,
                 },
             )
         };
@@ -790,6 +798,7 @@ fn repeated_header_footer_item_keys(
     page_thresholds: &HashMap<u32, f32>,
     chart_regions: &HashMap<u32, Vec<(f32, f32, f32, f32)>>,
     page_count: u32,
+    page_bounds: &extractor::PageVerticalBounds,
 ) -> HashSet<HeaderFooterItemKey> {
     let candidates = items
         .iter()
@@ -806,6 +815,7 @@ fn repeated_header_footer_item_keys(
         page_thresholds,
         &HashSet::new(),
         chart_regions,
+        page_bounds,
     );
     let all_items: HashSet<_> = lines
         .iter()
@@ -860,7 +870,13 @@ mod ocr_header_footer_tests {
             thresholds.insert(page, 0.1);
         }
 
-        let removed = repeated_header_footer_item_keys(&items, &thresholds, &HashMap::new(), 3);
+        let removed = repeated_header_footer_item_keys(
+            &items,
+            &thresholds,
+            &HashMap::new(),
+            3,
+            &HashMap::new(),
+        );
         assert_eq!(removed.len(), 2);
         for page in 1..=3 {
             assert_eq!(
@@ -1269,6 +1285,7 @@ pub fn extract_tables_in_regions_mem(
 
     let needed_pages: HashSet<u32> = page_regions.iter().map(|(p, _)| p + 1).collect();
     let font_cmaps = FontCMaps::from_doc_pages_fast(&doc, Some(&needed_pages));
+    let page_bounds = extractor::page_vertical_bounds(&doc);
 
     let mut items_by_page: HashMap<u32, Vec<TextItem>> = HashMap::new();
     let mut rects_by_page: HashMap<u32, Vec<PdfRect>> = HashMap::new();
@@ -1531,7 +1548,9 @@ pub fn extract_tables_in_regions_mem(
             {
                 candidates.push(candidate);
             }
-            if let Some(table) = tables::try_build_table_from_columns(&matched, page_1idx) {
+            if let Some(table) =
+                tables::try_build_table_from_columns(&matched, page_1idx, &page_bounds)
+            {
                 if let Some(candidate) = evaluate(TableCandidateSource::Column, &table) {
                     candidates.push(candidate);
                 }
@@ -4375,6 +4394,10 @@ fn process_document(
                     .as_ref()
                     .is_none_or(|filter| filter.contains(&page))
             };
+            // Measured once and shared: the folio filter, column detection and
+            // the column table builder must all read the same page geometry or
+            // they disagree about where a page's margin is.
+            let page_bounds = extractor::page_vertical_bounds(&doc);
             let rects: Vec<_> = rects
                 .into_iter()
                 .filter(|rect| selected_page(rect.page))
@@ -4396,7 +4419,7 @@ fn process_document(
                 items,
                 page_count,
                 options.page_filter.as_ref(),
-                &extractor::page_vertical_bounds(&doc),
+                &page_bounds,
             );
 
             let text_quality = analyze_text_quality(&items);
@@ -4425,6 +4448,7 @@ fn process_document(
                         page_count,
                         prefiltered_page_number_pages: Some(&removed_pages),
                         prefiltered_page_number_mask: Some(removal_mask.as_slice()),
+                        page_bounds: &page_bounds,
                         precomputed_chart_regions: Some(&chart_regions),
                     },
                 ))
@@ -6202,7 +6226,7 @@ fn select_items_with_document_folio_context(
     all_items: Vec<types::TextItem>,
     page_count: u32,
     page_filter: Option<&HashSet<u32>>,
-    page_bounds: &std::collections::HashMap<u32, (f32, f32)>,
+    page_bounds: &extractor::PageVerticalBounds,
 ) -> FolioFilteredItems {
     let (all_layout_items, all_removed_pages, all_removal_mask) =
         extractor::filter_markdown_page_numbers_with_removed_pages(
@@ -6616,7 +6640,7 @@ mod tests {
         let (filtered, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
             items.clone(),
             1,
-            &std::collections::HashMap::new(),
+            &HashMap::new(),
         );
         assert!(filtered.is_empty());
 
@@ -6712,7 +6736,7 @@ mod tests {
         let (page_local_layout, _, _) = extractor::filter_markdown_page_numbers_with_removed_pages(
             page_one_items.clone(),
             4,
-            &std::collections::HashMap::new(),
+            &HashMap::new(),
         );
         let page_local = compute_layout_complexity(&page_one_items, &page_local_layout, &[], &[]);
         assert!(
@@ -6724,7 +6748,7 @@ mod tests {
             items,
             4,
             Some(&HashSet::from([1])),
-            &std::collections::HashMap::new(),
+            &HashMap::new(),
         );
         assert_eq!(
             selected

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -2232,6 +2232,7 @@ fn convert_items_with_rects_lines_and_table_output(
         crate::extractor::filter_markdown_page_numbers_with_removed_pages(
             non_table_items.into_iter().map(|(_, item)| item).collect(),
             document_page_count,
+            &std::collections::HashMap::new(),
         )
         .0
     };

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1428,6 +1428,7 @@ pub fn to_markdown_from_items_with_rects_and_page_count(
             prefiltered_page_number_pages: None,
             prefiltered_page_number_mask: None,
             precomputed_chart_regions: None,
+            page_bounds: &HashMap::new(),
         },
     )
 }
@@ -1448,6 +1449,10 @@ pub(crate) struct MarkdownDocumentContext<'a> {
     /// Optional chart masks shared with layout analysis so the geometry is
     /// detected once and interpreted identically by both pipelines.
     pub(crate) precomputed_chart_regions: Option<&'a PageChartRegions>,
+    /// Vertical extent of each page's visible box, so the folio bands match
+    /// the page's real height. Empty on the items-only entry points, whose
+    /// callers hold no document to measure.
+    pub(crate) page_bounds: &'a crate::extractor::PageVerticalBounds,
 }
 
 /// Convert positioned text items to markdown, using rectangles and line segments for table detection.
@@ -1494,6 +1499,10 @@ pub(crate) fn complete_table_markdown_from_items(
             prefiltered_page_number_pages: None,
             prefiltered_page_number_mask: None,
             precomputed_chart_regions: None,
+            // OCR fusion hands in items recovered from a rendered page, not
+            // a document, so there is no page box to measure: the folio
+            // bands stay at their US-Letter calibration.
+            page_bounds: &HashMap::new(),
         },
         TableOutputMode::CompleteTables,
     );
@@ -1533,6 +1542,7 @@ fn convert_items_with_rects_lines_and_table_output(
         prefiltered_page_number_pages,
         prefiltered_page_number_mask,
         precomputed_chart_regions,
+        page_bounds,
     } = context;
 
     if items.is_empty() {
@@ -1994,7 +2004,9 @@ fn convert_items_with_rects_lines_and_table_output(
             });
             let has_structural_elements = band_rects.len() >= 6 || band_lines.len() >= 4;
             if !band_has_tables && !has_structural_elements {
-                if let Some(table) = crate::tables::try_build_table_from_columns(band_items, page) {
+                if let Some(table) =
+                    crate::tables::try_build_table_from_columns(band_items, page, page_bounds)
+                {
                     for &idx in &table.item_indices {
                         if let Some(&page_idx) = band_index_map.get(idx) {
                             if let Some(&(global_idx, _)) = group.get(page_idx) {
@@ -2232,7 +2244,7 @@ fn convert_items_with_rects_lines_and_table_output(
         crate::extractor::filter_markdown_page_numbers_with_removed_pages(
             non_table_items.into_iter().map(|(_, item)| item).collect(),
             document_page_count,
-            &std::collections::HashMap::new(),
+            page_bounds,
         )
         .0
     };
@@ -2247,6 +2259,7 @@ fn convert_items_with_rects_lines_and_table_output(
             &table_page_set,
             &page_chart_map,
             &page_image_regions,
+            page_bounds,
         )
     } else {
         // Separate items into physical-band pages, chart/prose pages, and
@@ -2276,6 +2289,7 @@ fn convert_items_with_rects_lines_and_table_output(
                 &table_page_set,
                 &page_chart_map,
                 &page_image_regions,
+                page_bounds,
             );
         // Process each split page's bands independently, then interleave
         // by Y position so paired zones (e.g. left/right months) appear together.
@@ -2299,6 +2313,7 @@ fn convert_items_with_rects_lines_and_table_output(
                             page_thresholds,
                             &table_page_set,
                             &page_chart_map,
+                            page_bounds,
                         ),
                     );
                 }
@@ -2333,6 +2348,7 @@ fn convert_items_with_rects_lines_and_table_output(
                                 page_thresholds,
                                 &table_page_set,
                                 &page_chart_map,
+                                page_bounds,
                             ),
                         );
                     }
@@ -2374,6 +2390,7 @@ fn convert_items_with_rects_lines_and_table_output(
                         page_thresholds,
                         &table_page_set,
                         &page_chart_map,
+                        page_bounds,
                     ),
                 );
                 remaining = below;
@@ -2746,6 +2763,7 @@ mod tests {
                 prefiltered_page_number_pages: Some(&removed_pages),
                 prefiltered_page_number_mask: Some(&removal_mask),
                 precomputed_chart_regions: None,
+                page_bounds: &HashMap::new(),
             },
         );
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -358,7 +358,11 @@ pub(crate) enum TableDetectionMode {
 /// purely by text alignment — common in exam/reference tables.
 ///
 /// Requires ≥3 columns, ≥3 rows, and ≥40% cell fill rate.
-pub(crate) fn try_build_table_from_columns(items: &[TextItem], page: u32) -> Option<Table> {
+pub(crate) fn try_build_table_from_columns(
+    items: &[TextItem],
+    page: u32,
+    page_bounds: &crate::extractor::PageVerticalBounds,
+) -> Option<Table> {
     use crate::extractor::{
         detect_columns, group_into_lines_with_thresholds, is_newspaper_layout, ColumnRegion,
     };
@@ -472,6 +476,7 @@ pub(crate) fn try_build_table_from_columns(items: &[TextItem], page: u32) -> Opt
                 bucket.clone(),
                 &thresholds,
                 &std::collections::HashSet::new(),
+                page_bounds,
             )
         })
         .collect();
@@ -1642,7 +1647,8 @@ mod tests {
             make_char("MPa", 514.7, 374.6, 10.0, 18.4),
         ];
 
-        let table = try_build_table_from_columns(&items, 1).unwrap();
+        let table =
+            try_build_table_from_columns(&items, 1, &std::collections::HashMap::new()).unwrap();
         let md = table_to_markdown(&table);
 
         assert!(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -163,6 +163,109 @@ fn make_recurring_contextual_folio_pdf() -> Vec<u8> {
     pdf
 }
 
+/// Three A4 pages carrying digit-only body content in both margins.
+///
+/// Shaped as contents entries rather than a grid, because table detection is
+/// handed the unfiltered items and hands the digits back: a fixture whose rows
+/// look tabular passes on every build and proves nothing. Each digit also sits
+/// far from its label, past the same-line context gap that rescues a digit
+/// standing beside words — the gap that makes the upstream issue's own repro
+/// pass unchanged.
+///
+/// The contents number at y=740 is inside the US-Letter top band (720) and
+/// outside A4's (769.89). The body digit at y=103 is the mirror case: outside
+/// the calibrated bottom band, inside a bottom band scaled up by A4's height
+/// (106.3). Each page carries its own pair, because lines that repeat
+/// verbatim across pages are collapsed as running material and only the first
+/// would survive to be checked.
+///
+/// The real folio is the digit at y=800, and it is written as a running head
+/// beside words on purpose: `markdown::postprocess` deletes an isolated
+/// digit-only line without consulting the bands at all, so a folio standing
+/// alone would be stripped whatever the geometry decided and would prove
+/// nothing about it.
+fn make_a4_margin_body_digits_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        "<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>",
+    );
+    for page_index in 0usize..3 {
+        let page_id = 3 + page_index * 2;
+        let content_id = page_id + 1;
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            page_id,
+            &format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595.28 841.89] /Resources << /Font << /F1 9 0 R >> >> /Contents {content_id} 0 R >>"
+            ),
+        );
+        let page_number = page_index + 1;
+        let contents_number = 20 + page_number;
+        let body_digit = 90 + page_number;
+        let heading = ["Introduction", "Methods", "Results"][page_index];
+        let footing = ["alpha", "beta", "gamma"][page_index];
+        let content = format!(
+            "BT /F1 9 Tf \
+             1 0 0 1 72 740 Tm ({heading}) Tj 1 0 0 1 500 740 Tm ({contents_number}) Tj \
+             1 0 0 1 72 400 Tm (Body prose {footing} carrying no digits) Tj \
+             1 0 0 1 72 103 Tm (Risk indicator {footing}) Tj 1 0 0 1 500 103 Tm ({body_digit}) Tj \
+             1 0 0 1 72 800 Tm ({page_number}) Tj 1 0 0 1 110 800 Tm (Company report) Tj ET"
+        );
+        add_object(
+            &mut pdf,
+            &mut offsets,
+            content_id,
+            &format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                content.len(),
+                content
+            ),
+        );
+    }
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        9,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
 fn make_pdf_with_malformed_unselected_page() -> Vec<u8> {
     let mut pdf = b"%PDF-1.4\n".to_vec();
     let mut offsets = vec![0usize];
@@ -3721,6 +3824,74 @@ fn test_extract_pages_markdown_uses_document_wide_folio_context() {
             "recurring contextual folio survived on page {}: {}",
             index + 1,
             page.markdown
+        );
+    }
+}
+
+/// Numbers as the Markdown presents them, so a table cell and a bare word
+/// compare the same way. Splitting on whitespace alone would leave `|14|`.
+fn number_tokens(markdown: &str) -> Vec<&str> {
+    markdown
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '.')
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+#[test]
+fn test_extract_pages_markdown_keeps_a4_body_digits_in_both_margins() {
+    let pdf = make_a4_margin_body_digits_pdf();
+    let result = extract_pages_markdown_mem(&pdf, None).unwrap();
+
+    assert_eq!(result.pages.len(), 3);
+    for (index, page) in result.pages.iter().enumerate() {
+        let tokens = number_tokens(&page.markdown);
+        let page_number = (index + 1).to_string();
+        let contents_number = (21 + index).to_string();
+        let body_digit = (91 + index).to_string();
+        assert!(
+            tokens.contains(&contents_number.as_str()),
+            "A4 contents entry below the top margin of page {page_number} lost \
+             its number to the folio filter: {}",
+            page.markdown
+        );
+        assert!(
+            tokens.contains(&body_digit.as_str()),
+            "A4 body digit above the footer margin on page {page_number} was \
+             removed as a folio: {}",
+            page.markdown
+        );
+        assert!(
+            page.markdown.contains("Company report"),
+            "the running head itself must survive on page {page_number}: {}",
+            page.markdown
+        );
+        assert!(
+            !tokens.contains(&page_number.as_str()),
+            "the real folio on page {page_number} survived: {}",
+            page.markdown
+        );
+    }
+}
+
+#[test]
+fn test_process_pdf_keeps_a4_body_digits_in_both_margins() {
+    // The same page through the `pdf2md` entry point, which reaches the folio
+    // filter by a different route than `extract_pages_markdown`.
+    let pdf = make_a4_margin_body_digits_pdf();
+    let result = process_pdf_mem_with_options(&pdf, PdfOptions::new()).unwrap();
+    let markdown = result.markdown.expect("pdf2md mode produces Markdown");
+    let tokens = number_tokens(&markdown);
+
+    for expected in ["21", "22", "23", "91", "92", "93"] {
+        assert!(
+            tokens.contains(&expected),
+            "A4 body digit {expected} was removed as a folio: {markdown}"
+        );
+    }
+    for folio in ["1", "2", "3"] {
+        assert!(
+            !tokens.contains(&folio),
+            "folio {folio} survived: {markdown}"
         );
     }
 }


### PR DESCRIPTION
Fixes #283, building on @mathurshubham's #287 — the first two commits are theirs, unchanged apart from a rebase onto `main`.

## What #287 gets right, and where I measured it costing content

#287 has the diagnosis exactly right: `PAGE_NUMBER_TOP_Y = 720.0` is calibrated for US Letter, and on A4 it turns the top ~122pt into the folio zone. It scales both bands by the page's visible-box height.

Scaling the **bottom** band is where it costs content. On A4 the band grows from 100 to 106.3, and that deletes the exponent of a displayed equation in `arXiv:2606.03264v1` — a lone `2` at y=105.52 on page 13, which `extract_text_with_positions` still reports:

```
main f4aab3b → #287, process_pdf Markdown, page 13
- *𝐾* 2 1 ∑︁(*𝑘*) *𝑉𝑟*(*𝑥*)= *𝑟* (*𝑥*)−*𝑟*mean(*𝑥*), (3) *𝐾* *𝑘*=1
+ *𝐾* 1 ∑︁(*𝑘*) *𝑉𝑟*(*𝑥*)= *𝑟* (*𝑥*)−*𝑟*mean(*𝑥*), (3) *𝐾* *𝑘*=1
```

Scaling the **top** band down is quieter. On 1.14.1 the gate is `y > 720`, so on any page shorter than 720pt no top band exists at all — nothing was ever a candidate. Scaled, A5 (595.28) gets `y > 541.2` and a 16:9 slide gets `y > 490.9`, so digit-only content in the first lines of those pages becomes removable where it was unconditionally safe.

## What this changes

**Only the top band knows about the page, and it is measured, not scaled.** `PAGE_NUMBER_TOP_Y` was never a threshold — it is "one inch below the top edge" written down as the value that margin takes on Letter. Measuring the margin from the page's real top edge restores what it meant, in one term:

```rust
let top = (y1 - PAGE_NUMBER_TOP_MARGIN).max(PAGE_NUMBER_TOP_Y);
```

| page | top band | vs 1.14.1 |
| --- | --- | --- |
| US Letter 792 | 720 | identical, by construction |
| A4 841.89 | 769.89 | the fix |
| A5 595.28 | 720, unreachable | unchanged — it had no top band |
| imposed spread 1584 | 1512 | instead of a band covering half the sheet |
| no geometry | 720 | identical |

Proportional scaling and this differ by 4.5pt on A4 and without bound elsewhere: on a 14400pt plotter page `720 · h/792` declares the top 1309pt — about 90 lines — the folio zone. Fixed margin is also what the comment on the constant was already describing.

**The bottom band does not move at all.** #283 is a top-band problem and nothing measured says the bottom one is wrong; every change to it I tried only deleted content. Scaling it by height gives the equation exponent above. Anchoring it to the box origin instead — `y0 + 100` — does the same thing to a print A4 whose CropBox is inset for trim (`[9 9 586.28 832.89]` puts the band at 109 and swallows that same y=105.5 glyph). Leaving it alone costs nothing that #283 asks for.

The caution runs one way on purpose. A folio left in the Markdown is noise a reader can see. A digit deleted from a formula or a table is silent, and this filter cannot undo it.

## One geometry for every folio decision

#287 threads the bounds into the removal mask. Two other places decide the same question and were left on the absolute constants:

- **Column detection** — `column_detection_items` and the chart-blind column input in `group_into_lines_with_thresholds_and_regions_impl`, which run on the document Markdown path. On A4 a digit at y=740 was kept by the filter and still counted as page furniture here, so the page's layout was inferred from an item set that did not match the one it emitted.
- **`try_build_table_from_columns`**, reachable from `to_markdown_from_items_with_rects_and_lines` and from `extract_tables_in_regions_mem`. Its per-column buckets go through `group_into_lines_with_thresholds` with `filter_page_numbers = true`, and an isolated digit in a bucket has no same-baseline context to rescue it.

Both now read the same `PageVerticalBounds`, derived once per document and carried on `MarkdownDocumentContext` beside `page_thresholds`. What is left on the calibrated constants is the items-only public surface — `group_into_lines`, `group_into_lines_preserving_all_text`, `to_markdown_from_items_*` — where a `TextItem` carries no page box and there is nothing to pass. Those say so at the call site rather than passing an unexplained literal.

## Evidence

**A regression test that fails on both predecessors.** `make_a4_margin_body_digits_pdf` builds three A4 pages with a contents number at y=740, a body digit at y=103 and a running head at y=800, asserted through `extract_pages_markdown_mem` and `process_pdf_mem`:

| build | contents number, y=740 | body digit, y=103 |
| --- | --- | --- |
| `main` 1.14.1 | **deleted** | kept |
| #287 as submitted | kept | **deleted** |
| this branch | kept | kept |

Three details the fixture needs, each found by a version that passed for the wrong reason:

- the rows are contents entries, not a grid — table detection is handed the unfiltered items and hands the digits back, so a tabular fixture passes on every build;
- each digit sits far from its label, past `PAGE_NUMBER_CONTEXT_GAP_EM` — that gap is why the issue's own synthetic repro already passes on current `main` and is not evidence either way;
- the folio shares its baseline with words, because `markdown::postprocess::remove_page_numbers` deletes an isolated digit-only line without consulting the bands at all, so a folio standing alone would be stripped whatever the geometry decided.

**Real documents.** Complete Markdown output compared against released 1.14.1 across 18 A4 documents — `arXiv:2606.03264v1` and 17 European securities Final Terms and PRIIPs KIDs, the corpus described in #283. Three lines change in the entire set, all restorations, nothing deleted anywhere:

```
arXiv p2    **1 Introduction**   →  **1 Introduction 3**
arXiv p14   (𝑘)                  →  (𝑘) <u>1</u>
KID p2      (nothing)            →  ## 1 2 3 4 5 6 7
```

All three are body content, not folios that newly survive: a contents page reference, a fraction numerator inside a formula, and the 1–7 PRIIPs summary risk indicator — one of the losses catalogued in the issue.

**Suite.** `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` (875 lib + 164 integration + 2 bin + 2 doc) all pass.

## What I could not run, and what is still open

`AGENTS.md` names `bench.py test` and `bench.py score` in the sibling `pdf-evals` repo as the gate for a layout-affecting change. That repo is not public, so I have not run it — and my 18-document substitute is A4-only, so it structurally cannot observe short trims or offset boxes. Please run the snapshot suite before merging.

Not addressed here, and worth knowing:

- `markdown::postprocess::remove_page_numbers` is a second, geometry-blind folio remover, on by default: it deletes any isolated 1–4 digit line. It plausibly explains why a bug described as swallowing eight lines of margin produced only three changed lines across 18 documents — a digit this fix restores is deleted again downstream if it lands alone on a line. Two sources of truth for "what is a page number", and only one of them was in scope here.
- Pages whose items were rotated out of box space by `correct_rotated_page` have `item.y ≤ 0`, so the whole page reads as bottom margin and every short digit-only item is a candidate, left to the contextual and recurrence gates. Unchanged by this PR either way; `page_number_bands` now says so instead of implying the box always applies.
- No `/Rotate` handling exists in the crate, so a `/Rotate 90` page with a portrait MediaBox applies the band to the wrong visual axis. Pre-existing.
- `extract_tables_in_regions_mem` derives bounds for every page of the document on a path that otherwise restricts work to the requested pages. Correct, but it grows with total pages rather than requested ones.
- The same-baseline-neighbour hardening from the issue is still out of scope, for the reason @mathurshubham gave: it changes Letter behaviour too and deserves its own discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures the top page-number band from each page’s actual top edge and uses the same per-page bounds in folio filtering, column detection, and column-based table building. US Letter behavior is unchanged; A4 and other tall pages no longer lose body digits misclassified as folios. The bottom band stays fixed to avoid deleting near-footer content.

- Behavior: top band = max(720pt, page_top − 72pt). Examples: Letter 792→720 (same), A4 841.89→769.89 (fix), A5 595.28→720 (unchanged/none), imposed 1584→1512. Pages without geometry keep calibrated constants.
- Consistency: adds `PageVerticalBounds` (`(y0, y1)` per page) via `page_vertical_bounds` and threads it through `filter_markdown_page_numbers_with_removed_pages`, `group_into_lines_with_thresholds*`, and `tables::try_build_table_from_columns`. `extract_tables_in_regions_mem` maps bounds to `(0, height)` to match its shifted page-box frame. Items‑only public APIs keep constants by design.
- Safety: bottom band remains 100pt; scaling it deleted real content (e.g., an equation exponent at y=105.5 on A4). The contextual deep-margin gate now uses the same measured bands as candidacy.
- Tests: new unit tests cover band math; new A4 regression PDFs verify both `extract_pages_markdown_mem` and `process_pdf_mem` keep body digits and remove real folios. Run the private layout snapshot suite before merging.

<sup>Written for commit 2b1cbda91e0a992e484d11213c42b17c4de5291c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

