### PR TITLE
fix(layout): accept figure-diluted prose columns via a sustained full-line run

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -462,15 +462,6 @@ fn try_xy_cut_split(
     ])
 }
 
-/// Check whether each proposed column contains paragraph-like content.
-///
-/// Groups items per column into rough lines by Y-proximity, then measures
-/// what fraction of those lines span a significant portion of the column
-/// width. Two-column prose (justified or ragged-right) produces lines that
-/// fill most of the column width. Tables, forms, and checklists produce
-/// short scattered items that don't.
-///
-/// Returns true only when *every* column passes a minimum prose density.
 /// A prose line must span at least this fraction of its column's width to
 /// count as "full" — shared by the gate's ratio and run measurements.
 const LINE_FILL_THRESHOLD: f32 = 0.45;
@@ -538,6 +529,18 @@ impl ProseLineStats {
     }
 }
 
+/// Check whether each proposed column contains paragraph-like content.
+///
+/// Groups items per column into rough lines by Y-proximity, then measures
+/// what fraction of those lines span a significant portion of the column
+/// width. Two-column prose (justified or ragged-right) produces lines that
+/// fill most of the column width. Tables, forms, and checklists produce
+/// short scattered items that don't. A column whose global ratio is diluted
+/// by a figure still qualifies through a sustained run of consecutive
+/// full-width lines at normal leading — a paragraph block scattered
+/// layouts cannot produce.
+///
+/// Returns true only when *every* column passes the prose evidence.
 fn columns_have_prose(columns: &[ColumnRegion], items: &[&TextItem]) -> bool {
     const Y_TOL: f32 = 3.0; // y-proximity to group items into the same line
     const MIN_PROSE_RATIO: f32 = 0.40; // ≥40% of lines must be "full"...

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -471,10 +471,83 @@ fn try_xy_cut_split(
 /// short scattered items that don't.
 ///
 /// Returns true only when *every* column passes a minimum prose density.
+/// A prose line must span at least this fraction of its column's width to
+/// count as "full" — shared by the gate's ratio and run measurements.
+const LINE_FILL_THRESHOLD: f32 = 0.45;
+
+/// Per-column line measurements backing the prose-evidence predicates in
+/// [`columns_have_prose`]: how many grouped lines exist, how many are
+/// "full" (span most of the column), the longest *vertically contiguous*
+/// run of full lines, and the item count per line.
+#[derive(Default)]
+struct ProseLineStats {
+    full_lines: usize,
+    total_lines: usize,
+    total_items: usize,
+    current_run: usize,
+    best_run: usize,
+    previous_line_y: Option<f32>,
+    previous_line_height: f32,
+}
+
+impl ProseLineStats {
+    /// A run only counts as a paragraph block while lines follow at normal
+    /// leading; a full line resuming after a figure-sized vertical gap
+    /// starts a new run rather than extending the previous one.
+    const MAX_LEADING_FACTOR: f32 = 2.5;
+
+    fn flush_line(&mut self, line_items: &[&TextItem], col: &ColumnRegion, col_width: f32) {
+        if line_items.is_empty() {
+            return;
+        }
+        self.total_lines += 1;
+        self.total_items += line_items.len();
+
+        let line_y = line_items[0].y;
+        let line_height = line_items
+            .iter()
+            .map(|i| i.height)
+            .fold(0.0_f32, f32::max)
+            .max(1.0);
+        if let Some(previous_y) = self.previous_line_y {
+            let leading = (previous_y - line_y).abs();
+            if leading > self.previous_line_height.max(line_height) * Self::MAX_LEADING_FACTOR {
+                self.current_run = 0;
+            }
+        }
+        self.previous_line_y = Some(line_y);
+        self.previous_line_height = line_height;
+
+        // Compute the span of text on this line within the column
+        let left = line_items
+            .iter()
+            .map(|i| i.x.max(col.x_min))
+            .fold(f32::INFINITY, f32::min);
+        let right = line_items
+            .iter()
+            .map(|i| (i.x + effective_width(i)).min(col.x_max))
+            .fold(f32::NEG_INFINITY, f32::max);
+        let span = (right - left).max(0.0);
+        if span >= col_width * LINE_FILL_THRESHOLD {
+            self.full_lines += 1;
+            self.current_run += 1;
+            self.best_run = self.best_run.max(self.current_run);
+        } else {
+            self.current_run = 0;
+        }
+    }
+}
+
 fn columns_have_prose(columns: &[ColumnRegion], items: &[&TextItem]) -> bool {
     const Y_TOL: f32 = 3.0; // y-proximity to group items into the same line
-    const LINE_FILL_THRESHOLD: f32 = 0.45; // line must span ≥45% of column width
-    const MIN_PROSE_RATIO: f32 = 0.40; // ≥40% of lines must be "full"
+    const MIN_PROSE_RATIO: f32 = 0.40; // ≥40% of lines must be "full"...
+                                       // ...or the column contains a sustained paragraph block: this many
+                                       // CONSECUTIVE full lines. A prose column hosting a figure + caption can
+                                       // fall under the global ratio (the fragments dilute it), but the
+                                       // scattered layouts this gate exists to reject — tables, TOCs,
+                                       // checklists, forms — cannot produce an unbroken block of full-width
+                                       // lines.
+    const MIN_PROSE_RUN: usize = 6;
     const MIN_LINES: usize = 8; // need enough lines to judge
     const MIN_COL_WIDTH: f32 = 120.0; // columns must be ≥120pt (not narrow sidebars/fragments)
     const MAX_AVG_ITEMS_PER_LINE: f32 = 3.5; // prose has 1-3 items/line; tables/forms have 4+
@@ -504,35 +577,9 @@ fn columns_have_prose(columns: &[ColumnRegion], items: &[&TextItem]) -> bool {
         sorted.sort_by(|a, b| b.y.total_cmp(&a.y));
 
         // Group into lines by Y-proximity and measure fill + item count
-        let mut full_lines = 0usize;
-        let mut total_lines = 0usize;
-        let mut total_items_in_lines = 0usize;
+        let mut stats = ProseLineStats::default();
         let mut line_items: Vec<&TextItem> = Vec::new();
         let mut line_y = f32::NAN;
-
-        let flush_line = |line_items: &[&TextItem],
-                          full: &mut usize,
-                          total: &mut usize,
-                          total_items: &mut usize| {
-            if line_items.is_empty() {
-                return;
-            }
-            *total += 1;
-            *total_items += line_items.len();
-            // Compute the span of text on this line within the column
-            let left = line_items
-                .iter()
-                .map(|i| i.x.max(col.x_min))
-                .fold(f32::INFINITY, f32::min);
-            let right = line_items
-                .iter()
-                .map(|i| (i.x + effective_width(i)).min(col.x_max))
-                .fold(f32::NEG_INFINITY, f32::max);
-            let span = (right - left).max(0.0);
-            if span >= col_width * LINE_FILL_THRESHOLD {
-                *full += 1;
-            }
-        };
 
         for item in &sorted {
             if line_items.is_empty() || (line_y - item.y).abs() < Y_TOL {
@@ -541,35 +588,29 @@ fn columns_have_prose(columns: &[ColumnRegion], items: &[&TextItem]) -> bool {
                 }
                 line_items.push(item);
             } else {
-                flush_line(
-                    &line_items,
-                    &mut full_lines,
-                    &mut total_lines,
-                    &mut total_items_in_lines,
-                );
+                stats.flush_line(&line_items, col, col_width);
                 line_items.clear();
                 line_y = item.y;
                 line_items.push(item);
             }
         }
-        flush_line(
-            &line_items,
-            &mut full_lines,
-            &mut total_lines,
-            &mut total_items_in_lines,
-        );
+        stats.flush_line(&line_items, col, col_width);
 
-        if total_lines < MIN_LINES {
+        if stats.total_lines < MIN_LINES {
             return false;
         }
 
+        let full_lines = stats.full_lines;
+        let total_lines = stats.total_lines;
+        let best_run = stats.best_run;
+        let total_items_in_lines = stats.total_items;
         let ratio = full_lines as f32 / total_lines as f32;
         let avg_items = total_items_in_lines as f32 / total_lines as f32;
         debug!(
-            "columns_have_prose: col [{:.0}..{:.0}] lines={} full={} ratio={:.2} avg_items={:.1}",
-            col.x_min, col.x_max, total_lines, full_lines, ratio, avg_items
+            "columns_have_prose: col [{:.0}..{:.0}] lines={} full={} ratio={:.2} run={} avg_items={:.1}",
+            col.x_min, col.x_max, total_lines, full_lines, ratio, best_run, avg_items
         );
-        if ratio < MIN_PROSE_RATIO {
+        if ratio < MIN_PROSE_RATIO && best_run < MIN_PROSE_RUN {
             return false;
         }
         // Tables and forms tend to have many small items per line (one per cell),
@@ -2565,6 +2606,85 @@ mod tests {
             item_type: ItemType::Text,
             mcid: None,
         }
+    }
+
+    #[test]
+    fn prose_gate_accepts_figure_diluted_column_via_run() {
+        // A prose column hosting a figure: 9 consecutive full-width lines
+        // (a paragraph block) followed by many short caption/figure
+        // fragments. The global full-line ratio falls under 40%, but the
+        // sustained run proves flowing prose.
+        let mut items: Vec<TextItem> = Vec::new();
+        for line in 0..9 {
+            // full-width prose line, ~230pt wide in a 250pt column
+            items.push(make_item(
+                1,
+                10.0,
+                700.0 - line as f32 * 14.0,
+                &"m".repeat(38),
+            ));
+        }
+        for line in 0..16 {
+            // short figure/caption fragments
+            items.push(make_item(1, 60.0, 560.0 - line as f32 * 14.0, "cap"));
+        }
+        let column = ColumnRegion {
+            x_min: 0.0,
+            x_max: 250.0,
+        };
+        let refs: Vec<&TextItem> = items.iter().collect();
+        assert!(columns_have_prose(&[column], &refs));
+    }
+
+    #[test]
+    fn prose_gate_run_requires_vertical_continuity() {
+        // Full-width lines separated by figure-sized vertical gaps are not
+        // a paragraph block: the run must reset across large leading, so a
+        // column of scattered wide labels stays rejected.
+        let mut items: Vec<TextItem> = Vec::new();
+        for line in 0..6 {
+            // Wide labels, sequence-consecutive but 90pt apart — far beyond
+            // normal leading. Without the continuity rule they would count
+            // as a 6-line paragraph block.
+            items.push(make_item(
+                1,
+                10.0,
+                720.0 - line as f32 * 90.0,
+                &"m".repeat(38),
+            ));
+        }
+        for line in 0..12 {
+            // Short fragments below, keeping total lines high and the
+            // global full-line ratio (6/18) under the 40% bar.
+            items.push(make_item(1, 60.0, 150.0 - line as f32 * 12.0, "box"));
+        }
+        let column = ColumnRegion {
+            x_min: 0.0,
+            x_max: 250.0,
+        };
+        let refs: Vec<&TextItem> = items.iter().collect();
+        assert!(!columns_have_prose(&[column], &refs));
+    }
+
+    #[test]
+    fn prose_gate_rejects_scattered_short_lines() {
+        // Checklist/form-like column: no sustained block of full lines and
+        // a low global ratio must still be rejected.
+        let mut items: Vec<TextItem> = Vec::new();
+        for line in 0..24 {
+            let text = if line % 4 == 0 {
+                "m".repeat(38)
+            } else {
+                "box".to_string()
+            };
+            items.push(make_item(1, 10.0, 700.0 - line as f32 * 14.0, &text));
+        }
+        let column = ColumnRegion {
+            x_min: 0.0,
+            x_max: 250.0,
+        };
+        let refs: Vec<&TextItem> = items.iter().collect();
+        assert!(!columns_have_prose(&[column], &refs));
     }
 
     /// Generate dense items in a horizontal zone across many Y positions.


### PR DESCRIPTION
## Summary

The `columns_have_prose` gate (added when relative-valley column detection false-split tables, TOCs, checklists, and forms) requires ≥40% of a column's lines to span ≥45% of its width. A genuine prose column hosting a figure and caption dilutes that global ratio below the bar — measured 0.38 on a two-column research page — so the valley is rejected, the page falls back to single-column, and same-baseline items from both columns merge across the gutter into woven, unreadable sentences.

## Fix

Accept a column that contains a **sustained paragraph block**: at least 6 consecutive full-width lines at normal leading. The scattered layouts the gate exists to reject cannot produce an unbroken, vertically contiguous run of full lines. Two hardening rules from review: the run resets across figure-sized vertical gaps (wide labels 90pt apart are not a paragraph), and the line measurements moved into a `ProseLineStats` struct instead of a six-parameter closure.

All other guards are unchanged (column width ≥120pt, minimum lines, items-per-line ≤3.5, and the global-ratio path still accepts as before).

## Diagnosis context

This came out of investigating multi-column reading-order quality: the dominant failure mode is sentence integrity, not ordering — pages where detected-but-rejected columns collapse to single-column produce line-by-line gutter weave. This fix converts that class to proper column-sequential output. The larger remaining class (text wrapping around inset figures, nested column regions) needs region-level segmentation and is out of scope here.

## Test plan

- [x] Unit tests: figure-diluted column accepted via run; scattered short lines still rejected; run requires vertical continuity (wide labels at 90pt spacing rejected)
- [x] `cargo fmt` / `clippy -- -D warnings` / full suites (953 unit + 165 integration)
- [x] Regression corpus: all pass, zero output changes — the layouts the gate protects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts figure-diluted prose columns by recognizing a sustained paragraph block, preserving multi-column sentence integrity. Previously `columns_have_prose` required ≥40% full lines and rejected genuine prose columns with figures, forcing single-column fallback and gutter weave.

- Adds sustained-run path: accept ≥6 consecutive full-width lines at normal leading; resets across gaps >2.5× line height. `LINE_FILL_THRESHOLD` is shared by ratio and run checks.
- Introduces `ProseLineStats` to track full/total lines, items per line, and best run; debug logs include run length.
- Keeps other guards unchanged: `MIN_LINES`, `MIN_COL_WIDTH` ≥120pt, `MAX_AVG_ITEMS_PER_LINE` ≤3.5; the ≥40% ratio path still accepts as before.
- Tests cover acceptance via run, continuity reset, and rejection of scattered short lines; regression corpus unchanged. Restores and extends `columns_have_prose` rustdoc after hoisting `LINE_FILL_THRESHOLD`.

<sup>Written for commit 47f3390c032ddd659e733a4cf94aec1829b254ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

