### PR TITLE
fix: first transaction row no longer duplicated in compact financial tables

### DIFF
--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -2008,15 +2008,24 @@ pub(crate) fn find_first_table_row(
         // Otherwise skip this sparse row
     }
 
-    // Collect item indices from excluded rows
+    // Collect item indices from excluded rows.
+    //
+    // Reuse find_row_index's nearest-row assignment (the same one used to
+    // build cell_items above) rather than a flat "within 15pt of any
+    // excluded row_y" check. The flat check can misclassify an item that's
+    // actually nearest to — and already assigned to — a *retained* row: a
+    // compact table (adjacent rows <15pt apart) can have items from the
+    // first real transaction row sitting within 15pt of an excluded
+    // metadata row above it. Excluding by nearest-row match instead keeps
+    // that item's exclusion status consistent with which row it's
+    // rendered in, so it can't end up simultaneously "excluded" (rendered
+    // as prose) and present in the retained table's cells (rendered in
+    // the table too) — see #399.
     if first_table_row > 0 {
-        let y_tolerance = 15.0;
         for (idx, item) in original_items {
-            // Check if this item is in one of the excluded rows
-            for row_y in rows.iter().take(first_table_row) {
-                if (item.y - *row_y).abs() < y_tolerance {
+            if let Some(row) = find_row_index(rows, item.y) {
+                if row < first_table_row {
                     excluded_items.insert(*idx);
-                    break;
                 }
             }
         }
@@ -2153,6 +2162,52 @@ mod tests {
             item_type: ItemType::Text,
             mcid: None,
         }
+    }
+
+    #[test]
+    fn find_first_table_row_does_not_exclude_compact_transaction_row_items() {
+        // Regression for #399: a metadata row ("Account:" / "Detail:") at
+        // y=100 sits only 12pt above the first real transaction row
+        // ("04/21/26" / "$17.01") at y=88 — inside the old flat 15pt
+        // exclusion tolerance. The metadata row is correctly identified as
+        // excluded (form-label pattern), but its items must not sweep up
+        // the transaction row's items just because they're geometrically
+        // close: those items are also retained inside the table's cells,
+        // so double-counting them as "excluded" (prose) duplicates the row
+        // in the final Markdown (once as prose, once in the table).
+        let account_label = make_item("Account:", 50.0, 100.0, 10.0, 60.0);
+        let detail_label = make_item("Detail:", 200.0, 100.0, 10.0, 50.0);
+        let date = make_item("04/21/26", 50.0, 88.0, 10.0, 60.0);
+        let amount = make_item("$17.01", 200.0, 88.0, 10.0, 50.0);
+
+        let items = vec![
+            (0usize, &account_label),
+            (1usize, &detail_label),
+            (2usize, &date),
+            (3usize, &amount),
+        ];
+
+        let rows = vec![100.0, 88.0];
+        let cell_items: Vec<Vec<Vec<&TextItem>>> = vec![
+            vec![vec![&account_label], vec![&detail_label]],
+            vec![vec![&date], vec![&amount]],
+        ];
+
+        let (first_table_row, excluded_items) = find_first_table_row(&cell_items, &rows, &items);
+
+        assert_eq!(
+            first_table_row, 1,
+            "the metadata row should be skipped, retaining the transaction row as row 0"
+        );
+        assert!(
+            !excluded_items.contains(&2) && !excluded_items.contains(&3),
+            "transaction row items must not be excluded just because they're within \
+             15pt of the excluded metadata row above them, got excluded={excluded_items:?}"
+        );
+        assert!(
+            excluded_items.contains(&0) && excluded_items.contains(&1),
+            "the metadata row's own items must still be excluded, got excluded={excluded_items:?}"
+        );
     }
 
     #[test]

--- a/tests/snapshots/real-estate-pricing.md
+++ b/tests/snapshots/real-estate-pricing.md
@@ -32,9 +32,9 @@ R E V I E W 8 5
 |---|---|---|---|---|
 ||Apartment|Industrial|Office-CBD|Retail|
 
-1982 1986 1990 1994 1998 2002 2006
+1994 2002
 
-**Table II:** Correlationsofspreadsbypropertytype **Correlation of Cap Rate Spreads Over Treasury** **Multifamily Industrial CBD Office**
+**Table II:** Correlationsofspreadsbypropertytype **Correlation of Cap Rate Spreads Over Treasury**
 
 ||Multifamily|Industrial|CBD Office|
 |---|---|---|---|


### PR DESCRIPTION
Fixes #399.

## Root cause

`find_first_table_row` (src/tables/detect_heuristic.rs) skips leading metadata-looking rows (e.g. `Account:` / `Detail:` form labels) before the real table content, and collects the item indices belonging to those skipped rows so they can be excluded from the table and rendered separately as prose.

That collection used a flat 15pt Y-proximity check against every skipped row's Y position — independent of which row each item was *actually* assigned to when `cell_items` was originally built (via `find_row_index`'s nearest-row match). In a compact table where adjacent rows are less than 15pt apart, an item belonging to (and correctly placed in) the first *retained* row could still fall within 15pt of a *skipped* row above it, so it got marked excluded too.

Since excluded items are rendered separately as prose while retained-row items stay in the table's cells, that item then rendered twice: once inside the table, once as a floating prose line above it — exactly the reported symptom (`04/21/26 $17.01` appearing both as prose and as a table row).

## Fix

Reuse `find_row_index` (the same nearest-row assignment already used to build `cell_items`) for the exclusion check, instead of an independent flat-tolerance check. An item is now excluded only when its actual nearest-row assignment is one of the skipped rows — consistent with which row it's rendered in.

## Testing

- New unit test `find_first_table_row_does_not_exclude_compact_transaction_row_items`, reproducing the issue's exact geometry (metadata row at y=100, transaction row at y=88, 12pt apart — inside the old flat tolerance). Verified it fails without the fix (both rows' items land in `excluded_items`) and passes with it.
- Existing snapshot regression (`real-estate-pricing.pdf`) exposed two pre-existing instances of the same duplication pattern in unrelated content — a chart's Y-axis year labels, and a table caption repeating its own header row's words — both partially or fully duplicated as prose above their respective tables. The fix removes exactly the duplicated portion in each case (content that's also present in the table underneath); nothing is lost, since the retained-row content still renders in the table. Snapshot updated to reflect this.
- `cargo fmt`, `cargo test` (all passing, 1 new), `cargo clippy --all-targets -- -D warnings` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate rendering of the first transaction row in compact tables. Previously, items within 15pt of a skipped metadata row were excluded even if they belonged to the first retained row, causing them to render both as prose and in the table; now items are excluded only if their nearest-row assignment (via `find_row_index`) is a skipped row.

**Review notes**
- Logic change in `find_first_table_row` (`src/tables/detect_heuristic.rs`): replace flat Y-proximity exclusion with `find_row_index`-based exclusion to align with `cell_items` row assignment.
- Tests: new unit test reproduces the compact-row geometry; snapshot `real-estate-pricing.md` updated to remove duplicated prose (chart years, table caption) with no loss of table content.
- Scope: affects only the exclusion pass; row detection and cell assignment are unchanged. Expected impact is removal of unintended duplicate prose above retained tables.

<sup>Written for commit a76f0d00ef44db0995f4b01fd3a89eefa820e759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

