### PR TITLE
fix: recover invisible OCR text layers on TextBased-classified PDFs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3940,7 +3940,12 @@ fn process_document(
         // For Mixed/template PDFs: if normal extraction produces garbage text
         // (mostly non-alphanumeric), retry with invisible (Tr=3) text included.
         // This unlocks OCR text layers behind scanned images.
-        if pdf_type == PdfType::Mixed {
+        // Scans with a dense OCR text overlay (e.g. OCRmyPDF output) carry
+        // enough text operators to be classified TextBased rather than Mixed,
+        // so a Mixed-only retry would never fire for them and extraction
+        // comes up empty. Widen the retry to TextBased, and also retry when
+        // extraction is suspiciously sparse for the page count.
+        if matches!(pdf_type, PdfType::Mixed | PdfType::TextBased) {
             if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _)| e) {
                 let sample: String = items
                     .iter()
@@ -3953,7 +3958,18 @@ fn process_document(
                     .take(200)
                     .map(|item| item.text.as_str())
                     .collect();
-                if is_garbage_text(&sample) || sample.trim().is_empty() {
+                // The sparseness floor (5 items/page, whole-document count)
+                // is deliberately conservative: a page with any real prose
+                // yields dozens of positioned items, while a scan whose only
+                // text survived as a handful of visible artifacts stays well
+                // under it. The retry is cheap relative to a false negative
+                // (the whole document reported as needing OCR), and the
+                // zero-visible-text gate in the invisible pass keeps it from
+                // ever duplicating visible text.
+                if is_garbage_text(&sample)
+                    || sample.trim().is_empty()
+                    || (items.len() as u32) < 5 * page_count
+                {
                     extractor::extract_positioned_text_include_invisible_with_folio_context(
                         &doc,
                         &font_cmaps,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1801,6 +1801,38 @@ fn test_extract_regions_mem_recovers_invisible_ocr_layer() {
     );
 }
 
+/// A scanned page whose invisible (Tr 3) OCR layer is dense enough to push
+/// the classifier past the template-image threshold lands as TextBased, not
+/// Mixed. The invisible retry must still fire there: without it the document
+/// extracts zero text and is reported as needing OCR even though the exact
+/// text is already in the PDF (typical for OCRmyPDF/dense re-OCR output).
+#[test]
+fn test_process_pdf_mem_recovers_dense_invisible_layer_on_textbased() {
+    let lines: Vec<String> = (0..60)
+        .map(|i| format!("Invoice line {i} with amount {i} due for payment shortly"))
+        .collect();
+    let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+    let buf = make_pdf_with_custom_text_layer(3, None, Some(&refs), false);
+
+    let result = process_pdf_mem(&buf).expect("process dense invisible-layer PDF");
+    assert_eq!(
+        result.pdf_type,
+        PdfType::TextBased,
+        "dense overlay should classify as TextBased — if this starts failing, \
+         the fixture no longer exercises the TextBased retry path"
+    );
+    let markdown = result.markdown.as_deref().unwrap_or("");
+    assert!(
+        markdown.contains("Invoice line 42"),
+        "invisible OCR layer should be recovered for TextBased PDFs, got: {markdown:?}"
+    );
+    assert!(
+        result.pages_needing_ocr.is_empty(),
+        "recovered OCR layer must not flag pages for OCR, got: {:?}",
+        result.pages_needing_ocr
+    );
+}
+
 /// ANY visible text on the page — even a single short line — must block the
 /// invisible-layer adoption entirely: the invisible pass returns visible
 /// items too, so adopting it alongside visible text would duplicate the


### PR DESCRIPTION
Fixes #385.

Dense invisible (Tr 3) OCR overlays — the typical output of OCRmyPDF and similar re-OCR pipelines — carry enough text operators to be classified `TextBased` rather than `Mixed`, so the existing Mixed-only invisible retry never fires for them. Normal extraction skips the invisible text and the whole document is reported as "OCR is required", even though the exact text is already embedded.

## Changes

- Widen the invisible retry in `process_document` to `Mixed | TextBased`.
- Also trigger the retry when extraction is suspiciously sparse for the page count (`items < 5 * page_count`, whole-document count — a conservative floor: any page with real prose yields dozens of positioned items). This catches overlays where a handful of visible artifacts would otherwise defeat the empty/garbage checks.
- Regression test: a synthetic 60-line dense Tr 3 overlay fixture that classifies as `TextBased`; without the fix it extracts nothing and flags every page for OCR.

The zero-visible-text gate in the invisible pass is untouched and keeps the retry behavior-safe for genuine text PDFs: the invisible layer is still never adopted when any visible text exists, so the retry can only add text where extraction produced garbage, nothing, or a near-empty result.

## Validation

- New regression test fails on `main`, passes with the fix.
- Full test suite green (924 lib + 163 integration + snapshots).
- Real-world corpus: 14 previously-failing OCRmyPDF-processed documents (1–20 pages, dense administrative scans) now all extract correctly; the densest (20 pages, ~376K chars of text layer) in ~0.3 s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover invisible OCR text layers on PDFs classified as TextBased so dense Tr=3 overlays (e.g., OCRmyPDF output) no longer yield empty extraction and “OCR is required.” Previously the invisible-layer retry ran only for Mixed; now it also runs for TextBased and when the first pass is suspiciously sparse.

- Widen the retry condition from `PdfType::Mixed` to `PdfType::Mixed | PdfType::TextBased`, and also retry when total items < 5 × page_count.
- Keep the zero-visible-text gate in the invisible pass to prevent duplicating visible text on genuine text PDFs.
- Add a regression test with a dense 60-line Tr 3 overlay that classifies as `TextBased`; it now extracts text and does not flag pages for OCR.
- Fixes #385.

<sup>Written for commit 9502e075057328928bd7ae38983c076919e58b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

