### PR TITLE
Restore logical reading order for visual-order Hebrew

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -951,6 +951,8 @@ pub struct MarkdownOptions {
     pub include_page_numbers: bool,
     /// Strip repeated headers/footers that appear on many pages
     pub strip_headers_footers: bool,
+    /// Restore logical reading order for Hebrew stored in visual order
+    pub fix_rtl_order: bool,
 }
 
 impl Default for MarkdownOptions {
@@ -980,6 +982,9 @@ impl Default for MarkdownOptions {
             include_links: true,
             include_page_numbers: false,
             strip_headers_footers: true,
+            // On by default: visual-order Hebrew is unreadable and silently
+            // wrong, and the detector is a no-op on every other document.
+            fix_rtl_order: true,
         }
     }
 }

--- a/src/markdown/postprocess.rs
+++ b/src/markdown/postprocess.rs
@@ -4,7 +4,8 @@ use regex::Regex;
 
 use super::{MarkdownOptions, MarkdownProfile};
 use crate::text_utils::{
-    is_page_number_line, is_rtl_char, is_visual_order_hebrew, reverse_visual_rtl,
+    is_arabic_char, is_hebrew_letter, is_page_number_line, is_visual_order_hebrew,
+    reverse_visual_rtl,
 };
 
 /// Clean up markdown output with post-processing
@@ -66,8 +67,8 @@ pub(crate) fn clean_markdown(mut text: String, options: &MarkdownOptions) -> Str
 /// Documents already in logical order, and documents with no Hebrew, are
 /// returned untouched.
 ///
-/// Arabic is deliberately out of scope here: it is already restored per text
-/// item during extraction, and reversing it a second time would undo that.
+/// Arabic is out of scope: it is already restored per text item during
+/// extraction, so [`restore_rtl_line`] skips any line carrying it.
 fn restore_rtl_reading_order(text: &str) -> String {
     if !is_visual_order_hebrew(text) {
         return text.to_string();
@@ -85,7 +86,11 @@ fn restore_rtl_reading_order(text: &str) -> String {
 
 /// Restore one line, keeping markdown structure in place around the prose.
 fn restore_rtl_line(line: &str) -> String {
-    if !line.chars().any(is_rtl_char) {
+    // Scoped to Hebrew, not RTL generally. Arabic reaches this point already
+    // in logical order — `expand_ligatures` restored it per text item during
+    // extraction — so reversing it here would undo that work. A line carrying
+    // both scripts is genuinely ambiguous, and is left alone.
+    if !line.chars().any(is_hebrew_letter) || line.chars().any(is_arabic_char) {
         return line.to_string();
     }
 
@@ -94,7 +99,7 @@ fn restore_rtl_line(line: &str) -> String {
         // An RTL table's leftmost visual column is its last logical one, so
         // cell order reverses along with the text inside each cell.
         let inner = &trimmed[1..trimmed.len() - 1];
-        let cells: Vec<String> = inner.split('|').rev().map(reverse_visual_rtl).collect();
+        let cells: Vec<String> = inner.split('|').rev().map(reverse_segments).collect();
         return format!("|{}|", cells.join("|"));
     }
 
@@ -105,7 +110,48 @@ fn restore_rtl_line(line: &str) -> String {
     let marker_len = leading_marker_len(rest);
     let (marker, prose) = rest.split_at(marker_len);
 
-    format!("{indent}{marker}{}", reverse_visual_rtl(prose))
+    format!("{indent}{marker}{}", reverse_segments(prose))
+}
+
+/// Reverse the text of a span while leaving inline markup where it sits.
+///
+/// Emphasis runs and `<u>` tags are emitted around text, not inside it, so
+/// reversing them along with the prose would produce `>u/<` and break the
+/// markup. Splitting on the tags and reversing only what lies between them
+/// keeps `<u>` wrapping the same words it wrapped before.
+fn reverse_segments(text: &str) -> String {
+    if !text.contains('<') && !text.contains('*') && !text.contains('`') {
+        return reverse_visual_rtl(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut segment = String::new();
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '<' => {
+                // An HTML tag: copy it through verbatim.
+                out.push_str(&reverse_visual_rtl(&segment));
+                segment.clear();
+                out.push('<');
+                for tag_char in chars.by_ref() {
+                    out.push(tag_char);
+                    if tag_char == '>' {
+                        break;
+                    }
+                }
+            }
+            '*' | '`' => {
+                out.push_str(&reverse_visual_rtl(&segment));
+                segment.clear();
+                out.push(c);
+            }
+            _ => segment.push(c),
+        }
+    }
+    out.push_str(&reverse_visual_rtl(&segment));
+    out
 }
 
 /// Length of the leading markdown marker on a line, if any.
@@ -725,5 +771,32 @@ mod tests {
         let visual = "םלוע םולש".to_string();
         let result = clean_markdown(visual, &MarkdownOptions::default());
         assert_eq!(result, "שלום עולם\n");
+    }
+
+    #[test]
+    fn rtl_never_reverses_arabic_twice() {
+        // Hebrew supplies the document-level signal; the Arabic line was
+        // already restored per item during extraction and must be left alone.
+        let doc = "םלוע םולש\n\n\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}";
+        let out = restore_rtl_reading_order(doc);
+        assert_eq!(out.lines().next().unwrap(), "שלום עולם");
+        assert_eq!(
+            out.lines().last().unwrap(),
+            "\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}"
+        );
+    }
+
+    #[test]
+    fn rtl_keeps_inline_markup_intact() {
+        let doc = "םלוע םולש\n\n<u>םלוע םולש</u>";
+        let out = restore_rtl_reading_order(doc);
+        assert_eq!(out.lines().last().unwrap(), "<u>שלום עולם</u>");
+    }
+
+    #[test]
+    fn rtl_keeps_emphasis_intact() {
+        let doc = "םלוע םולש\n\n**םלוע םולש**";
+        let out = restore_rtl_reading_order(doc);
+        assert_eq!(out.lines().last().unwrap(), "**שלום עולם**");
     }
 }

--- a/src/markdown/postprocess.rs
+++ b/src/markdown/postprocess.rs
@@ -3,10 +3,19 @@
 use regex::Regex;
 
 use super::{MarkdownOptions, MarkdownProfile};
-use crate::text_utils::is_page_number_line;
+use crate::text_utils::{
+    is_page_number_line, is_rtl_char, is_visual_order_hebrew, reverse_visual_rtl,
+};
 
 /// Clean up markdown output with post-processing
 pub(crate) fn clean_markdown(mut text: String, options: &MarkdownOptions) -> String {
+    // Runs before every other pass: the cleanups below match on punctuation and
+    // line shape, which only mean what they look like once the text is in
+    // logical order.
+    if options.fix_rtl_order {
+        text = restore_rtl_reading_order(&text);
+    }
+
     if options.profile == MarkdownProfile::Compact {
         // Dot-leader collapse saves tokens but changes source text, so it is
         // reserved for the explicit compact profile.
@@ -46,6 +55,90 @@ pub(crate) fn clean_markdown(mut text: String, options: &MarkdownOptions) -> Str
     text.push('\n');
 
     text
+}
+
+/// Restore logical reading order for a document whose Hebrew was laid out
+/// visually.
+///
+/// The decision is made once for the whole document — see
+/// [`is_visual_order_hebrew`] — because a producer picks one ordering for the
+/// entire file, and deciding per line would flip some lines and not others.
+/// Documents already in logical order, and documents with no Hebrew, are
+/// returned untouched.
+///
+/// Arabic is deliberately out of scope here: it is already restored per text
+/// item during extraction, and reversing it a second time would undo that.
+fn restore_rtl_reading_order(text: &str) -> String {
+    if !is_visual_order_hebrew(text) {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    for (i, line) in text.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&restore_rtl_line(line));
+    }
+    out
+}
+
+/// Restore one line, keeping markdown structure in place around the prose.
+fn restore_rtl_line(line: &str) -> String {
+    if !line.chars().any(is_rtl_char) {
+        return line.to_string();
+    }
+
+    let trimmed = line.trim();
+    if is_table_row(trimmed) {
+        // An RTL table's leftmost visual column is its last logical one, so
+        // cell order reverses along with the text inside each cell.
+        let inner = &trimmed[1..trimmed.len() - 1];
+        let cells: Vec<String> = inner.split('|').rev().map(reverse_visual_rtl).collect();
+        return format!("|{}|", cells.join("|"));
+    }
+
+    // Leading markers (heading hashes, list bullets, quote carets) are
+    // structure, not prose — reorder only what follows them.
+    let prose_start = line.len() - line.trim_start().len();
+    let (indent, rest) = line.split_at(prose_start);
+    let marker_len = leading_marker_len(rest);
+    let (marker, prose) = rest.split_at(marker_len);
+
+    format!("{indent}{marker}{}", reverse_visual_rtl(prose))
+}
+
+/// Length of the leading markdown marker on a line, if any.
+fn leading_marker_len(s: &str) -> usize {
+    let bytes = s.as_bytes();
+
+    // Heading: one to six '#' followed by a space.
+    let hashes = bytes.iter().take_while(|&&b| b == b'#').count();
+    if (1..=6).contains(&hashes) && bytes.get(hashes) == Some(&b' ') {
+        return hashes + 1;
+    }
+
+    // Bullet list or block quote.
+    if matches!(bytes.first(), Some(b'-' | b'*' | b'+' | b'>')) && bytes.get(1) == Some(&b' ') {
+        return 2;
+    }
+
+    // Ordered list: digits followed by '. '.
+    let digits = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+    if digits > 0 && bytes.get(digits) == Some(&b'.') && bytes.get(digits + 1) == Some(&b' ') {
+        return digits + 2;
+    }
+
+    0
+}
+
+/// A pipe-delimited table row, excluding the `|---|---|` separator whose
+/// dashes carry no text to reorder.
+fn is_table_row(trimmed: &str) -> bool {
+    if !(trimmed.starts_with('|') && trimmed.ends_with('|') && trimmed.len() > 2) {
+        return false;
+    }
+    !trimmed.chars().all(|c| matches!(c, '|' | '-' | ':' | ' '))
 }
 
 /// Collapse runs of 2+ spaces to a single space within each line.
@@ -563,5 +656,74 @@ mod tests {
     fn test_format_urls_no_urls() {
         let input = "No links here";
         assert_eq!(format_urls(input), input);
+    }
+
+    #[test]
+    fn rtl_visual_hebrew_restored() {
+        assert_eq!(restore_rtl_reading_order("םלוע םולש"), "שלום עולם");
+    }
+
+    #[test]
+    fn rtl_logical_hebrew_untouched() {
+        let input = "שלום עולם\n\nחשבונית מס 12345";
+        assert_eq!(restore_rtl_reading_order(input), input);
+    }
+
+    #[test]
+    fn rtl_pass_is_idempotent() {
+        let visual = "## םלוע םולש\n\nהקידבל טסקט הז";
+        let once = restore_rtl_reading_order(visual);
+        assert_eq!(restore_rtl_reading_order(&once), once);
+    }
+
+    #[test]
+    fn rtl_leaves_latin_documents_byte_identical() {
+        let input = "# Invoice 12345\n\n|Qty|Item|Total|\n|---|---|---|\n|1|Consulting|100.00|";
+        assert_eq!(restore_rtl_reading_order(input), input);
+    }
+
+    #[test]
+    fn rtl_preserves_heading_and_list_markers() {
+        // The marker stays on the left; only the prose after it is reordered.
+        assert_eq!(restore_rtl_reading_order("## םלוע םולש"), "## שלום עולם");
+        assert_eq!(restore_rtl_reading_order("- םלוע םולש"), "- שלום עולם");
+        assert_eq!(restore_rtl_reading_order("1. םלוע םולש"), "1. שלום עולם");
+    }
+
+    #[test]
+    fn rtl_table_reverses_cell_order_and_keeps_separator() {
+        // A visually-laid-out invoice row: rightmost visual column is the
+        // first logical one, so cell order reverses with the cell text.
+        let visual = "|םוכס|ריחמ|טוריפ|תומכ|\n|---|---|---|---|";
+        let expected = "|כמות|פירוט|מחיר|סכום|\n|---|---|---|---|";
+        assert_eq!(restore_rtl_reading_order(visual), expected);
+    }
+
+    #[test]
+    fn rtl_leaves_signal_free_text_alone() {
+        // Not one final form in this row, so the ordering is genuinely
+        // undecidable — leaving it as-is beats a coin flip that scrambles it.
+        let row = "|תומכ|ריחמ|";
+        assert_eq!(restore_rtl_reading_order(row), row);
+    }
+
+    #[test]
+    fn rtl_can_be_disabled() {
+        let visual = "םלוע םולש".to_string();
+        let options = MarkdownOptions {
+            fix_rtl_order: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            clean_markdown(visual.clone(), &options),
+            format!("{visual}\n")
+        );
+    }
+
+    #[test]
+    fn rtl_runs_through_clean_markdown_by_default() {
+        let visual = "םלוע םולש".to_string();
+        let result = clean_markdown(visual, &MarkdownOptions::default());
+        assert_eq!(result, "שלום עולם\n");
     }
 }

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -124,8 +124,20 @@ fn is_arabic_presentation_form(c: char) -> bool {
     matches!(c, '\u{FB50}'..='\u{FDFF}' | '\u{FE70}'..='\u{FEFE}')
 }
 
-fn is_hebrew_letter(c: char) -> bool {
+pub(crate) fn is_hebrew_letter(c: char) -> bool {
     matches!(c, '\u{05D0}'..='\u{05EA}')
+}
+
+/// Arabic in any of its forms, including the presentation forms that mark
+/// visual-order storage.
+pub(crate) fn is_arabic_char(c: char) -> bool {
+    matches!(c,
+        '\u{0600}'..='\u{06FF}'   // Arabic
+        | '\u{0750}'..='\u{077F}' // Arabic Supplement
+        | '\u{08A0}'..='\u{08FF}' // Arabic Extended-A
+        | '\u{FB50}'..='\u{FDFF}' // Presentation Forms-A
+        | '\u{FE70}'..='\u{FEFE}' // Presentation Forms-B
+    )
 }
 
 /// Hebrew final forms (ך ם ן ף ץ), which are legal only as a word's last letter.

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -124,6 +124,55 @@ fn is_arabic_presentation_form(c: char) -> bool {
     matches!(c, '\u{FB50}'..='\u{FDFF}' | '\u{FE70}'..='\u{FEFE}')
 }
 
+fn is_hebrew_letter(c: char) -> bool {
+    matches!(c, '\u{05D0}'..='\u{05EA}')
+}
+
+/// Hebrew final forms (ך ם ן ף ץ), which are legal only as a word's last letter.
+fn is_hebrew_final_form(c: char) -> bool {
+    matches!(
+        c,
+        '\u{05DA}' | '\u{05DD}' | '\u{05DF}' | '\u{05E3}' | '\u{05E5}'
+    )
+}
+
+/// Detect Hebrew stored in visual (screen) order rather than logical order.
+///
+/// Arabic announces visual-order storage through presentation forms, so
+/// [`expand_ligatures`] can key off those per text item. Hebrew has no such
+/// marker — the same base codepoints (U+05D0-05EA) appear in both orderings —
+/// so the ordering has to be inferred from word shape instead.
+///
+/// The signal is Hebrew's five final forms: they may only end a word. When a
+/// producer lays glyphs out visually, extraction walks each word backwards and
+/// those letters surface at the *start* of words. Counting which end they land
+/// on separates the two orderings without a dictionary. Ties (including text
+/// with no final forms at all) report `false` so that ambiguous input is left
+/// untouched rather than scrambled.
+///
+/// Intended for whole-document text: a single word rarely carries enough
+/// signal, and a per-fragment decision would flip part of a page and not
+/// the rest.
+pub(crate) fn is_visual_order_hebrew(text: &str) -> bool {
+    let (mut at_start, mut at_end) = (0u32, 0u32);
+
+    for word in text.split(|c: char| !is_hebrew_letter(c)) {
+        let mut chars = word.chars();
+        let Some(first) = chars.next() else { continue };
+        let Some(last) = chars.next_back() else {
+            continue; // single-letter word: same char at both ends, no signal
+        };
+        if is_hebrew_final_form(first) {
+            at_start += 1;
+        }
+        if is_hebrew_final_form(last) {
+            at_end += 1;
+        }
+    }
+
+    at_start > at_end
+}
+
 pub(crate) fn is_rtl_text<I, S>(texts: I) -> bool
 where
     I: Iterator<Item = S>,
@@ -253,18 +302,21 @@ pub(crate) fn expand_ligatures(text: &str) -> String {
     // visual (LTR screen) order. After NFKC normalization, reverse to restore
     // logical reading order.
     if had_presentation_forms {
-        result = reverse_visual_arabic(&result);
+        result = reverse_visual_rtl(&result);
     }
 
     result
 }
 
-/// Reverse visual-order Arabic text to logical order.
+/// Reverse visual-order RTL text to logical order.
 ///
 /// Pure RTL text (no ASCII alphanumerics) gets a simple character reversal.
 /// Mixed content (embedded numbers or Latin words) splits into LTR and non-LTR
 /// runs: run order is reversed, and only non-LTR runs are reversed internally.
-fn reverse_visual_arabic(text: &str) -> String {
+///
+/// Script-agnostic: used for Arabic (triggered per text item by presentation
+/// forms) and for Hebrew (triggered per document by [`is_visual_order_hebrew`]).
+pub(crate) fn reverse_visual_rtl(text: &str) -> String {
     // Check if there are any LTR runs (ASCII letters or digits)
     let has_ltr = text.chars().any(|c| c.is_ascii_alphanumeric());
 
@@ -928,21 +980,63 @@ mod tests {
     }
 
     #[test]
-    fn reverse_visual_arabic_pure_rtl() {
+    fn hebrew_visual_order_detected() {
+        // "שלום עולם" laid out visually: the final ם opens each word.
+        assert!(is_visual_order_hebrew("םלוע םולש"));
+        assert!(is_visual_order_hebrew("םלוע םולש הז טסקט הקידבל"));
+    }
+
+    #[test]
+    fn hebrew_logical_order_left_alone() {
+        // Same strings the right way round — final forms close their words.
+        assert!(!is_visual_order_hebrew("שלום עולם"));
+        assert!(!is_visual_order_hebrew("שלום עולם זה טקסט לבדיקה"));
+        assert!(!is_visual_order_hebrew(
+            "חשבונית מס 12345 | סך הכל לתשלום 100.00"
+        ));
+    }
+
+    #[test]
+    fn hebrew_without_final_forms_is_ambiguous() {
+        // No final form anywhere: no signal either way, so report logical and
+        // leave the text untouched rather than guess.
+        assert!(!is_visual_order_hebrew("תודה רבה"));
+        assert!(!is_visual_order_hebrew("הבר הדות"));
+    }
+
+    #[test]
+    fn non_hebrew_never_reports_visual() {
+        assert!(!is_visual_order_hebrew("Hello World 1234"));
+        assert!(!is_visual_order_hebrew(
+            "\u{0645}\u{0631}\u{062D}\u{0628}\u{0627}"
+        )); // مرحبا
+        assert!(!is_visual_order_hebrew(""));
+    }
+
+    #[test]
+    fn hebrew_reversal_round_trips() {
+        let logical = "שלום עולם";
+        let visual: String = logical.chars().rev().collect();
+        assert!(is_visual_order_hebrew(&visual));
+        assert_eq!(reverse_visual_rtl(&visual), logical);
+    }
+
+    #[test]
+    fn reverse_visual_rtl_pure_rtl() {
         // Pure RTL: simple reversal
         let input = "\u{0628}\u{0627}"; // ba (visual order)
-        let result = reverse_visual_arabic(input);
+        let result = reverse_visual_rtl(input);
         assert_eq!(result, "\u{0627}\u{0628}"); // ab (logical order)
     }
 
     #[test]
-    fn reverse_visual_arabic_with_ltr_run() {
+    fn reverse_visual_rtl_with_ltr_run() {
         // Mixed: Arabic + embedded number "123" + Arabic
         // Visual order: أ 123 ب  → runs: [أ], [123], [ب]
         // Reversed runs: [ب], [123], [أ]
         // Non-LTR reversed internally: ب, 123, أ
         let input = "\u{0623}123\u{0628}";
-        let result = reverse_visual_arabic(input);
+        let result = reverse_visual_rtl(input);
         assert_eq!(result, "\u{0628}123\u{0623}");
     }
 


### PR DESCRIPTION
## The problem

Hebrew PDFs that store glyphs in visual order extract reversed, and nothing downstream catches it:

```
## מ"עב ןואג ריש          ← should be: שיר גאון בע"מ
|כ"הס|ריחמ|טוריפ|תומכ|    ← should be: |כמות|פירוט|מחיר|סה"כ|
```

The output is not merely untidy — it is unreadable, and an agent consuming it has no way to tell.

## Why it happens

The reversal already exists. `expand_ligatures()` calls `reverse_visual_arabic()` whenever it sees visual-order text. The trigger is the catch:

```rust
let had_presentation_forms = text.chars().any(is_arabic_presentation_form);
```

Arabic presentation forms (U+FB50-FDFF, U+FE70-FEFE) are an Arabic-only phenomenon. Visual-order Hebrew is written with plain base codepoints (U+05D0-05EA), so this is always `false` and the reversal never runs. Hebrew falls through a gap: `is_rtl_char` knows about it, `sort_line_items` sorts for it, but nothing ever flips it.

## The signal

Hebrew has no presentation-form marker, so ordering has to come from word shape. Its five final forms — ך ם ן ף ץ — are legal **only** as a word's last letter. When a producer lays glyphs out visually, extraction walks each word backwards and those letters surface at the *start* of words instead.

`is_visual_order_hebrew()` counts which end they land on. Ties — including text with no final forms at all — report logical, so ambiguous input is left alone rather than scrambled. Guessing wrong in that direction is the expensive mistake: it corrupts a correct document.

## Where the decision is made

Once per document, in `clean_markdown()` — not per text item. A producer picks one ordering for the whole file, and `expand_ligatures()` only ever sees fragments, most too short to carry the signal. Deciding per fragment would flip some lines of a page and not others, which is worse than either consistent answer.

Markdown table rows also get their cell order reversed: an RTL table's leftmost visual column is its last logical one.

## Notes for review

- `reverse_visual_arabic` → `reverse_visual_rtl`. The function was already script-agnostic; it now has two callers.
- **Arabic is deliberately untouched.** It keeps its existing per-item path and is explicitly out of scope for the document pass, so it is never reversed twice.
- Opt out with `MarkdownOptions.fix_rtl_order`.
- Two rough edges belong to the existing reversal and are left alone to keep this diff focused: mirrored pairs are not flipped (`)ח.פ(`), and a comma adjacent to a number stays glued to it (`,12`). Both already affect Arabic today; a follow-up could route the reversal through a full UBA implementation.

## Verification

`cargo fmt`, `cargo clippy` (no new warnings from these files) and `cargo test` all pass — 923 unit + 162 integration, including 15 new tests.

Behaviour was diffed against `main` with a release build:

| Corpus | Result |
|---|---|
| All 27 `tests/fixtures/*.pdf` | byte-identical |
| 10 non-Hebrew documents | byte-identical |
| 29 Hebrew documents | 24 visual → now correct; **5 already logical → untouched** |

No false positives — the "already logical, left alone" column is the one that matters, and it is clean.

I could not run the `pdf-evals` snapshot suite (sibling repo, not public as far as I can tell), so that check is outstanding and worth running before merge. The test corpus above is real-world Hebrew paperwork — invoices, payslips, bank transfers — which I can't attach as fixtures since it is personal; the unit tests use synthetic strings only. Happy to add a synthetic Hebrew fixture PDF if you want integration coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores logical reading order for visual-order Hebrew so extracted markdown is readable. Previously, Hebrew text reversed on extraction, Arabic in mixed docs could be reversed twice, and inline markup could invert; now the pass is scoped to Hebrew and preserves inline tags and emphasis.

**Key points**
- Detect visual-order Hebrew via final-form letters: count appearances at word starts vs ends; ties report logical and leave text unchanged.
- Decide once per document in `clean_markdown()`; scope line reversal to lines with Hebrew and no Arabic so Arabic is never double-reversed.
- Reverse prose with `reverse_visual_rtl` (renamed from `reverse_visual_arabic`); preserve heading/list/quote markers.
- Reverse pipe-delimited table cell order; separator rows (`|---|`) stay unchanged.
- Preserve inline markup: keep `<u>`, `*`/`**`, and `` ` `` runs in place and reverse only text segments.
- Add `MarkdownOptions.fix_rtl_order` (default true); disable to keep visual order. Non-Hebrew docs remain byte-identical; already-logical Hebrew stays untouched; tests updated and pass.

<sup>Written for commit dc7a11fac8fcff23e9df967e9a4e0562d84bb7b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

