### PR TITLE
fix(extractor): merge small-caps runs so they stop reading as table columns

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -889,17 +889,25 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     Some((end, floor * fs))
 }
 
+/// Fractional font-size band within which `merge_text_items` treats two runs as
+/// the same size. Shared with `is_small_caps_continuation`, which exists only to
+/// rescue junctions this band would otherwise break.
+const MERGE_FONT_SIZE_BAND: f32 = 0.20;
+
 /// Detect a small-caps continuation: typesetters render small caps as a
 /// full-size capital immediately followed by shrunken capitals in the same
 /// font (`(R) Tj` at 9.98pt, then `(OLANDO) Tj` at 6.74pt). Those runs are one
-/// word, but the 20% font-size band in `merge_text_items` would split them,
+/// word, but the font-size band in `merge_text_items` would split them,
 /// leaving "R" and "OLANDO" as separate items — which then read as separate
 /// table columns, since column boundaries cluster on item start positions.
 ///
 /// Gated tightly so it cannot absorb the other reasons a smaller run follows a
 /// larger one:
+///   - runs the size band already accepts — excluded by requiring the junction
+///     to *cross* the band, so within-band pairs keep the normal word-spacing
+///     logic instead of having their space suppressed
 ///   - superscripts / footnote markers — excluded by requiring an uppercase
-///     *letter*, so digits never qualify
+///     *letter* on both sides, so digits never qualify
 ///   - drop caps — excluded because the body text that follows is mixed case
 ///   - adjacent table cells or separate words — excluded by requiring the runs
 ///     to be visually contiguous (essentially no gap)
@@ -909,14 +917,18 @@ fn is_small_caps_continuation(
     next: &TextItem,
     gap: f32,
 ) -> bool {
-    // Must shrink, and only into the small-caps ratio range. Real small caps
-    // sit near 0.7-0.8 of the full cap height; anything smaller is a
-    // superscript or a different run entirely.
+    // Must shrink. Real small caps sit near 0.7-0.8 of the full cap height;
+    // anything smaller is a superscript or a different run entirely.
     if first.font_size <= 0.0 || next.font_size >= first.font_size {
         return false;
     }
-    let ratio = next.font_size / first.font_size;
-    if !(0.55..=0.92).contains(&ratio) {
+    // Only rescue junctions the size band would have broken. Within-band pairs
+    // merge on their own, and suppressing their space would swallow real word
+    // gaps between two similarly-sized uppercase words.
+    if (next.font_size - first.font_size).abs() <= first.font_size * MERGE_FONT_SIZE_BAND {
+        return false;
+    }
+    if next.font_size / first.font_size < 0.55 {
         return false;
     }
     // Visually contiguous: the capital and its small caps touch. A real word
@@ -940,13 +952,27 @@ fn is_small_caps_continuation(
     if !saw_letter {
         return false;
     }
-    // What we are continuing must itself end in a capital.
-    text_so_far
-        .trim_end()
+    // What we are continuing must itself end in a capital. Check the actual
+    // trailing character rather than skipping back to the nearest letter: after
+    // "ANGELA M. MAZZARELLI1" the run to continue is the footnote marker, not
+    // the "I" before it.
+    let trimmed = text_so_far.trim_end();
+    if trimmed.chars().last().is_some_and(|c| c.is_numeric()) {
+        // One legitimate exception: an ordinal suffix set as a smaller run,
+        // e.g. "JULY 4" + "TH". Only the four English suffixes qualify —
+        // anything else after a digit is a footnote marker or numeric suffix.
+        return matches!(trimmed_suffix(next), "TH" | "ST" | "ND" | "RD");
+    }
+    trimmed
         .chars()
         .rev()
         .find(|c| c.is_alphabetic())
         .is_some_and(|c| c.is_uppercase())
+}
+
+/// The continuation run's text, trimmed — used to spot ordinal suffixes.
+fn trimmed_suffix(next: &TextItem) -> &str {
+    next.text.trim()
 }
 
 pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
@@ -1011,10 +1037,10 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 // font-size band below and must never take a space.
                 let small_caps_join =
                     is_small_caps_continuation(&text, first, next, next.x - end_x);
-                // Must be similar font size (within 20%), except for genuine
-                // small-caps runs, where the shrunken capitals are the same
-                // word as the full-size initial (see helper).
-                if (next.font_size - first.font_size).abs() > first.font_size * 0.20
+                // Must be similar font size, except for genuine small-caps
+                // runs, where the shrunken capitals are the same word as the
+                // full-size initial (see helper).
+                if (next.font_size - first.font_size).abs() > first.font_size * MERGE_FONT_SIZE_BAND
                     && !small_caps_join
                 {
                     break;
@@ -3091,18 +3117,73 @@ mod tests {
         assert_eq!(merged[0].text, "ROLANDO T. ACOSTA, P.J.");
     }
 
+    /// The full two-column row: both names must merge independently and the
+    /// 72pt column gap between them must survive as an item boundary.
     #[test]
     fn small_caps_merge_does_not_swallow_a_second_column() {
-        // Same row, but a real column gap (72pt) before the next name.
         let items = vec![
+            // Column 1: "ROLANDO T. ACOSTA, P.J." ending at x=249.65
+            make_item_fs("R", 144.36, 581.84, 7.20, 9.98),
+            make_item_fs("OLANDO", 151.56, 581.84, 30.56, 6.74),
+            make_item_fs("T. A", 185.45, 581.84, 17.58, 9.98),
+            make_item_fs("COSTA", 203.94, 581.84, 23.15, 6.74),
+            make_item_fs(", P.J.", 227.09, 581.84, 22.56, 9.98),
+            // Column 2 starts at x=321.96 — a 72pt gap.
             make_item_fs("A", 321.96, 581.84, 7.20, 9.98),
             make_item_fs("NIL", 329.17, 581.84, 12.72, 6.74),
             make_item_fs("C. S", 345.04, 581.84, 19.59, 9.98),
             make_item_fs("INGH", 364.62, 581.84, 19.08, 6.74),
         ];
         let merged = merge_text_items(items);
+        let texts: Vec<&str> = merged.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec!["ROLANDO T. ACOSTA, P.J.", "ANIL C. SINGH"],
+            "column gap should keep the two names apart"
+        );
+    }
+
+    #[test]
+    fn small_caps_merge_keeps_word_space_between_same_size_capitals() {
+        // Two uppercase words at sizes the merge band already accepts (9.98 and
+        // 9.0, a 10% drop) separated by a real word gap. The small-caps path
+        // must not claim this junction and swallow the space.
+        let items = vec![
+            make_item_fs("SEE", 100.0, 500.0, 18.0, 9.98),
+            make_item_fs("ALSO", 119.2, 500.0, 24.0, 9.0),
+        ];
+        let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1, "got {:?}", merged);
-        assert_eq!(merged[0].text, "ANIL C. SINGH");
+        assert_eq!(merged[0].text, "SEE ALSO");
+    }
+
+    #[test]
+    fn trailing_digit_is_not_a_capital_awaiting_small_caps() {
+        // "...MAZZARELLI1" ends in a footnote marker; the backward search for an
+        // uppercase letter must not skip the digit and glue the next run.
+        assert!(!is_small_caps_continuation(
+            "ANGELA M. MAZZARELLI1",
+            &make_item_fs("ANGELA", 100.0, 500.0, 40.0, 9.98),
+            &make_item_fs("SHULMAN", 140.0, 500.0, 30.0, 6.74),
+            0.0,
+        ));
+    }
+
+    #[test]
+    fn ordinal_suffix_after_a_digit_still_merges() {
+        // "TUESDAY, JULY 4" + "TH" is one word in the source; the digit guard
+        // must not block the four English ordinal suffixes.
+        for suffix in ["TH", "ST", "ND", "RD"] {
+            assert!(
+                is_small_caps_continuation(
+                    "TUESDAY, JULY 4",
+                    &make_item_fs("JULY", 100.0, 500.0, 30.0, 12.0),
+                    &make_item_fs(suffix, 130.0, 500.0, 8.0, 8.0),
+                    0.0,
+                ),
+                "{suffix} should merge after a digit"
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -887,6 +887,66 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
     Some((end, floor * fs))
 }
 
+/// Detect a small-caps continuation: typesetters render small caps as a
+/// full-size capital immediately followed by shrunken capitals in the same
+/// font (`(R) Tj` at 9.98pt, then `(OLANDO) Tj` at 6.74pt). Those runs are one
+/// word, but the 20% font-size band in `merge_text_items` would split them,
+/// leaving "R" and "OLANDO" as separate items — which then read as separate
+/// table columns, since column boundaries cluster on item start positions.
+///
+/// Gated tightly so it cannot absorb the other reasons a smaller run follows a
+/// larger one:
+///   - superscripts / footnote markers — excluded by requiring an uppercase
+///     *letter*, so digits never qualify
+///   - drop caps — excluded because the body text that follows is mixed case
+///   - adjacent table cells or separate words — excluded by requiring the runs
+///     to be visually contiguous (essentially no gap)
+fn is_small_caps_continuation(
+    text_so_far: &str,
+    first: &TextItem,
+    next: &TextItem,
+    gap: f32,
+) -> bool {
+    // Must shrink, and only into the small-caps ratio range. Real small caps
+    // sit near 0.7-0.8 of the full cap height; anything smaller is a
+    // superscript or a different run entirely.
+    if first.font_size <= 0.0 || next.font_size >= first.font_size {
+        return false;
+    }
+    let ratio = next.font_size / first.font_size;
+    if !(0.55..=0.92).contains(&ratio) {
+        return false;
+    }
+    // Visually contiguous: the capital and its small caps touch. A real word
+    // space or a column gap disqualifies.
+    if !(-first.font_size * 0.2..=first.font_size * 0.15).contains(&gap) {
+        return false;
+    }
+    // The continuation must be all-uppercase letters (digits and lowercase
+    // both disqualify), and must contain at least one letter.
+    let mut saw_letter = false;
+    for ch in next.text.chars() {
+        if ch.is_alphabetic() {
+            saw_letter = true;
+            if !ch.is_uppercase() {
+                return false;
+            }
+        } else if ch.is_numeric() {
+            return false;
+        }
+    }
+    if !saw_letter {
+        return false;
+    }
+    // What we are continuing must itself end in a capital.
+    text_so_far
+        .trim_end()
+        .chars()
+        .rev()
+        .find(|c| c.is_alphabetic())
+        .is_some_and(|c| c.is_uppercase())
+}
+
 pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
     if items.is_empty() {
         return items;
@@ -945,8 +1005,16 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
             let mut j = i + 1;
             while j < group.len() {
                 let next = group[j];
-                // Must be similar font size (within 20%)
-                if (next.font_size - first.font_size).abs() > first.font_size * 0.20 {
+                // A small-caps junction is mid-word: it both survives the
+                // font-size band below and must never take a space.
+                let small_caps_join =
+                    is_small_caps_continuation(&text, first, next, next.x - end_x);
+                // Must be similar font size (within 20%), except for genuine
+                // small-caps runs, where the shrunken capitals are the same
+                // word as the full-size initial (see helper).
+                if (next.font_size - first.font_size).abs() > first.font_size * 0.20
+                    && !small_caps_join
+                {
                     break;
                 }
                 // Never merge across style boundaries: the merged item
@@ -1000,7 +1068,7 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                     Some((run_end, floor)) if j <= run_end => floor,
                     _ => threshold,
                 };
-                if needs_bullet_space || gap > effective_threshold {
+                if !small_caps_join && (needs_bullet_space || gap > effective_threshold) {
                     text.push(' ');
                 }
                 text.push_str(&next.text);
@@ -3002,6 +3070,90 @@ mod tests {
             item_type: ItemType::Text,
             mcid: None,
         }
+    }
+
+    /// Small caps as typesetters emit them: a full-size capital at 9.98pt
+    /// immediately followed by shrunken capitals at 6.74pt, touching.
+    /// Modelled on `199AD3d.pdf` p.5 ("ROLANDO T. ACOSTA, P.J.").
+    #[test]
+    fn small_caps_run_merges_into_one_word() {
+        let items = vec![
+            make_item_fs("R", 144.36, 581.84, 7.20, 9.98),
+            make_item_fs("OLANDO", 151.56, 581.84, 30.56, 6.74),
+            make_item_fs("T. A", 185.45, 581.84, 17.58, 9.98),
+            make_item_fs("COSTA", 203.94, 581.84, 23.15, 6.74),
+            make_item_fs(", P.J.", 227.09, 581.84, 22.56, 9.98),
+        ];
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1, "got {:?}", merged);
+        assert_eq!(merged[0].text, "ROLANDO T. ACOSTA, P.J.");
+    }
+
+    #[test]
+    fn small_caps_merge_does_not_swallow_a_second_column() {
+        // Same row, but a real column gap (72pt) before the next name.
+        let items = vec![
+            make_item_fs("A", 321.96, 581.84, 7.20, 9.98),
+            make_item_fs("NIL", 329.17, 581.84, 12.72, 6.74),
+            make_item_fs("C. S", 345.04, 581.84, 19.59, 9.98),
+            make_item_fs("INGH", 364.62, 581.84, 19.08, 6.74),
+        ];
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1, "got {:?}", merged);
+        assert_eq!(merged[0].text, "ANIL C. SINGH");
+    }
+
+    #[test]
+    fn superscript_footnote_marker_is_not_a_small_caps_continuation() {
+        // A digit must never qualify — otherwise footnote markers get glued on
+        // without the superscript handling.
+        assert!(!is_small_caps_continuation(
+            "MAZZARELLI",
+            &make_item_fs("MAZZARELLI", 100.0, 500.0, 50.0, 9.98),
+            &make_item_fs("1", 150.0, 503.0, 3.0, 6.74),
+            0.0,
+        ));
+    }
+
+    #[test]
+    fn drop_cap_is_not_a_small_caps_continuation() {
+        // Mixed-case body text after a large initial is a drop cap, not small
+        // caps.
+        assert!(!is_small_caps_continuation(
+            "T",
+            &make_item_fs("T", 100.0, 500.0, 20.0, 30.0),
+            &make_item_fs("he court held", 120.0, 500.0, 60.0, 10.0),
+            0.0,
+        ));
+    }
+
+    #[test]
+    fn separate_word_is_not_a_small_caps_continuation() {
+        // A real word space disqualifies even when both runs are uppercase.
+        let first = make_item_fs("SEE", 100.0, 500.0, 20.0, 9.98);
+        let next = make_item_fs("ALSO", 128.0, 500.0, 25.0, 6.74);
+        assert!(!is_small_caps_continuation("SEE", &first, &next, 8.0));
+    }
+
+    #[test]
+    fn lowercase_continuation_is_not_small_caps() {
+        assert!(!is_small_caps_continuation(
+            "SMALL",
+            &make_item_fs("SMALL", 100.0, 500.0, 30.0, 9.98),
+            &make_item_fs("caps", 130.0, 500.0, 20.0, 6.74),
+            0.0,
+        ));
+    }
+
+    #[test]
+    fn too_small_a_ratio_is_not_small_caps() {
+        // 0.4 ratio is a superscript/sub-run, outside the small-caps band.
+        assert!(!is_small_caps_continuation(
+            "A",
+            &make_item_fs("A", 100.0, 500.0, 7.0, 10.0),
+            &make_item_fs("BC", 107.0, 500.0, 8.0, 4.0),
+            0.0,
+        ));
     }
 
     #[test]

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -246,19 +246,49 @@ fn extract_form_xobject_text_inner(
     let mut current_font = String::new();
     let mut current_font_size: f32 = 12.0;
     let mut text_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
+    // Text line matrix (TLM) — Td/TD/T* move relative to the start of the
+    // current line, not to the position left by the last show operator.
+    let mut line_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
+    let mut text_leading: f32 = 0.0; // TL parameter (text-space units)
+    let mut char_spacing: f32 = 0.0; // Tc parameter
+    let mut word_spacing: f32 = 0.0; // Tw parameter
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
-    let mut ctm_stack: Vec<[f32; 6]> = Vec::new();
+
+    // Text state (Tc/Tw/TL/Tf) is part of the graphics state and must be
+    // saved/restored by q/Q alongside the CTM.
+    #[derive(Clone)]
+    struct GraphicsState {
+        ctm: [f32; 6],
+        char_spacing: f32,
+        word_spacing: f32,
+        text_leading: f32,
+        current_font: String,
+        current_font_size: f32,
+    }
+    let mut ctm_stack: Vec<GraphicsState> = Vec::new();
 
     for op in &content.operations {
         match op.operator.as_str() {
             "q" => {
-                ctm_stack.push(ctm);
+                ctm_stack.push(GraphicsState {
+                    ctm,
+                    char_spacing,
+                    word_spacing,
+                    text_leading,
+                    current_font: current_font.clone(),
+                    current_font_size,
+                });
             }
             "Q" => {
                 if let Some(saved) = ctm_stack.pop() {
-                    ctm = saved;
+                    ctm = saved.ctm;
+                    char_spacing = saved.char_spacing;
+                    word_spacing = saved.word_spacing;
+                    text_leading = saved.text_leading;
+                    current_font = saved.current_font;
+                    current_font_size = saved.current_font_size;
                 }
             }
             "cm" => {
@@ -321,6 +351,7 @@ fn extract_form_xobject_text_inner(
             "BT" => {
                 in_text_block = true;
                 text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                line_matrix = text_matrix;
             }
             "ET" => {
                 in_text_block = false;
@@ -333,12 +364,33 @@ fn extract_form_xobject_text_inner(
                     current_font_size = get_number(&op.operands[1]).unwrap_or(12.0);
                 }
             }
+            "TL" => {
+                // Set text leading (used by T*, ', and ")
+                if let Some(tl) = op.operands.first().and_then(get_number) {
+                    text_leading = tl;
+                }
+            }
+            "Tc" => {
+                if let Some(tc) = op.operands.first().and_then(get_number) {
+                    char_spacing = tc;
+                }
+            }
+            "Tw" => {
+                if let Some(tw) = op.operands.first().and_then(get_number) {
+                    word_spacing = tw;
+                }
+            }
             "Td" | "TD" => {
+                // Move text position: TLM = T(tx,ty) x TLM; Tm = TLM
                 if op.operands.len() >= 2 {
                     let tx = get_number(&op.operands[0]).unwrap_or(0.0);
                     let ty = get_number(&op.operands[1]).unwrap_or(0.0);
-                    text_matrix[4] += tx * text_matrix[0] + ty * text_matrix[2];
-                    text_matrix[5] += tx * text_matrix[1] + ty * text_matrix[3];
+                    line_matrix[4] += tx * line_matrix[0] + ty * line_matrix[2];
+                    line_matrix[5] += tx * line_matrix[1] + ty * line_matrix[3];
+                    text_matrix = line_matrix;
+                    if op.operator == "TD" {
+                        text_leading = -ty;
+                    }
                 }
             }
             "Tm" => {
@@ -347,7 +399,19 @@ fn extract_form_xobject_text_inner(
                         text_matrix[i] =
                             get_number(operand).unwrap_or(if i == 0 || i == 3 { 1.0 } else { 0.0 });
                     }
+                    line_matrix = text_matrix;
                 }
+            }
+            "T*" => {
+                // Move to start of next line: equivalent to `0 -TL Td`
+                let tl = if text_leading != 0.0 {
+                    text_leading
+                } else {
+                    current_font_size * 1.2
+                };
+                line_matrix[4] += (-tl) * line_matrix[2];
+                line_matrix[5] += (-tl) * line_matrix[3];
+                text_matrix = line_matrix;
             }
             "g" => {
                 if let Some(gray) = op.operands.first().and_then(get_number) {
@@ -384,17 +448,33 @@ fn extract_form_xobject_text_inner(
                     _ => fill_is_white = false,
                 }
             }
-            "Tj" => {
-                if in_text_block && !op.operands.is_empty() {
+            "Tj" | "'" | "\"" => {
+                // `'` = move to next line then show; `"` = set word/char spacing,
+                // move to next line, then show (string is the last operand).
+                if op.operator != "Tj" {
+                    if op.operator == "\"" && op.operands.len() >= 3 {
+                        word_spacing = get_number(&op.operands[0]).unwrap_or(word_spacing);
+                        char_spacing = get_number(&op.operands[1]).unwrap_or(char_spacing);
+                    }
+                    let tl = if text_leading != 0.0 {
+                        text_leading
+                    } else {
+                        current_font_size * 1.2
+                    };
+                    line_matrix[4] += (-tl) * line_matrix[2];
+                    line_matrix[5] += (-tl) * line_matrix[3];
+                    text_matrix = line_matrix;
+                }
+                if let (true, Some(show_operand)) = (in_text_block, op.operands.last()) {
                     if fill_is_white {
                         if let Some(font_info) = font_widths.get(&current_font) {
-                            if let Some(raw_bytes) = get_operand_bytes(&op.operands[0]) {
+                            if let Some(raw_bytes) = get_operand_bytes(show_operand) {
                                 let w_ts = compute_string_width_ts(
                                     raw_bytes,
                                     font_info,
                                     current_font_size,
-                                    0.0,
-                                    0.0,
+                                    char_spacing,
+                                    word_spacing,
                                 );
                                 text_matrix[4] += w_ts * text_matrix[0];
                                 text_matrix[5] += w_ts * text_matrix[1];
@@ -403,7 +483,7 @@ fn extract_form_xobject_text_inner(
                         continue;
                     }
                     if let Some(text) = extract_text_from_operand(
-                        &op.operands[0],
+                        show_operand,
                         &current_font,
                         font_base_names.get(&current_font).map(|s| s.as_str()),
                         font_cmaps,
@@ -419,13 +499,13 @@ fn extract_form_xobject_text_inner(
                             * type3_scales.get(&current_font).copied().unwrap_or(1.0);
                         let (x, y) = (combined[4], combined[5]);
                         let width = if let Some(font_info) = font_widths.get(&current_font) {
-                            if let Some(raw_bytes) = get_operand_bytes(&op.operands[0]) {
+                            if let Some(raw_bytes) = get_operand_bytes(show_operand) {
                                 let w_ts = compute_string_width_ts(
                                     raw_bytes,
                                     font_info,
                                     current_font_size,
-                                    0.0,
-                                    0.0,
+                                    char_spacing,
+                                    word_spacing,
                                 );
                                 text_matrix[4] += w_ts * text_matrix[0];
                                 text_matrix[5] += w_ts * text_matrix[1];
@@ -548,8 +628,8 @@ fn extract_form_xobject_text_inner(
                                         raw_bytes,
                                         fi,
                                         current_font_size,
-                                        0.0,
-                                        0.0,
+                                        char_spacing,
+                                        word_spacing,
                                     );
                                 }
                             }
@@ -682,4 +762,168 @@ pub(crate) fn get_form_fonts<'a>(
     }
 
     fonts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::{dictionary, Stream};
+
+    /// Build a document whose page draws *all* of its content through a single
+    /// Form XObject — the shape emitted by print-to-PDF producers like PDFlib,
+    /// where the page stream itself is only `q /X1 Do Q`.
+    fn doc_with_form_content(form_content: &[u8]) -> (Document, ObjectId) {
+        let mut doc = Document::new();
+        let widths: Vec<Object> = (0..=255).map(|_| 600.into()).collect();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "FirstChar" => 0,
+            "LastChar" => 255,
+            "Widths" => Object::Array(widths),
+        });
+        let form_id = doc.add_object(Object::Stream(Stream::new(
+            dictionary! {
+                "Type" => "XObject",
+                "Subtype" => "Form",
+                "BBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                "Resources" => dictionary! {
+                    "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+                },
+            },
+            form_content.to_vec(),
+        )));
+        let content_id = doc.add_object(Object::Stream(Stream::new(
+            dictionary! {},
+            b"q /X1 Do Q".to_vec(),
+        )));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Contents" => Object::Reference(content_id),
+            "Resources" => dictionary! {
+                "XObject" => dictionary! { "X1" => Object::Reference(form_id) },
+            },
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        });
+        let pages_id = doc.add_object(dictionary! {
+            "Type" => "Pages",
+            "Count" => Object::Integer(1),
+            "Kids" => vec![Object::Reference(page_id)],
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => Object::Reference(pages_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        (doc, page_id)
+    }
+
+    fn form_items(form_content: &[u8]) -> Vec<TextItem> {
+        let (doc, page_id) = doc_with_form_content(form_content);
+        let font_cmaps = FontCMaps::from_doc(&doc);
+        let ((items, _, _), _, _, _) = super::super::content_stream::extract_page_text_items(
+            &doc,
+            page_id,
+            1,
+            &font_cmaps,
+            false,
+            &mut FontStyleCache::new(),
+        )
+        .unwrap();
+        items
+    }
+
+    fn find<'a>(items: &'a [TextItem], text: &str) -> &'a TextItem {
+        items
+            .iter()
+            .find(|item| item.text == text)
+            .unwrap_or_else(|| {
+                let found: Vec<&String> = items.iter().map(|i| &i.text).collect();
+                panic!("no item {text:?} in {found:?}")
+            })
+    }
+
+    #[test]
+    fn t_star_inside_form_moves_to_next_line() {
+        // T* was previously unhandled inside Form XObjects, so every line after
+        // the first piled onto the preceding baseline and drifted right.
+        let items =
+            form_items(b"BT /F1 12 Tf 12 TL 1 0 0 1 100 700 Tm (first) Tj T* (second) Tj ET");
+
+        let first = find(&items, "first");
+        let second = find(&items, "second");
+        assert!((first.y - 700.0).abs() < 0.1, "first y = {}", first.y);
+        assert!((second.y - 688.0).abs() < 0.1, "second y = {}", second.y);
+        assert!((second.x - 100.0).abs() < 0.1, "second x = {}", second.x);
+    }
+
+    #[test]
+    fn td_inside_form_is_relative_to_line_start_not_shown_text() {
+        // Td moves relative to the text *line* matrix. Applying it to the
+        // matrix already advanced by Tj marched each line off the right edge.
+        let items = form_items(b"BT /F1 12 Tf 1 0 0 1 100 700 Tm (AAAAA) Tj 0 -12 Td (B) Tj ET");
+
+        let b = find(&items, "B");
+        assert!((b.x - 100.0).abs() < 0.1, "B x = {} (expected 100)", b.x);
+        assert!((b.y - 688.0).abs() < 0.1, "B y = {}", b.y);
+    }
+
+    #[test]
+    fn td_inside_form_sets_leading_for_later_t_star() {
+        // `TD` sets the leading to -ty as a side effect; a following T* must
+        // reuse it.
+        let items = form_items(
+            b"BT /F1 12 Tf 1 0 0 1 100 700 Tm (one) Tj 0 -15 TD (two) Tj T* (three) Tj ET",
+        );
+
+        assert!((find(&items, "two").y - 685.0).abs() < 0.1);
+        let three = find(&items, "three");
+        assert!((three.y - 670.0).abs() < 0.1, "three y = {}", three.y);
+        assert!((three.x - 100.0).abs() < 0.1, "three x = {}", three.x);
+    }
+
+    #[test]
+    fn quote_operator_inside_form_moves_to_next_line() {
+        let items = form_items(b"BT /F1 12 Tf 12 TL 1 0 0 1 100 700 Tm (first) Tj (second) ' ET");
+
+        let second = find(&items, "second");
+        assert!((second.y - 688.0).abs() < 0.1, "second y = {}", second.y);
+        assert!((second.x - 100.0).abs() < 0.1, "second x = {}", second.x);
+    }
+
+    #[test]
+    fn double_quote_operator_inside_form_sets_spacing_and_moves() {
+        // `aw ac (string) "` — set word spacing and char spacing, then T* and show.
+        let items =
+            form_items(b"BT /F1 12 Tf 12 TL 1 0 0 1 100 700 Tm (first) Tj 0 0 (second) \" ET");
+
+        let second = find(&items, "second");
+        assert!((second.y - 688.0).abs() < 0.1, "second y = {}", second.y);
+        assert!((second.x - 100.0).abs() < 0.1, "second x = {}", second.x);
+    }
+
+    #[test]
+    fn char_spacing_inside_form_widens_advance() {
+        // Tc was hardcoded to 0 in the form parser, so advance widths drifted.
+        // 2 glyphs x 600/1000 x 12pt = 14.4, plus 2 x Tc(2.0) = 18.4.
+        let items = form_items(b"BT /F1 12 Tf 1 0 0 1 100 700 Tm 2 Tc (AB) Tj ET");
+
+        let ab = find(&items, "AB");
+        assert!((ab.width - 18.4).abs() < 0.1, "AB width = {}", ab.width);
+    }
+
+    #[test]
+    fn q_restores_text_state_inside_form() {
+        // Tc/TL live in the graphics state; `Q` must roll them back.
+        let items =
+            form_items(b"BT /F1 12 Tf 12 TL 1 0 0 1 100 700 Tm q 30 TL (a) Tj Q T* (b) Tj ET");
+
+        let b = find(&items, "b");
+        assert!(
+            (b.y - 688.0).abs() < 0.1,
+            "b y = {} (leading should restore to 12)",
+            b.y
+        );
+    }
 }

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -256,8 +256,8 @@ fn extract_form_xobject_text_inner(
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
 
-    // Text state (Tc/Tw/TL/Tf) is part of the graphics state and must be
-    // saved/restored by q/Q alongside the CTM.
+    // Text state (Tc/Tw/TL/Tf) and the fill colour are part of the graphics
+    // state and must be saved/restored by q/Q alongside the CTM.
     #[derive(Clone)]
     struct GraphicsState {
         ctm: [f32; 6],
@@ -266,6 +266,7 @@ fn extract_form_xobject_text_inner(
         text_leading: f32,
         current_font: String,
         current_font_size: f32,
+        fill_is_white: bool,
     }
     let mut ctm_stack: Vec<GraphicsState> = Vec::new();
 
@@ -279,6 +280,7 @@ fn extract_form_xobject_text_inner(
                     text_leading,
                     current_font: current_font.clone(),
                     current_font_size,
+                    fill_is_white,
                 });
             }
             "Q" => {
@@ -289,6 +291,7 @@ fn extract_form_xobject_text_inner(
                     text_leading = saved.text_leading;
                     current_font = saved.current_font;
                     current_font_size = saved.current_font_size;
+                    fill_is_white = saved.fill_is_white;
                 }
             }
             "cm" => {
@@ -911,6 +914,25 @@ mod tests {
 
         let ab = find(&items, "AB");
         assert!((ab.width - 18.4).abs() < 0.1, "AB width = {}", ab.width);
+    }
+
+    #[test]
+    fn q_restores_fill_colour_inside_form() {
+        // A white fill set inside q/Q must not leak past the Q — otherwise the
+        // following black text is treated as invisible and dropped entirely.
+        let items = form_items(
+            b"BT /F1 12 Tf 12 TL 1 0 0 1 100 700 Tm q 1 g (hidden) Tj Q T* (visible) Tj ET",
+        );
+
+        assert!(
+            items.iter().any(|item| item.text == "visible"),
+            "text after Q was dropped: {:?}",
+            items.iter().map(|i| &i.text).collect::<Vec<_>>()
+        );
+        assert!(
+            !items.iter().any(|item| item.text == "hidden"),
+            "white-filled text should still be suppressed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> Follow-up to #369 (merged as `89dd20d`), which fixed the Form XObject operator handling this builds on.

## Problem

Typesetters render small caps as a full-size capital immediately followed by shrunken capitals in the same font — `(R) Tj` at 9.98pt, then `(OLANDO) Tj` at 6.74pt, touching:

```
x=144.36 'R'       fs=9.98
x=151.56 'OLANDO'  fs=6.74   gap 0.0
x=185.45 'T. A'    fs=9.98   gap 3.3
x=203.94 'COSTA'   fs=6.74   gap 0.9
x=227.09 ', P.J.'  fs=9.98   gap 0.0
x=321.96 'A'       fs=9.98   gap 72.3  <- the real column gap
```

The 20% font-size band in `merge_text_items` split those into separate items. Table column boundaries cluster on item **start** positions (`find_column_boundaries` never consults widths), so each fragment started far enough from the last to become its own column — even though the runs are touching.

The result on `199AD3d.pdf` p.5 (the list of Appellate Division justices):

```
|OLANDO|COSTA|NIL|INGH||
|---|---|---|---|---|
|IANNE|ENWICK|ETER|OULTON||
|ALLIE|ANZANET|IZBETH|ONZÁLEZ||

|R|T. A|, P.J.|A|C. S|
|---|---|---|---|---|
|D|T. R||P|H. M|
```

Every initial capital was torn off into a second phantom table.

## Fix

`is_small_caps_continuation` allows the merge across the size band, gated tightly enough to exclude the other reasons a smaller run follows a larger one:

| Excluded | How |
|---|---|
| superscripts / footnote markers | requires an uppercase **letter**, so digits never qualify |
| drop caps | the body text that follows is mixed case |
| adjacent cells or separate words | requires the runs to be visually contiguous |
| unrelated sub-runs | size ratio must fall in the small-caps band (0.55–0.92) |

A small-caps junction is mid-word, so it also suppresses the space that would otherwise be inserted: `"T. A"` + `"COSTA"` → `T. ACOSTA`, not `T. A COSTA`.

Result:

```
|ROLANDO T. ACOSTA, P.J.|ANIL C. SINGH|
|---|---|
|DIANNE T. RENWICK|PETER H. MOULTON|
|SALLIE MANZANET-DANIELS|LIZBETH GONZÁLEZ|
```

Every name now matches the `pdftotext` reference exactly. Note the fix is upstream of the table detector — correcting the items removes the false tables at the root, with no change to `tables/`.

## Results

On `199AD3d.pdf` (1370 pages): false-positive tables **65 → 52**, word recall vs a pdftotext reference **97.7% → 97.8%**.

Verified by running both binaries over all 203 eval PDFs and diffing outputs directly: **19 differ, 184 byte-identical.** Other documents this fixes:

| PDF | Change |
|---|---|
| `Waters-Edge` | two more garbled heading-tables — `##### B. C R S` plus `\|\|OMPLIANCE\|EPORTING YSTEM\|` → `##### B. COMPLIANCE REPORTING SYSTEM` |
| `cn-student-handbook` | six TOC entries had collapsed to their initials; `U M S H...` → `UNIVERSITY MISSION AND STUDENT HANDBOOK...` |
| `546403` | `(FAA)` + `ADVISORY CIRCULARS ( )` + a stray `CONT` → `(FAA) ADVISORY CIRCULARS (CONT)` |
| `ERP-2025` | `T ABLE B–1` → `TABLE B–1` |
| `DMP-Keypad` | `THINLINE` + stray `TM KEYPADS` → `THINLINETM KEYPADS` |
| `zhaw`, `Stijn` | subscripted math variables: `*T* *G*` → `*TG*` |

## One known regression

`PA_PVEM_Sen_Waldo_Fernández` (+1689 bytes). Its running footer genuinely **is** small caps, so the merge correctly assembles the text (400 items → 275) — but the now-contiguous footer lines align well enough that the heuristic detector turns the wrapped document title into a 4-column table, where it previously rendered as bold prose.

I'd rather flag this than bury it. Net across the corpus is strongly positive (one running footer framed as a table, against the fixes above), but it is a real regression on that file.

### The detector fix I tried, and why it isn't here

Gating the `num_cols >= 3` bypass in `has_table_like_content` on "no cell has ≥ 12 words" fixed PA_PVEM and three other false positives — and **removed 143 tables across 44 files, including correct ones.** `MCF5235RM` went 505 → 483 tables and its register-notation glossary degraded from a correct symbol/description table into a fused column plus a ~100-word monster cell, because rejecting a good candidate lets a worse fallback win.

No wordiness threshold separates the cases: PA_PVEM's longest cell is 14 words while MCF5235RM's legitimate cells are ≤ 10. A positional signal — running-header/footer bands, or cross-page repetition — is the way in, and belongs in its own change. Reverted here; `tables/` is untouched.

## Review fixes

Three findings from cubic, all valid. Two applied as suggested; one I resolved differently after measuring it.

**Space suppression was too broad.** The helper accepted size ratios up to 0.92 — inside the 20% band `merge_text_items` already treats as the same size. Two similarly-sized uppercase words with a real word gap therefore lost their space (`SEE` + `ALSO` → `SEEALSO`), even though the normal path would have merged them correctly. It now requires the junction to *cross* the band, which is its only reason to exist; within-band pairs keep the normal word-spacing logic. The band is a shared `MERGE_FONT_SIZE_BAND` constant so helper and caller cannot drift.

**A trailing digit was skipped.** The backward search for "the capital being continued" stepped over non-letters, so `ANGELA M. MAZZARELLI1` found the earlier `I` and accepted the join. It now checks the actual trailing character.

Rejecting *every* trailing digit — the straightforward reading of the finding — turned out to cost real quality, which the corpus A/B caught. In `meetings_in_mass_july_2023` the source reads `TUESDAY, JULY 4TH` with the ordinal suffix set as a smaller run; a blanket rejection reverted that to `TUESDAY, JULY 4` plus a stray `TH` leaking onto the next line — which is what `main` produces and what `pdftotext` shows is wrong. The final version allows only the four English ordinal suffixes (`TH`/`ST`/`ND`/`RD`) after a digit; anything else is treated as a footnote marker and rejected, so the case cubic raised stays blocked.

**A test's name did not match its data.** `small_caps_merge_does_not_swallow_a_second_column` claimed to exercise the 72pt column gap but held only the second column's items, so it just re-tested the happy path. It now holds the full nine-item row and asserts exactly two merged results.

Both new guards were verified to be load-bearing: removing either makes its own test fail.

## Verification

- `cargo fmt` clean, `cargo clippy -- -D warnings` clean, **900 unit tests pass** (10 covering small caps).
- Tests cover the two-column small-caps row from the reporter volume, the column-gap boundary, ordinal suffixes after a digit, and rejection of superscript digits, footnote markers, drop caps, separate words, lowercase continuations, within-band word gaps, and out-of-band size ratios.
- All figures above are measured against current `main` (`89dd20d` plus #370 Form XObject budgets and #372 CID `/W` bounds), neither of which touches item merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
