### PR TITLE
feat: support extracting markdown for pages of an encrypted PDF

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -103,6 +103,9 @@ ocr = pdf_inspector.process_pdf_with_ocr(
     offline=True,
 )
 
+# Password-protected PDFs
+result = pdf_inspector.extract_pages_markdown("document.pdf", password="secret")
+
 # Structure-tree elements from tagged PDFs (empty list when untagged).
 # Pages are 1-indexed to match TextItem.page, so (page, mcid) joins directly
 # against extract_text_with_positions — e.g. to recover real heading levels:
@@ -133,8 +136,8 @@ headings = [
 | `extract_text_with_positions_bytes(data, pages=None)` | Text with positions from bytes |
 | `extract_text_in_regions(path, page_regions)` | Extract text in bounding-box regions |
 | `extract_text_in_regions_bytes(data, page_regions)` | Region extraction from bytes |
-| `extract_pages_markdown(path, pages=None)` | Per-page Markdown + layout metadata (all pages by default) |
-| `extract_pages_markdown_bytes(data, pages=None)` | Per-page Markdown from bytes |
+| `extract_pages_markdown(path, pages=None, password=None)` | Per-page Markdown + layout metadata (all pages by default) |
+| `extract_pages_markdown_bytes(data, pages=None, password=None)` | Per-page Markdown from bytes |
 | `extract_structure_elements(path, pages=None)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
 | `extract_structure_elements_bytes(data, pages=None)` | Structure-tree elements from bytes |
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -459,6 +459,15 @@ for page in &result.pages {
 println!("Complex layout? {}", result.is_complex);
 ```
 
+For password-protected PDFs, use `extract_pages_markdown_with_password`
+(and `extract_pages_markdown_mem_with_password` for in-memory buffers):
+
+```rust
+use pdf_inspector::extract_pages_markdown_with_password;
+
+let result = extract_pages_markdown_with_password("document.pdf", None, Some("secret"))?;
+```
+
 Extract structure-tree elements from tagged PDFs, and join them against
 `extract_text_with_positions` to attach semantic roles (heading levels,
 paragraphs, table cells) to extracted text:
@@ -512,6 +521,8 @@ for item in extract_text_with_positions("tagged.pdf")? {
 | `to_markdown_from_items_with_rects(items, options, rects)` | Markdown with rectangle-based table detection |
 | `extract_pages_markdown(path, pages)` | Per-page Markdown + layout metadata (file) |
 | `extract_pages_markdown_mem(bytes, pages)` | Per-page Markdown from bytes |
+| `extract_pages_markdown_with_password(path, pages, password)` | Per-page Markdown, decrypting with `password` if encrypted |
+| `extract_pages_markdown_mem_with_password(bytes, pages, password)` | Per-page Markdown from bytes, decrypting with `password` if encrypted |
 | `extract_structure_elements(path, pages)` | Structure-tree elements from tagged PDFs (page, mcid, role) |
 | `extract_structure_elements_mem(bytes, pages)` | Structure-tree elements from bytes |
 

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -888,22 +888,27 @@ pub struct PagesExtractionResult {
 /// Omit `pages` (or pass `undefined`) to return every page in document
 /// order. Pass an array of 0-indexed page numbers to restrict output to
 /// those pages, in caller-supplied order.
+///
+/// Pass `password` (or `undefined`) to decrypt an encrypted PDF. When
+/// omitted, the empty password is tried (owner-only encryption).
 #[napi]
 pub fn extract_pages_markdown(
     buffer: Buffer,
     pages: Option<Vec<u32>>,
+    password: Option<String>,
 ) -> Result<PagesExtractionResult> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("extract_pages_markdown", move || {
-        extract_pages_markdown_impl(&bytes, pages.as_deref())
+        extract_pages_markdown_impl(&bytes, pages.as_deref(), password.as_deref())
     })
 }
 
 fn extract_pages_markdown_impl(
     bytes: &[u8],
     pages: Option<&[u32]>,
+    password: Option<&str>,
 ) -> Result<PagesExtractionResult> {
-    let result = pdf_inspector::extract_pages_markdown_mem(bytes, pages)
+    let result = pdf_inspector::extract_pages_markdown_mem_with_password(bytes, pages, password)
         .map_err(|e| to_napi_err(e, "extract_pages_markdown"))?;
     Ok(PagesExtractionResult {
         pages: result
@@ -1094,6 +1099,7 @@ pub fn classify_pdf_async(buffer: Buffer) -> AsyncTask<ClassifyPdfTask> {
 pub struct ExtractPagesMarkdownTask {
     bytes: Vec<u8>,
     pages: Option<Vec<u32>>,
+    password: Option<String>,
 }
 
 impl Task for ExtractPagesMarkdownTask {
@@ -1103,9 +1109,12 @@ impl Task for ExtractPagesMarkdownTask {
     fn compute(&mut self) -> Result<Self::Output> {
         let bytes = std::mem::take(&mut self.bytes);
         let pages = self.pages.take();
+        let password = self.password.take();
         catch_panic(
             "extract_pages_markdown",
-            panic::AssertUnwindSafe(move || extract_pages_markdown_impl(&bytes, pages.as_deref())),
+            panic::AssertUnwindSafe(move || {
+                extract_pages_markdown_impl(&bytes, pages.as_deref(), password.as_deref())
+            }),
         )
     }
 
@@ -1122,9 +1131,11 @@ impl Task for ExtractPagesMarkdownTask {
 pub fn extract_pages_markdown_async(
     buffer: Buffer,
     pages: Option<Vec<u32>>,
+    password: Option<String>,
 ) -> AsyncTask<ExtractPagesMarkdownTask> {
     AsyncTask::new(ExtractPagesMarkdownTask {
         bytes: buffer.to_vec(),
         pages,
+        password,
     })
 }

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -274,6 +274,7 @@ def extract_text_in_regions_bytes(
 def extract_pages_markdown(
     path: str,
     pages: Optional[list[int]] = None,
+    password: Optional[str] = None,
 ) -> PagesExtractionResult:
     """Extract formatted markdown for pages of a PDF, with layout classification.
 
@@ -282,6 +283,8 @@ def extract_pages_markdown(
         pages: Optional list of 0-indexed pages. When ``None`` (default), every
             page is returned in document order. Otherwise, output matches the
             caller-supplied order.
+        password: Optional password to decrypt an encrypted PDF. When ``None``
+            (default), the empty password is tried (owner-only encryption).
 
     Returns:
         PagesExtractionResult with per-page markdown and document-wide layout
@@ -292,6 +295,7 @@ def extract_pages_markdown(
 def extract_pages_markdown_bytes(
     data: bytes,
     pages: Optional[list[int]] = None,
+    password: Optional[str] = None,
 ) -> PagesExtractionResult:
     """Extract formatted markdown for pages of a PDF from bytes.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,17 @@ fn extract_pages_markdown_mem_impl(
     strip_repeated_headers_footers: bool,
     preserve_ocr_candidates: bool,
 ) -> Result<(PagesExtractionResult, u32), PdfError> {
+    extract_pages_markdown_mem_with_password(buffer, pages, None)
+}
+
+/// Same as [`extract_pages_markdown_mem`], decrypting with `password` if the
+/// document is encrypted. `None` falls back to the empty password
+/// (owner-only encryption).
+pub fn extract_pages_markdown_mem_with_password(
+    buffer: &[u8],
+    pages: Option<&[u32]>,
+    password: Option<&str>,
+) -> Result<PagesExtractionResult, PdfError> {
     validate_pdf_bytes(buffer)?;
     let (doc, page_count) = load_document_from_mem_with_password(buffer, password)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
@@ -826,9 +837,20 @@ pub fn extract_pages_markdown<P: AsRef<Path>>(
     path: P,
     pages: Option<&[u32]>,
 ) -> Result<PagesExtractionResult, PdfError> {
+    extract_pages_markdown_with_password(path, pages, None)
+}
+
+/// Same as [`extract_pages_markdown`], decrypting with `password` if the
+/// document is encrypted. `None` falls back to the empty password
+/// (owner-only encryption).
+pub fn extract_pages_markdown_with_password<P: AsRef<Path>>(
+    path: P,
+    pages: Option<&[u32]>,
+    password: Option<&str>,
+) -> Result<PagesExtractionResult, PdfError> {
     validate_pdf_file(&path)?;
     let buffer = std::fs::read(path.as_ref())?;
-    extract_pages_markdown_mem(&buffer, pages)
+    extract_pages_markdown_mem_with_password(&buffer, pages, password)
 }
 
 // =========================================================================

--- a/src/python.rs
+++ b/src/python.rs
@@ -920,16 +920,20 @@ fn extract_text_in_regions_bytes(
 ///     pages: Optional list of 0-indexed pages. When None (default), every
 ///         page is returned in document order. When provided, output
 ///         matches the caller-supplied order.
+///     password: Optional password to decrypt an encrypted PDF. When None
+///         (default), the empty password is tried (owner-only encryption).
 ///
 /// Returns:
 ///     PagesExtractionResult with per-page markdown and classification data.
 #[pyfunction]
-#[pyo3(signature = (path, pages=None))]
+#[pyo3(signature = (path, pages=None, password=None))]
 fn extract_pages_markdown(
     path: &str,
     pages: Option<Vec<u32>>,
+    password: Option<&str>,
 ) -> PyResult<PyPagesExtractionResult> {
-    let result = crate::extract_pages_markdown(path, pages.as_deref()).map_err(to_py_err)?;
+    let result = crate::extract_pages_markdown_with_password(path, pages.as_deref(), password)
+        .map_err(to_py_err)?;
     Ok(to_py_pages_result(result))
 }
 
@@ -937,12 +941,14 @@ fn extract_pages_markdown(
 ///
 /// See [`extract_pages_markdown`] for details.
 #[pyfunction]
-#[pyo3(signature = (data, pages=None))]
+#[pyo3(signature = (data, pages=None, password=None))]
 fn extract_pages_markdown_bytes(
     data: &[u8],
     pages: Option<Vec<u32>>,
+    password: Option<&str>,
 ) -> PyResult<PyPagesExtractionResult> {
-    let result = crate::extract_pages_markdown_mem(data, pages.as_deref()).map_err(to_py_err)?;
+    let result = crate::extract_pages_markdown_mem_with_password(data, pages.as_deref(), password)
+        .map_err(to_py_err)?;
     Ok(to_py_pages_result(result))
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,9 +6,10 @@ use pdf_inspector::types::ItemType;
 use pdf_inspector::types::TextLine;
 use pdf_inspector::{
     detect_pdf_type, detect_vector_grid_in_region_mem, extract_pages_markdown,
-    extract_pages_markdown_mem, extract_tables_in_regions_mem, extract_text,
-    extract_text_in_regions_mem, extract_text_with_positions, extract_text_with_positions_mem,
-    process_pdf_mem, process_pdf_mem_with_options, process_pdf_with_options, to_markdown,
+    extract_pages_markdown_mem, extract_pages_markdown_with_password,
+    extract_tables_in_regions_mem, extract_text, extract_text_in_regions_mem,
+    extract_text_with_positions, extract_text_with_positions_mem, process_pdf_mem,
+    process_pdf_mem_with_options, process_pdf_with_options, to_markdown,
     to_markdown_from_items_with_rects_and_page_count, MarkdownOptions, PdfError, PdfOptions,
     PdfType, TextItem,
 };
@@ -4318,6 +4319,35 @@ fn encrypted_pdf_decrypts_with_correct_password() {
     let md = ok.markdown.unwrap_or_default();
     // Assert a stable fixture token so a garbled-but-long extraction (the
     // encrypted-stream regression this guards) still fails the test.
+    assert!(
+        md.contains("Procurement"),
+        "decrypted markdown should contain the fixture's real text, got {} chars",
+        md.len()
+    );
+}
+
+#[test]
+fn extract_pages_markdown_decrypts_with_correct_password() {
+    let path = "tests/fixtures/encrypted-secret123.pdf";
+
+    // No password: the file is encrypted and can't be read.
+    let no_pw = extract_pages_markdown_with_password(path, None, None);
+    assert!(
+        matches!(no_pw, Err(PdfError::Encrypted)),
+        "expected Encrypted without a password, got {no_pw:?}"
+    );
+
+    // Wrong password: still rejected.
+    let wrong = extract_pages_markdown_with_password(path, None, Some("wrong"));
+    assert!(
+        matches!(wrong, Err(PdfError::Encrypted)),
+        "expected Encrypted with a wrong password, got {wrong:?}"
+    );
+
+    // Correct password: decrypts and extracts real content.
+    let ok = extract_pages_markdown_with_password(path, None, Some("secret123"))
+        .expect("correct password should decrypt");
+    let md: String = ok.pages.iter().map(|p| p.markdown.as_str()).collect();
     assert!(
         md.contains("Procurement"),
         "decrypted markdown should contain the fixture's real text, got {} chars",


### PR DESCRIPTION
The changes allow extracting markdown from encrypted PDFs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds decryption support for per-page Markdown extraction so encrypted PDFs can be processed. Previously `extract_pages_markdown` failed with Encrypted; now callers can provide a password, with a fallback to the empty password for owner-only encryption. Unencrypted PDFs behave the same; Node remains backward compatible.

- Rust: new `extract_pages_markdown_with_password` and `extract_pages_markdown_mem_with_password`; existing functions delegate with `None`.
- Python: `extract_pages_markdown(path, pages=None, password=None)` and `extract_pages_markdown_bytes(data, pages=None, password=None)` accept an optional `password`; `pdf_inspector.pyi` updated.
- Node N-API: `extract_pages_markdown(buffer, pages?, password?)` and `extract_pages_markdown_async(buffer, pages?, password?)` now accept an optional `password` (third arg).
- Docs updated (Python, Rust); integration tests cover no/wrong/correct password cases.

Required action if you need to read encrypted PDFs: pass the document password to the relevant API.

<sup>Written for commit e5a9a2fd5e29b8cd0927be57b1597b4075586e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

