### PR TITLE
fix(release): repair ARM64 package builds

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -86,12 +86,14 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            docker-options: -e CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8
           # macos-13 was retired by GitHub; macos-15-intel is the remaining
           # Intel runner label (available through 2027).
           - os: macos-15-intel
@@ -113,6 +115,9 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           manylinux: auto
+          # The manylinux AArch64 GCC omits this macro while preprocessing
+          # ring's assembly. AArch64 is ARMv8 by definition.
+          docker-options: ${{ matrix.docker-options }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -70,6 +71,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build-flags: --use-napi-cross
+            cflags: -D__ARM_ARCH=8
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             build-flags: -x
@@ -126,6 +128,10 @@ jobs:
 
       - name: Build native addon
         working-directory: napi
+        env:
+          # napi-cross's old AArch64 GCC omits this predefined macro while
+          # preprocessing ring's assembly. AArch64 is ARMv8 by definition.
+          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.cflags }}
         run: bunx napi build --platform --release --target ${{ matrix.target }} ${{ matrix.build-flags }}
 
       - name: Upload native binary


### PR DESCRIPTION
## Summary

Repairs the Python and Node Linux ARM64 release builds by supplying the ARMv8 macro omitted by their legacy cross-compilers while preprocessing ring assembly. It also keeps both artifact matrices running after an individual target failure so release retries retain complete diagnostics and unaffected build artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs Linux ARM64 package builds for Python wheels and Node N-API addons. Previously, ARM64 targets failed because legacy cross-compilers omitted the ARMv8 macro while preprocessing `ring` assembly and the matrix aborted on first failure; now we define `__ARM_ARCH=8` for `aarch64-unknown-linux-gnu` and disable matrix fail-fast so other targets continue and artifacts/diagnostics are preserved.

- Injects `-D__ARM_ARCH=8` for ARM64: via `docker-options` in `publish-pypi.yml` (`manylinux`) and via `CFLAGS_aarch64_unknown_linux_gnu` in `publish.yml` (`napi-cross`).
- Sets `strategy.fail-fast: false` in both workflows to avoid early matrix aborts; non-ARM64 targets are otherwise unchanged.

<sup>Written for commit 8950a36218bc00af5140efd81f229ad310c16f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

