### PR TITLE
fix(extractor): bound ToUnicode bfrange expansion during subset remap

### DIFF
--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -540,28 +540,14 @@ impl ToUnicodeCMap {
 
     /// Remap a CMap that references pre-subsetting GIDs to sequential post-subsetting GIDs.
     /// Collects all source CIDs, sorts them, and reassigns to 1, 2, 3, ...
+    ///
+    /// Range expansion stops after `MAX_CID_W_EXPANSION` CID visits, counting
+    /// overwrites, so repeated full-width `bfrange`s cannot re-expand the
+    /// 16-bit domain. Later overlapping ranges that would have introduced new
+    /// CIDs after that many visits are truncated.
     pub fn remap_to_sequential(&self) -> ToUnicodeCMap {
         let mut cid_to_unicode: HashMap<u16, String> = HashMap::new();
-        let mut assigned = 0usize;
-
-        // Expand ranges first. Count every CID considered, including
-        // overwrites, so repeating a full-width bfrange cannot re-expand the
-        // 16-bit domain.
-        'ranges: for &(start, end, base) in &self.ranges {
-            if start > end {
-                continue;
-            }
-            for cid in start..=end {
-                if assigned >= MAX_CID_W_EXPANSION {
-                    break 'ranges;
-                }
-                assigned += 1;
-                let unicode_cp = base + (cid - start) as u32;
-                if let Some(ch) = char::from_u32(unicode_cp) {
-                    cid_to_unicode.insert(cid, ch.to_string());
-                }
-            }
-        }
+        expand_bfranges_for_remap(&self.ranges, &mut cid_to_unicode, MAX_CID_W_EXPANSION);
 
         // char_map entries override range entries
         for (&cid, unicode) in &self.char_map {
@@ -584,6 +570,33 @@ impl ToUnicodeCMap {
 
         new_cmap
     }
+}
+
+/// Expand `bfrange` entries into individual CID→Unicode inserts.
+/// Returns how many CIDs were visited. Counts overwrites so a repeated
+/// full-width range cannot keep working after `max_assignments`.
+fn expand_bfranges_for_remap(
+    ranges: &[(u16, u16, u32)],
+    cid_to_unicode: &mut HashMap<u16, String>,
+    max_assignments: usize,
+) -> usize {
+    let mut assigned = 0usize;
+    'ranges: for &(start, end, base) in ranges {
+        if start > end {
+            continue;
+        }
+        for cid in start..=end {
+            if assigned >= max_assignments {
+                break 'ranges;
+            }
+            assigned += 1;
+            let unicode_cp = base + (cid - start) as u32;
+            if let Some(ch) = char::from_u32(unicode_cp) {
+                cid_to_unicode.insert(cid, ch.to_string());
+            }
+        }
+    }
+    assigned
 }
 
 /// Parse a hex string to u16
@@ -2936,8 +2949,14 @@ endbfrange
 
     #[test]
     fn remap_to_sequential_repeated_full_bfranges_stay_bounded() {
-        // 5,000 copies of `<0003> <ffff> <0041>` must not re-expand the
-        // 16-bit domain on every declaration during subset remap.
+        // 5,000 copies of `<0003> <ffff>` must stop after 65,536 CID visits,
+        // not 5,000 × ~65,533 expansions.
+        let ranges = vec![(3u16, 65535u16, 0x41u32); 5_000];
+        let mut map = std::collections::HashMap::new();
+        let assigned = expand_bfranges_for_remap(&ranges, &mut map, MAX_CID_W_EXPANSION);
+        assert_eq!(assigned, MAX_CID_W_EXPANSION);
+        assert!(map.len() <= MAX_CID_W_EXPANSION);
+
         let mut body = String::new();
         let mut remaining = 5_000usize;
         while remaining > 0 {
@@ -2952,7 +2971,6 @@ endbfrange
         let data = format!("1 begincodespacerange\n<0000> <ffff>\nendcodespacerange\n{body}");
         let cmap = ToUnicodeCMap::parse(data.as_bytes()).unwrap();
         let remapped = cmap.remap_to_sequential();
-        assert!(remapped.char_map.len() <= MAX_CID_W_EXPANSION);
         assert_eq!(remapped.lookup(1), Some("A".to_string()));
     }
 

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -542,10 +542,20 @@ impl ToUnicodeCMap {
     /// Collects all source CIDs, sorts them, and reassigns to 1, 2, 3, ...
     pub fn remap_to_sequential(&self) -> ToUnicodeCMap {
         let mut cid_to_unicode: HashMap<u16, String> = HashMap::new();
+        let mut assigned = 0usize;
 
-        // Expand ranges first
-        for &(start, end, base) in &self.ranges {
+        // Expand ranges first. Count every CID considered, including
+        // overwrites, so repeating a full-width bfrange cannot re-expand the
+        // 16-bit domain.
+        'ranges: for &(start, end, base) in &self.ranges {
+            if start > end {
+                continue;
+            }
             for cid in start..=end {
+                if assigned >= MAX_CID_W_EXPANSION {
+                    break 'ranges;
+                }
+                assigned += 1;
                 let unicode_cp = base + (cid - start) as u32;
                 if let Some(ch) = char::from_u32(unicode_cp) {
                     cid_to_unicode.insert(cid, ch.to_string());
@@ -1868,10 +1878,10 @@ fn merge_cmaps(mut base: ToUnicodeCMap, overlay: ToUnicodeCMap) -> ToUnicodeCMap
 }
 
 /// Shared 16-bit CID expansion cap (65,536).
-/// Encoding `begincidrange` and `/W` width assignment count every insert,
-/// including overwrites, so a repeated full-width range cannot keep working
-/// after the domain is filled. The `/W` unicode heuristic caps unique CIDs
-/// with the same number.
+/// Encoding `begincidrange`, `/W` width assignment, and ToUnicode sequential
+/// remap count every insert, including overwrites, so a repeated full-width
+/// range cannot keep working after the domain is filled. The `/W` unicode
+/// heuristic caps unique CIDs with the same number.
 pub(crate) const MAX_CID_W_EXPANSION: usize = 65_536;
 
 /// Check if a CIDFont's /W (widths) array contains CID values that look like
@@ -2922,6 +2932,28 @@ endbfrange
         assert_eq!(remapped.lookup(0x0004), Some("Z".to_string()));
         // Ranges should be cleared (all in char_map now)
         assert!(remapped.ranges.is_empty());
+    }
+
+    #[test]
+    fn remap_to_sequential_repeated_full_bfranges_stay_bounded() {
+        // 5,000 copies of `<0003> <ffff> <0041>` must not re-expand the
+        // 16-bit domain on every declaration during subset remap.
+        let mut body = String::new();
+        let mut remaining = 5_000usize;
+        while remaining > 0 {
+            let n = remaining.min(100);
+            body.push_str(&format!("{n} beginbfrange\n"));
+            for _ in 0..n {
+                body.push_str("<0003> <ffff> <0041>\n");
+            }
+            body.push_str("endbfrange\n");
+            remaining -= n;
+        }
+        let data = format!("1 begincodespacerange\n<0000> <ffff>\nendcodespacerange\n{body}");
+        let cmap = ToUnicodeCMap::parse(data.as_bytes()).unwrap();
+        let remapped = cmap.remap_to_sequential();
+        assert!(remapped.char_map.len() <= MAX_CID_W_EXPANSION);
+        assert_eq!(remapped.lookup(1), Some("A".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Subset remap expands every ToUnicode `bfrange` into individual CID→Unicode inserts. Repeating a valid full-width range (`<0003> <ffff>`) re-did that work on every copy, so a compact CMap could burn seconds of CPU.
- Stop after 65,536 CID assignments (the 16-bit domain), the same cap already used for `/W` and Encoding `begincidrange`. Normal subset remaps are unchanged.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] Unit tests: existing sequential remap cases still pass; 5,000 copies of `<0003> <ffff>` stay within 65,536 keys


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds ToUnicode `bfrange` expansion during subset remap to the 16‑bit domain. Previously, repeating a full‑width range (e.g., `<0003> <ffff>`) re-expanded on every copy; now expansion stops after 65,536 CID visits, counting overwrites, matching `/W` and Encoding caps.

- Adds `expand_bfranges_for_remap` and applies shared `MAX_CID_W_EXPANSION = 65_536` in `remap_to_sequential`; later overlapping ranges truncate once the budget is exhausted; `char_map` entries still override ranges.
- Behavior change: repeated `bfrange` entries beyond the 16‑bit domain no longer add mappings; normal remaps are unaffected.
- Updates tests to assert visit count equals the cap for 5,000 repeated full‑width `bfrange`s; existing remap tests still pass.
- No API changes or migrations.

<sup>Written for commit 45be5718b99c248efa1b0e0f1807da84231166d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

