### PR TITLE
fix(tables): bound disjoint-rect clustering so overlap tests stay subquadratic

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -85,17 +85,19 @@ pub(crate) fn rects_overlap(a: &(f32, f32, f32, f32), b: &(f32, f32, f32, f32), 
 const MAX_CLUSTER_RECTS: usize = 2000;
 
 /// Pairwise-disjoint rects never merge, so a component-size cap does not
-/// stop the all-pairs loop. Bound the number of AABB tests so a page of
-/// thousands of isolated drawing rects cannot go quadratic.
-const MAX_CLUSTER_OVERLAP_CHECKS: usize = 1_000_000;
+/// stop the all-pairs loop. Each rect is compared with at most this many
+/// later candidates (already restricted to overlapping X); remaining
+/// X-ranges are still processed so a dense stack cannot starve a table
+/// elsewhere on the page.
+const MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT: usize = 256;
 
 /// Cluster rects by spatial overlap using union-find.
 /// Returns groups of rect indices; only groups with ≥ `min_size` rects are returned.
 ///
 /// Overlap tests are ordered by left edge and skipped once a pair cannot
-/// overlap in X. Combined with [`MAX_CLUSTER_RECTS`] and
-/// [`MAX_CLUSTER_OVERLAP_CHECKS`], scattered or stacked disjoint rects stay
-/// linear-ish instead of O(n²).
+/// overlap in X. Each rect is limited to
+/// [`MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT`] AABB tests so stacked disjoint
+/// drawings stay linear-ish without dropping later independent clusters.
 pub(crate) fn cluster_rects(
     rects: &[(f32, f32, f32, f32)],
     tolerance: f32,
@@ -108,12 +110,12 @@ pub(crate) fn cluster_rects(
     let mut order: Vec<usize> = (0..n).collect();
     order.sort_by(|&a, &b| rects[a].0.total_cmp(&rects[b].0));
 
-    let mut checks = 0usize;
-    'outer: for (pos, &i) in order.iter().enumerate() {
+    for (pos, &i) in order.iter().enumerate() {
         if uf.component_size(i) >= MAX_CLUSTER_RECTS {
             continue;
         }
         let i_right = rects[i].0 + rects[i].2 + two_tol;
+        let mut checks = 0usize;
         for &j in &order[pos + 1..] {
             if rects[j].0 > i_right {
                 break;
@@ -121,13 +123,10 @@ pub(crate) fn cluster_rects(
             if uf.component_size(j) >= MAX_CLUSTER_RECTS {
                 continue;
             }
-            checks += 1;
-            if checks > MAX_CLUSTER_OVERLAP_CHECKS {
-                debug!(
-                    "cluster_rects: overlap-check budget {MAX_CLUSTER_OVERLAP_CHECKS} exhausted (n={n})"
-                );
-                break 'outer;
+            if checks >= MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT {
+                break;
             }
+            checks += 1;
             if rects_overlap(&rects[i], &rects[j], tolerance) {
                 uf.union(i, j);
                 if uf.component_size(i) >= MAX_CLUSTER_RECTS {
@@ -3856,14 +3855,18 @@ mod tests {
     }
 
     #[test]
-    fn test_cluster_rects_stacked_disjoint_respects_check_budget() {
-        // Same left edge: the X sweep cannot skip pairs. The overlap-check
-        // budget must still keep this from going fully quadratic.
+    fn test_cluster_rects_stacked_disjoint_respects_per_rect_budget() {
+        // Same left edge: the X sweep cannot skip pairs. A per-rect check
+        // cap keeps this from going fully quadratic, and a table at a later
+        // X still clusters.
         let n = 8_000usize;
-        let rects: Vec<(f32, f32, f32, f32)> =
+        let mut rects: Vec<(f32, f32, f32, f32)> =
             (0..n).map(|i| (0.0, i as f32 * 20.0, 10.0, 10.0)).collect();
+        rects.push((500.0, 0.0, 10.0, 10.0));
+        rects.push((508.0, 0.0, 10.0, 10.0));
         let groups = cluster_rects(&rects, 0.0, 2);
-        assert!(groups.is_empty());
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 2);
     }
 
     // --- snap_edges ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -109,6 +109,7 @@ const CLUSTER_GRID_CELL: f32 = 64.0;
 /// tens of points wide, so a 64-pt cell holds a handful of neighbors — not
 /// thousands of stacked drawings.
 const MAX_CLUSTER_PAIRS_PER_CELL: usize = 16_384;
+const MAX_OVERLAP_CHECKS_PER_LARGE_RECT: usize = 8_192;
 
 /// Cluster rects by spatial overlap using union-find.
 /// Returns groups of rect indices; only groups with ≥ `min_size` rects are returned.
@@ -172,16 +173,22 @@ pub(crate) fn cluster_rects(
         }
     }
 
-    // Oversized spans skip the grid; compare them against every rect so a
-    // page-wide rule still unions the cells it actually overlaps.
-    for &i in large.iter().take(32) {
+    // Oversized spans skip the grid; compare each against other rects so a
+    // page-wide rule still unions the cells it actually overlaps. Every
+    // oversized rect is visited; AABB tests per rect are capped.
+    for &i in &large {
         if uf.component_size(i) >= MAX_CLUSTER_RECTS {
             continue;
         }
+        let mut checks = 0usize;
         for j in 0..n {
+            if checks >= MAX_OVERLAP_CHECKS_PER_LARGE_RECT {
+                break;
+            }
             if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
                 continue;
             }
+            checks += 1;
             if rects_overlap(&rects[i], &rects[j], tolerance) {
                 uf.union(i, j);
                 if uf.component_size(i) >= MAX_CLUSTER_RECTS {
@@ -3928,6 +3935,18 @@ mod tests {
         // Wider than 64 grid cells; must still union the small overlapping rect.
         let rects = vec![(0.0, 0.0, 5000.0, 10.0), (4900.0, 0.0, 10.0, 10.0)];
         let groups = cluster_rects(&rects, 0.0, 1);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_many_oversized_spans_all_get_a_pass() {
+        // More than 32 huge rects: the last one must still union its overlap.
+        let mut rects: Vec<(f32, f32, f32, f32)> = (0..40)
+            .map(|i| (0.0, i as f32 * 20.0, 5000.0, 10.0))
+            .collect();
+        rects.push((4900.0, 39.0 * 20.0, 10.0, 10.0));
+        let groups = cluster_rects(&rects, 0.0, 2);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 2);
     }

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1,6 +1,6 @@
 //! Rectangle-based table detection using union-find clustering.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use log::debug;
 
@@ -94,6 +94,37 @@ fn grid_span(lo: f32, hi: f32, cell: f32) -> Option<std::ops::RangeInclusive<i32
     Some(a..=b)
 }
 
+fn union_bucket_pairs(
+    uf: &mut UnionFind,
+    rects: &[(f32, f32, f32, f32)],
+    bucket: &[usize],
+    tolerance: f32,
+) {
+    let m = bucket.len();
+    let mut pairs = 0usize;
+    'cell: for a in 0..m {
+        let i = bucket[a];
+        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+            continue;
+        }
+        for &j in &bucket[a + 1..] {
+            if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+                break 'cell;
+            }
+            if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                continue;
+            }
+            pairs += 1;
+            if rects_overlap(&rects[i], &rects[j], tolerance) {
+                uf.union(i, j);
+                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Maximum component size for rect clustering.  No real table has thousands
 /// of cell rects — once a component exceeds this, it is a vector drawing or
 /// page-spanning clipping path.  We skip overlap checks for rects already in
@@ -145,35 +176,14 @@ pub(crate) fn cluster_rects(
 
     let mut keys: Vec<_> = grid.keys().copied().collect();
     keys.sort_unstable();
+    let mut keys_by_y: BTreeMap<i32, Vec<i32>> = BTreeMap::new();
     for &key in &keys {
-        let bucket = &grid[&key];
-        let m = bucket.len();
-        let mut pairs = 0usize;
-        'cell: for a in 0..m {
-            let i = bucket[a];
-            if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                continue;
-            }
-            for &j in &bucket[a + 1..] {
-                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
-                    break 'cell;
-                }
-                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
-                    continue;
-                }
-                pairs += 1;
-                if rects_overlap(&rects[i], &rects[j], tolerance) {
-                    uf.union(i, j);
-                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                        break;
-                    }
-                }
-            }
-        }
+        union_bucket_pairs(&mut uf, rects, &grid[&key], tolerance);
+        keys_by_y.entry(key.1).or_default().push(key.0);
     }
 
-    // Oversized spans skip insert; query the grid cells they cover so a
-    // later overlapping cell is not starved by earlier disjoint candidates.
+    // Oversized spans skip insert. Range-query occupied cells they cover so
+    // later X-ranges are not starved and we do not scan unrelated rows.
     for &i in &large {
         if uf.component_size(i) >= MAX_CLUSTER_RECTS {
             continue;
@@ -183,25 +193,31 @@ pub(crate) fn cluster_rects(
         let x_hi = grid_coord(x + w + tolerance, cell);
         let y_lo = grid_coord(y - tolerance, cell);
         let y_hi = grid_coord(y + h + tolerance, cell);
-        for &(gx, gy) in &keys {
-            if gx < x_lo || gx > x_hi || gy < y_lo || gy > y_hi {
-                continue;
-            }
-            let bucket = &grid[&(gx, gy)];
-            let mut pairs = 0usize;
-            for &j in bucket {
-                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+        for (&gy, gxs) in keys_by_y.range(y_lo..=y_hi) {
+            let start = gxs.partition_point(|&gx| gx < x_lo);
+            for &gx in &gxs[start..] {
+                if gx > x_hi {
                     break;
                 }
-                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
-                    continue;
-                }
-                pairs += 1;
-                if rects_overlap(&rects[i], &rects[j], tolerance) {
-                    uf.union(i, j);
-                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                let bucket = &grid[&(gx, gy)];
+                let mut pairs = 0usize;
+                for &j in bucket {
+                    if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
                         break;
                     }
+                    if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                        continue;
+                    }
+                    pairs += 1;
+                    if rects_overlap(&rects[i], &rects[j], tolerance) {
+                        uf.union(i, j);
+                        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                            break;
+                        }
+                    }
+                }
+                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                    break;
                 }
             }
             if uf.component_size(i) >= MAX_CLUSTER_RECTS {
@@ -210,67 +226,37 @@ pub(crate) fn cluster_rects(
         }
     }
 
-    // Oversized-vs-oversized: band by Y so stacked page-wide rules stay linear.
+    // Oversized-vs-oversized: band on the short axis so stacked or side-by-side
+    // page-spanning rules stay linear. Dual-oversized rects use a coarser Y band.
+    let mut large_x: HashMap<i32, Vec<usize>> = HashMap::new();
     let mut large_y: HashMap<i32, Vec<usize>> = HashMap::new();
-    let mut huge_y: Vec<usize> = Vec::new();
+    let mut large_coarse_y: HashMap<i32, Vec<usize>> = HashMap::new();
     for &i in &large {
-        let (_, y, _, h) = rects[i];
-        match grid_span(y - tolerance, y + h + tolerance, cell) {
-            Some(ys) => {
+        let (x, y, w, h) = rects[i];
+        let xs = grid_span(x - tolerance, x + w + tolerance, cell);
+        let ys = grid_span(y - tolerance, y + h + tolerance, cell);
+        match (xs, ys) {
+            (Some(xs), _) => {
+                for gx in xs {
+                    large_x.entry(gx).or_default().push(i);
+                }
+            }
+            (_, Some(ys)) => {
                 for gy in ys {
                     large_y.entry(gy).or_default().push(i);
                 }
             }
-            None => huge_y.push(i),
-        }
-    }
-    let mut y_keys: Vec<_> = large_y.keys().copied().collect();
-    y_keys.sort_unstable();
-    for gy in y_keys {
-        let bucket = &large_y[&gy];
-        let m = bucket.len();
-        let mut pairs = 0usize;
-        'y_band: for a in 0..m {
-            let i = bucket[a];
-            if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                continue;
-            }
-            for &j in &bucket[a + 1..] {
-                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
-                    break 'y_band;
-                }
-                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
-                    continue;
-                }
-                pairs += 1;
-                if rects_overlap(&rects[i], &rects[j], tolerance) {
-                    uf.union(i, j);
-                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                        break;
-                    }
-                }
+            _ => {
+                let gy = grid_coord(y - tolerance, cell * 64.0);
+                large_coarse_y.entry(gy).or_default().push(i);
             }
         }
     }
-    for &i in &huge_y {
-        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-            continue;
-        }
-        let mut pairs = 0usize;
-        for &j in &large {
-            if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
-                break;
-            }
-            if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
-                continue;
-            }
-            pairs += 1;
-            if rects_overlap(&rects[i], &rects[j], tolerance) {
-                uf.union(i, j);
-                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                    break;
-                }
-            }
+    for bands in [&large_x, &large_y, &large_coarse_y] {
+        let mut band_keys: Vec<_> = bands.keys().copied().collect();
+        band_keys.sort_unstable();
+        for key in band_keys {
+            union_bucket_pairs(&mut uf, rects, &bands[&key], tolerance);
         }
     }
 
@@ -4032,16 +4018,19 @@ mod tests {
         // 9k earlier disjoint drawings would exhaust an index-order cap of
         // 8,192 before the overlapping cell is visited.
         let mut rects: Vec<(f32, f32, f32, f32)> = (0..9_000)
-            .map(|i| (0.0, i as f32 * 20.0, 10.0, 10.0))
+            .map(|i| (10_000.0, i as f32 * 20.0, 10.0, 10.0))
             .collect();
+        let wide = rects.len();
         rects.push((0.0, 0.0, 5000.0, 10.0));
+        let target = rects.len();
         rects.push((4900.0, 0.0, 10.0, 10.0));
         let groups = cluster_rects(&rects, 0.0, 2);
-        assert!(groups.iter().any(|g| {
-            g.len() >= 2
-                && g.iter()
-                    .any(|&idx| (rects[idx].2 - 5000.0).abs() < f32::EPSILON)
-        }));
+        assert!(
+            groups
+                .iter()
+                .any(|g| g.contains(&wide) && g.contains(&target)),
+            "wide rule and far-end cell must share a cluster"
+        );
     }
 
     // --- snap_edges ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -125,6 +125,38 @@ fn union_bucket_pairs(
     }
 }
 
+fn union_rect_against_bands(
+    uf: &mut UnionFind,
+    rects: &[(f32, f32, f32, f32)],
+    i: usize,
+    bands: &BTreeMap<i32, Vec<usize>>,
+    lo: i32,
+    hi: i32,
+    tolerance: f32,
+) {
+    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+        return;
+    }
+    for (_, bucket) in bands.range(lo..=hi) {
+        let mut pairs = 0usize;
+        for &j in bucket {
+            if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+                break;
+            }
+            if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                continue;
+            }
+            pairs += 1;
+            if rects_overlap(&rects[i], &rects[j], tolerance) {
+                uf.union(i, j);
+                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                    return;
+                }
+            }
+        }
+    }
+}
+
 /// Maximum component size for rect clustering.  No real table has thousands
 /// of cell rects — once a component exceeds this, it is a vector drawing or
 /// page-spanning clipping path.  We skip overlap checks for rects already in
@@ -227,10 +259,14 @@ pub(crate) fn cluster_rects(
     }
 
     // Oversized-vs-oversized: band on the short axis so stacked or side-by-side
-    // page-spanning rules stay linear. Dual-oversized rects use a coarser Y band.
-    let mut large_x: HashMap<i32, Vec<usize>> = HashMap::new();
-    let mut large_y: HashMap<i32, Vec<usize>> = HashMap::new();
-    let mut large_coarse_y: HashMap<i32, Vec<usize>> = HashMap::new();
+    // page-spanning rules stay linear. Wide vs tall pairs are matched by
+    // querying the tall X-index; dual-oversized rects occupy every coarse-Y
+    // cell they span.
+    let mut large_x: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    let mut large_y: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    let mut large_coarse_y: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    let mut wide: Vec<usize> = Vec::new();
+    let mut dual: Vec<usize> = Vec::new();
     for &i in &large {
         let (x, y, w, h) = rects[i];
         let xs = grid_span(x - tolerance, x + w + tolerance, cell);
@@ -242,22 +278,43 @@ pub(crate) fn cluster_rects(
                 }
             }
             (_, Some(ys)) => {
+                wide.push(i);
                 for gy in ys {
                     large_y.entry(gy).or_default().push(i);
                 }
             }
             _ => {
-                let gy = grid_coord(y - tolerance, cell * 64.0);
-                large_coarse_y.entry(gy).or_default().push(i);
+                dual.push(i);
+                let coarse = cell * 64.0;
+                match grid_span(y - tolerance, y + h + tolerance, coarse) {
+                    Some(ys) => {
+                        for gy in ys {
+                            large_coarse_y.entry(gy).or_default().push(i);
+                        }
+                    }
+                    None => {
+                        large_coarse_y.entry(i32::MIN).or_default().push(i);
+                    }
+                }
             }
         }
     }
     for bands in [&large_x, &large_y, &large_coarse_y] {
-        let mut band_keys: Vec<_> = bands.keys().copied().collect();
-        band_keys.sort_unstable();
-        for key in band_keys {
-            union_bucket_pairs(&mut uf, rects, &bands[&key], tolerance);
+        for bucket in bands.values() {
+            union_bucket_pairs(&mut uf, rects, bucket, tolerance);
         }
+    }
+    for &i in wide.iter().chain(&dual) {
+        let (x, _, w, _) = rects[i];
+        let x_lo = grid_coord(x - tolerance, cell);
+        let x_hi = grid_coord(x + w + tolerance, cell);
+        union_rect_against_bands(&mut uf, rects, i, &large_x, x_lo, x_hi, tolerance);
+    }
+    for &i in &dual {
+        let (_, y, _, h) = rects[i];
+        let y_lo = grid_coord(y - tolerance, cell);
+        let y_hi = grid_coord(y + h + tolerance, cell);
+        union_rect_against_bands(&mut uf, rects, i, &large_y, y_lo, y_hi, tolerance);
     }
 
     // Group indices by root
@@ -4031,6 +4088,22 @@ mod tests {
                 .any(|g| g.contains(&wide) && g.contains(&target)),
             "wide rule and far-end cell must share a cluster"
         );
+    }
+
+    #[test]
+    fn test_cluster_rects_wide_and_tall_oversized_union() {
+        let rects = vec![(0.0, 0.0, 5000.0, 10.0), (0.0, 0.0, 10.0, 5000.0)];
+        let groups = cluster_rects(&rects, 0.0, 2);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_dual_oversized_spans_coarse_y() {
+        let rects = vec![(0.0, 0.0, 5000.0, 5000.0), (0.0, 4500.0, 5000.0, 5000.0)];
+        let groups = cluster_rects(&rects, 0.0, 2);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 2);
     }
 
     // --- snap_edges ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -109,7 +109,6 @@ const CLUSTER_GRID_CELL: f32 = 64.0;
 /// tens of points wide, so a 64-pt cell holds a handful of neighbors — not
 /// thousands of stacked drawings.
 const MAX_CLUSTER_PAIRS_PER_CELL: usize = 16_384;
-const MAX_OVERLAP_CHECKS_PER_LARGE_RECT: usize = 8_192;
 
 /// Cluster rects by spatial overlap using union-find.
 /// Returns groups of rect indices; only groups with ≥ `min_size` rects are returned.
@@ -146,7 +145,7 @@ pub(crate) fn cluster_rects(
 
     let mut keys: Vec<_> = grid.keys().copied().collect();
     keys.sort_unstable();
-    for key in keys {
+    for &key in &keys {
         let bucket = &grid[&key];
         let m = bucket.len();
         let mut pairs = 0usize;
@@ -173,22 +172,99 @@ pub(crate) fn cluster_rects(
         }
     }
 
-    // Oversized spans skip the grid; compare each against other rects so a
-    // page-wide rule still unions the cells it actually overlaps. Every
-    // oversized rect is visited; AABB tests per rect are capped.
+    // Oversized spans skip insert; query the grid cells they cover so a
+    // later overlapping cell is not starved by earlier disjoint candidates.
     for &i in &large {
         if uf.component_size(i) >= MAX_CLUSTER_RECTS {
             continue;
         }
-        let mut checks = 0usize;
-        for j in 0..n {
-            if checks >= MAX_OVERLAP_CHECKS_PER_LARGE_RECT {
+        let (x, y, w, h) = rects[i];
+        let x_lo = grid_coord(x - tolerance, cell);
+        let x_hi = grid_coord(x + w + tolerance, cell);
+        let y_lo = grid_coord(y - tolerance, cell);
+        let y_hi = grid_coord(y + h + tolerance, cell);
+        for &(gx, gy) in &keys {
+            if gx < x_lo || gx > x_hi || gy < y_lo || gy > y_hi {
+                continue;
+            }
+            let bucket = &grid[&(gx, gy)];
+            let mut pairs = 0usize;
+            for &j in bucket {
+                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+                    break;
+                }
+                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                    continue;
+                }
+                pairs += 1;
+                if rects_overlap(&rects[i], &rects[j], tolerance) {
+                    uf.union(i, j);
+                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                        break;
+                    }
+                }
+            }
+            if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                break;
+            }
+        }
+    }
+
+    // Oversized-vs-oversized: band by Y so stacked page-wide rules stay linear.
+    let mut large_y: HashMap<i32, Vec<usize>> = HashMap::new();
+    let mut huge_y: Vec<usize> = Vec::new();
+    for &i in &large {
+        let (_, y, _, h) = rects[i];
+        match grid_span(y - tolerance, y + h + tolerance, cell) {
+            Some(ys) => {
+                for gy in ys {
+                    large_y.entry(gy).or_default().push(i);
+                }
+            }
+            None => huge_y.push(i),
+        }
+    }
+    let mut y_keys: Vec<_> = large_y.keys().copied().collect();
+    y_keys.sort_unstable();
+    for gy in y_keys {
+        let bucket = &large_y[&gy];
+        let m = bucket.len();
+        let mut pairs = 0usize;
+        'y_band: for a in 0..m {
+            let i = bucket[a];
+            if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                continue;
+            }
+            for &j in &bucket[a + 1..] {
+                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+                    break 'y_band;
+                }
+                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                    continue;
+                }
+                pairs += 1;
+                if rects_overlap(&rects[i], &rects[j], tolerance) {
+                    uf.union(i, j);
+                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    for &i in &huge_y {
+        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+            continue;
+        }
+        let mut pairs = 0usize;
+        for &j in &large {
+            if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
                 break;
             }
             if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
                 continue;
             }
-            checks += 1;
+            pairs += 1;
             if rects_overlap(&rects[i], &rects[j], tolerance) {
                 uf.union(i, j);
                 if uf.component_size(i) >= MAX_CLUSTER_RECTS {
@@ -3949,6 +4025,23 @@ mod tests {
         let groups = cluster_rects(&rects, 0.0, 2);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_oversized_not_starved_by_earlier_disjoint() {
+        // 9k earlier disjoint drawings would exhaust an index-order cap of
+        // 8,192 before the overlapping cell is visited.
+        let mut rects: Vec<(f32, f32, f32, f32)> = (0..9_000)
+            .map(|i| (0.0, i as f32 * 20.0, 10.0, 10.0))
+            .collect();
+        rects.push((0.0, 0.0, 5000.0, 10.0));
+        rects.push((4900.0, 0.0, 10.0, 10.0));
+        let groups = cluster_rects(&rects, 0.0, 2);
+        assert!(groups.iter().any(|g| {
+            g.len() >= 2
+                && g.iter()
+                    .any(|&idx| (rects[idx].2 - 5000.0).abs() < f32::EPSILON)
+        }));
     }
 
     // --- snap_edges ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -1,6 +1,6 @@
 //! Rectangle-based table detection using union-find clustering.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use log::debug;
 
@@ -138,8 +138,12 @@ fn union_rect_against_bands(
         return;
     }
     let mut pairs = 0usize;
+    let mut seen = HashSet::new();
     for (_, bucket) in bands.range(lo..=hi) {
         for &j in bucket {
+            if !seen.insert(j) {
+                continue;
+            }
             if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
                 return;
             }

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -82,12 +82,16 @@ fn grid_coord(value: f32, cell: f32) -> i32 {
     (value / cell).floor().clamp(-1_000_000.0, 1_000_000.0) as i32
 }
 
-/// Inclusive grid range, capped so a pathological huge rect cannot fill
-/// millions of buckets.
-fn grid_span(lo: f32, hi: f32, cell: f32) -> std::ops::RangeInclusive<i32> {
+/// Inclusive grid range. `None` if the rect covers more cells than we will
+/// materialize — those rects are clustered via a bounded fallback.
+fn grid_span(lo: f32, hi: f32, cell: f32) -> Option<std::ops::RangeInclusive<i32>> {
     let a = grid_coord(lo.min(hi), cell);
     let b = grid_coord(lo.max(hi), cell);
-    a..=a.saturating_add((b.saturating_sub(a)).min(64))
+    let span = b.saturating_sub(a);
+    if span > 64 {
+        return None;
+    }
+    Some(a..=b)
 }
 
 /// Maximum component size for rect clustering.  No real table has thousands
@@ -122,15 +126,27 @@ pub(crate) fn cluster_rects(
     let cell = CLUSTER_GRID_CELL.max(tolerance * 4.0);
 
     let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
+    let mut large: Vec<usize> = Vec::new();
     for (idx, &(x, y, w, h)) in rects.iter().enumerate() {
-        for gx in grid_span(x - tolerance, x + w + tolerance, cell) {
-            for gy in grid_span(y - tolerance, y + h + tolerance, cell) {
-                grid.entry((gx, gy)).or_default().push(idx);
+        match (
+            grid_span(x - tolerance, x + w + tolerance, cell),
+            grid_span(y - tolerance, y + h + tolerance, cell),
+        ) {
+            (Some(xs), Some(ys)) => {
+                for gx in xs {
+                    for gy in ys.clone() {
+                        grid.entry((gx, gy)).or_default().push(idx);
+                    }
+                }
             }
+            _ => large.push(idx),
         }
     }
 
-    for bucket in grid.values() {
+    let mut keys: Vec<_> = grid.keys().copied().collect();
+    keys.sort_unstable();
+    for key in keys {
+        let bucket = &grid[&key];
         let m = bucket.len();
         let mut pairs = 0usize;
         'cell: for a in 0..m {
@@ -151,6 +167,25 @@ pub(crate) fn cluster_rects(
                     if uf.component_size(i) >= MAX_CLUSTER_RECTS {
                         break;
                     }
+                }
+            }
+        }
+    }
+
+    // Oversized spans skip the grid; compare them against every rect so a
+    // page-wide rule still unions the cells it actually overlaps.
+    for &i in large.iter().take(32) {
+        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+            continue;
+        }
+        for j in 0..n {
+            if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                continue;
+            }
+            if rects_overlap(&rects[i], &rects[j], tolerance) {
+                uf.union(i, j);
+                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                    break;
                 }
             }
         }
@@ -3884,6 +3919,15 @@ mod tests {
         rects.push((500.0, 0.0, 10.0, 10.0));
         rects.push((508.0, 0.0, 10.0, 10.0));
         let groups = cluster_rects(&rects, 0.0, 2);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_oversized_span_still_unions() {
+        // Wider than 64 grid cells; must still union the small overlapping rect.
+        let rects = vec![(0.0, 0.0, 5000.0, 10.0), (4900.0, 0.0, 10.0, 10.0)];
+        let groups = cluster_rects(&rects, 0.0, 1);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 2);
     }

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -78,6 +78,18 @@ pub(crate) fn rects_overlap(a: &(f32, f32, f32, f32), b: &(f32, f32, f32, f32), 
     !(a_right < b_left || b_right < a_left || a_top < b_bottom || b_top < a_bottom)
 }
 
+fn grid_coord(value: f32, cell: f32) -> i32 {
+    (value / cell).floor().clamp(-1_000_000.0, 1_000_000.0) as i32
+}
+
+/// Inclusive grid range, capped so a pathological huge rect cannot fill
+/// millions of buckets.
+fn grid_span(lo: f32, hi: f32, cell: f32) -> std::ops::RangeInclusive<i32> {
+    let a = grid_coord(lo.min(hi), cell);
+    let b = grid_coord(lo.max(hi), cell);
+    a..=a.saturating_add((b.saturating_sub(a)).min(64))
+}
+
 /// Maximum component size for rect clustering.  No real table has thousands
 /// of cell rects — once a component exceeds this, it is a vector drawing or
 /// page-spanning clipping path.  We skip overlap checks for rects already in
@@ -85,19 +97,21 @@ pub(crate) fn rects_overlap(a: &(f32, f32, f32, f32), b: &(f32, f32, f32, f32), 
 const MAX_CLUSTER_RECTS: usize = 2000;
 
 /// Pairwise-disjoint rects never merge, so a component-size cap does not
-/// stop the all-pairs loop. Each rect is compared with at most this many
-/// later candidates (already restricted to overlapping X); remaining
-/// X-ranges are still processed so a dense stack cannot starve a table
-/// elsewhere on the page.
-const MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT: usize = 256;
+/// stop an all-pairs loop. Rects are hashed into this many points of grid
+/// and compared only against others in the same cell.
+const CLUSTER_GRID_CELL: f32 = 64.0;
+
+/// All-pairs AABB tests allowed inside one grid cell. A real table cell is
+/// tens of points wide, so a 64-pt cell holds a handful of neighbors — not
+/// thousands of stacked drawings.
+const MAX_CLUSTER_PAIRS_PER_CELL: usize = 16_384;
 
 /// Cluster rects by spatial overlap using union-find.
 /// Returns groups of rect indices; only groups with ≥ `min_size` rects are returned.
 ///
-/// Overlap tests are ordered by left edge and skipped once a pair cannot
-/// overlap in X. Each rect is limited to
-/// [`MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT`] AABB tests so stacked disjoint
-/// drawings stay linear-ish without dropping later independent clusters.
+/// Overlap tests run inside a uniform grid so far-apart rects are never
+/// compared, and each cell is pair-capped so a dense stack cannot go
+/// quadratic or starve an independent table in another cell.
 pub(crate) fn cluster_rects(
     rects: &[(f32, f32, f32, f32)],
     tolerance: f32,
@@ -105,32 +119,38 @@ pub(crate) fn cluster_rects(
 ) -> Vec<Vec<usize>> {
     let n = rects.len();
     let mut uf = UnionFind::new(n);
-    let two_tol = tolerance * 2.0;
+    let cell = CLUSTER_GRID_CELL.max(tolerance * 4.0);
 
-    let mut order: Vec<usize> = (0..n).collect();
-    order.sort_by(|&a, &b| rects[a].0.total_cmp(&rects[b].0));
-
-    for (pos, &i) in order.iter().enumerate() {
-        if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-            continue;
-        }
-        let i_right = rects[i].0 + rects[i].2 + two_tol;
-        let mut checks = 0usize;
-        for &j in &order[pos + 1..] {
-            if rects[j].0 > i_right {
-                break;
+    let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
+    for (idx, &(x, y, w, h)) in rects.iter().enumerate() {
+        for gx in grid_span(x - tolerance, x + w + tolerance, cell) {
+            for gy in grid_span(y - tolerance, y + h + tolerance, cell) {
+                grid.entry((gx, gy)).or_default().push(idx);
             }
-            if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+        }
+    }
+
+    for bucket in grid.values() {
+        let m = bucket.len();
+        let mut pairs = 0usize;
+        'cell: for a in 0..m {
+            let i = bucket[a];
+            if uf.component_size(i) >= MAX_CLUSTER_RECTS {
                 continue;
             }
-            if checks >= MAX_CLUSTER_OVERLAP_CHECKS_PER_RECT {
-                break;
-            }
-            checks += 1;
-            if rects_overlap(&rects[i], &rects[j], tolerance) {
-                uf.union(i, j);
-                if uf.component_size(i) >= MAX_CLUSTER_RECTS {
-                    break;
+            for &j in &bucket[a + 1..] {
+                if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
+                    break 'cell;
+                }
+                if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                    continue;
+                }
+                pairs += 1;
+                if rects_overlap(&rects[i], &rects[j], tolerance) {
+                    uf.union(i, j);
+                    if uf.component_size(i) >= MAX_CLUSTER_RECTS {
+                        break;
+                    }
                 }
             }
         }
@@ -3830,7 +3850,7 @@ mod tests {
 
     #[test]
     fn test_cluster_rects_overlapping_grid_still_clusters() {
-        // Neighboring cells overlap; x-sweep must still union the whole grid.
+        // Neighboring cells overlap; the grid must still union the whole table.
         let mut rects = Vec::new();
         for row in 0..4 {
             for col in 0..4 {
@@ -3845,8 +3865,8 @@ mod tests {
     #[test]
     fn test_cluster_rects_many_disjoint_stays_subquadratic() {
         // Pairwise-disjoint rects never merge, so a component-size cap does
-        // not stop all-pairs overlap tests. Spread in X so the sweep can
-        // skip far-apart pairs; 8k is enough that n² tests would dominate.
+        // not stop all-pairs overlap tests. Spread in X so they land in
+        // different grid cells; 8k is enough that n² tests would dominate.
         let n = 8_000usize;
         let rects: Vec<(f32, f32, f32, f32)> =
             (0..n).map(|i| (i as f32 * 20.0, 0.0, 10.0, 10.0)).collect();
@@ -3855,10 +3875,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cluster_rects_stacked_disjoint_respects_per_rect_budget() {
-        // Same left edge: the X sweep cannot skip pairs. A per-rect check
-        // cap keeps this from going fully quadratic, and a table at a later
-        // X still clusters.
+    fn test_cluster_rects_stacked_disjoint_does_not_starve_later_table() {
+        // Same X, spread in Y: a spatial grid must still union an overlapping
+        // pair in another region of the page.
         let n = 8_000usize;
         let mut rects: Vec<(f32, f32, f32, f32)> =
             (0..n).map(|i| (0.0, i as f32 * 20.0, 10.0, 10.0)).collect();

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -81,16 +81,21 @@ pub(crate) fn rects_overlap(a: &(f32, f32, f32, f32), b: &(f32, f32, f32, f32), 
 /// Maximum component size for rect clustering.  No real table has thousands
 /// of cell rects — once a component exceeds this, it is a vector drawing or
 /// page-spanning clipping path.  We skip overlap checks for rects already in
-/// an oversized component, keeping the original O(n²) loop but making it
-/// effectively O(n) for pathological pages.
+/// an oversized component.
 const MAX_CLUSTER_RECTS: usize = 2000;
+
+/// Pairwise-disjoint rects never merge, so a component-size cap does not
+/// stop the all-pairs loop. Bound the number of AABB tests so a page of
+/// thousands of isolated drawing rects cannot go quadratic.
+const MAX_CLUSTER_OVERLAP_CHECKS: usize = 1_000_000;
 
 /// Cluster rects by spatial overlap using union-find.
 /// Returns groups of rect indices; only groups with ≥ `min_size` rects are returned.
 ///
-/// Skips overlap checks for rects whose component has already exceeded
-/// [`MAX_CLUSTER_RECTS`], so pages with tens of thousands of vector-drawing
-/// rects complete in milliseconds instead of minutes.
+/// Overlap tests are ordered by left edge and skipped once a pair cannot
+/// overlap in X. Combined with [`MAX_CLUSTER_RECTS`] and
+/// [`MAX_CLUSTER_OVERLAP_CHECKS`], scattered or stacked disjoint rects stay
+/// linear-ish instead of O(n²).
 pub(crate) fn cluster_rects(
     rects: &[(f32, f32, f32, f32)],
     tolerance: f32,
@@ -98,19 +103,33 @@ pub(crate) fn cluster_rects(
 ) -> Vec<Vec<usize>> {
     let n = rects.len();
     let mut uf = UnionFind::new(n);
+    let two_tol = tolerance * 2.0;
 
-    for i in 0..n {
-        // If rect i is already in an oversized component, no point comparing
-        // it against further rects — the component won't be used for table
-        // detection anyway.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by(|&a, &b| rects[a].0.total_cmp(&rects[b].0));
+
+    let mut checks = 0usize;
+    'outer: for (pos, &i) in order.iter().enumerate() {
         if uf.component_size(i) >= MAX_CLUSTER_RECTS {
             continue;
         }
-        for j in (i + 1)..n {
+        let i_right = rects[i].0 + rects[i].2 + two_tol;
+        for &j in &order[pos + 1..] {
+            if rects[j].0 > i_right {
+                break;
+            }
+            if uf.component_size(j) >= MAX_CLUSTER_RECTS {
+                continue;
+            }
+            checks += 1;
+            if checks > MAX_CLUSTER_OVERLAP_CHECKS {
+                debug!(
+                    "cluster_rects: overlap-check budget {MAX_CLUSTER_OVERLAP_CHECKS} exhausted (n={n})"
+                );
+                break 'outer;
+            }
             if rects_overlap(&rects[i], &rects[j], tolerance) {
                 uf.union(i, j);
-                // Check if the merged component just exceeded the cap —
-                // if so, no need to test more pairs for rect i.
                 if uf.component_size(i) >= MAX_CLUSTER_RECTS {
                     break;
                 }
@@ -3808,6 +3827,43 @@ mod tests {
         let groups = cluster_rects(&rects, 0.0, 2);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_overlapping_grid_still_clusters() {
+        // Neighboring cells overlap; x-sweep must still union the whole grid.
+        let mut rects = Vec::new();
+        for row in 0..4 {
+            for col in 0..4 {
+                rects.push((col as f32 * 9.0, row as f32 * 9.0, 10.0, 10.0));
+            }
+        }
+        let groups = cluster_rects(&rects, 0.0, 1);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 16);
+    }
+
+    #[test]
+    fn test_cluster_rects_many_disjoint_stays_subquadratic() {
+        // Pairwise-disjoint rects never merge, so a component-size cap does
+        // not stop all-pairs overlap tests. Spread in X so the sweep can
+        // skip far-apart pairs; 8k is enough that n² tests would dominate.
+        let n = 8_000usize;
+        let rects: Vec<(f32, f32, f32, f32)> =
+            (0..n).map(|i| (i as f32 * 20.0, 0.0, 10.0, 10.0)).collect();
+        let groups = cluster_rects(&rects, 0.0, 2);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_cluster_rects_stacked_disjoint_respects_check_budget() {
+        // Same left edge: the X sweep cannot skip pairs. The overlap-check
+        // budget must still keep this from going fully quadratic.
+        let n = 8_000usize;
+        let rects: Vec<(f32, f32, f32, f32)> =
+            (0..n).map(|i| (0.0, i as f32 * 20.0, 10.0, 10.0)).collect();
+        let groups = cluster_rects(&rects, 0.0, 2);
+        assert!(groups.is_empty());
     }
 
     // --- snap_edges ---

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -137,11 +137,11 @@ fn union_rect_against_bands(
     if uf.component_size(i) >= MAX_CLUSTER_RECTS {
         return;
     }
+    let mut pairs = 0usize;
     for (_, bucket) in bands.range(lo..=hi) {
-        let mut pairs = 0usize;
         for &j in bucket {
             if pairs >= MAX_CLUSTER_PAIRS_PER_CELL {
-                break;
+                return;
             }
             if i == j || uf.component_size(j) >= MAX_CLUSTER_RECTS {
                 continue;
@@ -304,17 +304,27 @@ pub(crate) fn cluster_rects(
             union_bucket_pairs(&mut uf, rects, bucket, tolerance);
         }
     }
-    for &i in wide.iter().chain(&dual) {
-        let (x, _, w, _) = rects[i];
-        let x_lo = grid_coord(x - tolerance, cell);
-        let x_hi = grid_coord(x + w + tolerance, cell);
-        union_rect_against_bands(&mut uf, rects, i, &large_x, x_lo, x_hi, tolerance);
-    }
-    for &i in &dual {
-        let (_, y, _, h) = rects[i];
-        let y_lo = grid_coord(y - tolerance, cell);
-        let y_hi = grid_coord(y + h + tolerance, cell);
-        union_rect_against_bands(&mut uf, rects, i, &large_y, y_lo, y_hi, tolerance);
+    // Cross-orientation is |wide|×|tall| if every wide rule spans the page.
+    // Skip that pass when the product cannot be a table (a few rules).
+    let tall_n = large
+        .len()
+        .saturating_sub(wide.len())
+        .saturating_sub(dual.len());
+    let cross_n =
+        (wide.len() + dual.len()).saturating_mul(tall_n) + dual.len().saturating_mul(wide.len());
+    if cross_n > 0 && cross_n <= MAX_CLUSTER_PAIRS_PER_CELL {
+        for &i in wide.iter().chain(&dual) {
+            let (x, _, w, _) = rects[i];
+            let x_lo = grid_coord(x - tolerance, cell);
+            let x_hi = grid_coord(x + w + tolerance, cell);
+            union_rect_against_bands(&mut uf, rects, i, &large_x, x_lo, x_hi, tolerance);
+        }
+        for &i in &dual {
+            let (_, y, _, h) = rects[i];
+            let y_lo = grid_coord(y - tolerance, cell);
+            let y_hi = grid_coord(y + h + tolerance, cell);
+            union_rect_against_bands(&mut uf, rects, i, &large_y, y_lo, y_hi, tolerance);
+        }
     }
 
     // Group indices by root
@@ -4104,6 +4114,16 @@ mod tests {
         let groups = cluster_rects(&rects, 0.0, 2);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 2);
+    }
+
+    #[test]
+    fn test_cluster_rects_many_wide_and_tall_stays_subquadratic() {
+        let mut rects = Vec::with_capacity(4_000);
+        for i in 0..2_000 {
+            rects.push((0.0, i as f32 * 20.0, 5000.0, 10.0));
+            rects.push((i as f32 * 20.0, 0.0, 10.0, 5000.0));
+        }
+        let _groups = cluster_rects(&rects, 0.0, 2);
     }
 
     // --- snap_edges ---


### PR DESCRIPTION
## Summary
- Rect clustering skipped further overlap tests only after a component reached 2,000 rects. Pairwise-disjoint drawing rects never merge, so the all-pairs loop stayed quadratic.
- Sweep by left edge so far-apart rects are not compared, and stop after 1,000,000 AABB tests. Overlapping cell grids still cluster; isolated rects do not form tables.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] 4×4 overlapping grid still unions into one component
- [x] 8k disjoint rects (spread and stacked) return no groups and finish quickly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds table-rect clustering with a uniform grid and bounded fallbacks so overlap tests stay subquadratic while independent tables still union. Previously we compared all pairs until a component exceeded 2,000 rects, so disjoint rects were O(n²) and wide-by-tall oversized crossings could miss or go quadratic.

- Hash rects into grid cells sized at max(64 pt, 4× tolerance) and cap comparisons to 16,384 per cell; visit cells in key order; skip rects in components ≥2,000.
- Oversized spans (>64 cells) skip insertion; range-query only occupied rows in their Y range, partition X keys, and compare under the same cap so later X ranges still cluster.
- Oversized-vs-oversized: band on the short axis; from each wide or dual rect, query the tall X-index; insert dual-oversized into coarse-Y cells and process bands in key order.
- Skip wide-by-tall unions when the product exceeds the per-cell cap so mixed oversized drawings cannot go quadratic; deduplicate candidates within X/Y band queries so the cap applies to distinct rects (a rect spanning multiple cells counts once).

<sup>Written for commit 77f5885f6ebdccd2722380ec27e7553a4c23feaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

