### PR TITLE
refactor(tests): resolve clippy warnings for needless range loop and vec initialization

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -5242,11 +5242,11 @@ mod tests {
             "Arnes Lateral",
             "Arnes Sensor",
         ];
-        for r in 0..9 {
+        for (r, name) in names.iter().enumerate() {
             let y = 377.5 - 15.0 * r as f32;
             items.push(make_item(&(r + 1).to_string(), 396.0, y, 9.0));
             items.push(make_item("7701023403016", 410.0, y, 9.0));
-            items.push(make_item(names[r], 480.0, y, 9.0));
+            items.push(make_item(name, 480.0, y, 9.0));
             items.push(make_item("1", 680.0, y, 9.0));
         }
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -2143,12 +2143,13 @@ mod tests {
 
     #[test]
     fn test_large_data_table_not_rejected() {
-        let mut items = Vec::new();
         // Header row
-        items.push(make_item("Temp", 100.0, 800.0, 8.0));
-        items.push(make_item("Pressure", 200.0, 800.0, 8.0));
-        items.push(make_item("Volume", 300.0, 800.0, 8.0));
-        items.push(make_item("Enthalpy", 400.0, 800.0, 8.0));
+        let mut items = vec![
+            make_item("Temp", 100.0, 800.0, 8.0),
+            make_item("Pressure", 200.0, 800.0, 8.0),
+            make_item("Volume", 300.0, 800.0, 8.0),
+            make_item("Enthalpy", 400.0, 800.0, 8.0),
+        ];
 
         // 49 data rows
         for i in 1..50 {


### PR DESCRIPTION
### Summary
- Replace `for r in 0..9` with idiomatic `for (r, name) in names.iter().enumerate()` in `src/tables/detect_rects.rs` (`clippy::needless_range_loop`).
- Simplify `Vec::new()` followed by consecutive pushes into `vec![...]` in `src/tables/mod.rs` (`clippy::vec_init_then_push`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors test fixtures to resolve `clippy::needless_range_loop` and `clippy::vec_init_then_push` without changing expected outcomes. The rectangle test now iterates `names.iter().enumerate()` instead of `0..9`, so the row count follows `names.len()` rather than a hardcoded constant.

**Review notes**
- `src/tables/detect_rects.rs`: Replace range loop with `(r, name)` from `names.iter().enumerate()`; use `name` directly instead of indexing; other logic unchanged.
- `src/tables/mod.rs`: Replace `Vec::new()` followed by four pushes with a single `vec![...]` header initialization.

<sup>Written for commit 55aac3b9cddec073ef0584cd6b3fd79554b165cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

