### PR TITLE
fix(tables): reject parallel-prose grids on all unsplit pages

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -639,7 +639,7 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // prose continuations outnumber the rows, which no genuine table
     // produces: the "header" is then just two short line fragments at the
     // top of parallel prose columns.
-    let header_blocks = has_compact_header && continuation_fragments < table.cells.len();
+    let header_blocks = has_compact_header && continuation_fragments <= table.cells.len();
     let is_parallel = !header_blocks
         && non_empty >= 5
         // Independent prose columns have asynchronous line/paragraph breaks;
@@ -2683,6 +2683,35 @@ mod tests {
             (0..6).collect(),
         );
         assert!(!is_parallel_prose_table(&data));
+
+        // A compact header row atop parallel prose columns: cross-row prose
+        // continuations outnumber the rows, so the header cannot save the
+        // candidate — this is page prose with two short fragments on top.
+        let headed_parallel_prose = crate::tables::Table::new(
+            vec![90.0, 340.0],
+            vec![340.0, 320.0, 300.0, 280.0, 260.0],
+            vec![
+                vec!["June 2023".into(), "Page 5".into()],
+                vec![
+                    "the committee reviewed the proposal and decided that the".into(),
+                    "funding for the second phase would continue subject to the".into(),
+                ],
+                vec![
+                    "implementation schedule should be extended by another".into(),
+                    "quarterly reviews established during the first phase of the".into(),
+                ],
+                vec![
+                    "six months to accommodate the revised procurement rules".into(),
+                    "".into(),
+                ],
+                vec![
+                    "adopted at the previous meeting of the governing board".into(),
+                    "participating institutions across the partner regions".into(),
+                ],
+            ],
+            (0..10).collect(),
+        );
+        assert!(is_parallel_prose_table(&headed_parallel_prose));
 
         let headed_text_table = crate::tables::Table::new(
             vec![90.0, 340.0],

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -635,7 +635,12 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
         }
     }
 
-    let is_parallel = !has_compact_header
+    // A compact header row is evidence for a real table — unless cross-row
+    // prose continuations outnumber the rows, which no genuine table
+    // produces: the "header" is then just two short line fragments at the
+    // top of parallel prose columns.
+    let header_blocks = has_compact_header && continuation_fragments < table.cells.len();
+    let is_parallel = !header_blocks
         && non_empty >= 5
         // Independent prose columns have asynchronous line/paragraph breaks;
         // a fully populated grid is positive evidence for a real descriptive
@@ -1375,7 +1380,6 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
             chart_page_prose_column_split(&page_layout_items)
                 .filter(|&split_x| chart_spans_prose_split(region, split_x))
         });
-        let chart_prose_columns = chart_prose_split.is_some();
 
         // Check for side-by-side table layout using the original items. Sparse
         // numeric cells need table context before they can be distinguished
@@ -1616,10 +1620,16 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                     if subset_items.len() < min_items {
                         return;
                     }
-                    // Keep body-font detection available on chart pages: a real
-                    // table can share the prose anchors. Reject only candidates
-                    // whose cells prove they are parallel prose fragments.
-                    let reject_parallel_prose = chart_prose_columns && !was_split;
+                    // Reject candidates whose cells prove they are parallel
+                    // prose fragments — the shape produced when the body-font
+                    // pass projects a multi-column text page onto one table
+                    // grid (two-column reference sections are the classic
+                    // case). The check needs internal transition evidence
+                    // (unterminated cells flowing into lowercase starts in
+                    // the same column), so genuine tables with long cells
+                    // pass. Band-split retries stay exempt: they exist for
+                    // tables that only assemble after recombining bands.
+                    let reject_parallel_prose = !was_split;
                     let tables = detect_tables_with_page_width(
                         subset_items,
                         base_size,


### PR DESCRIPTION
## What

The body-font heuristic table pass projects multi-column text pages onto table grids: on a two-column reference section, every line pair across the gutter reads as a "row with two X-clusters", and the whole page is emitted as a woven table (`|col1-line|col2-line|`). This was the largest mechanical cause of multi-column reading-order failures.

## How

The existing parallel-prose rejector (`is_parallel_prose_table`) — which requires **transition evidence** (unterminated cells flowing into lowercase starts in the same column across physical rows), not mere cell length — was gated to chart pages only. It now runs for every unsplit page.

One refinement found by tracing a blocked case: a compact header row still protects a candidate, **except** when cross-row prose continuations outnumber the rows — no genuine table produces a continuation on average in every row, so the "header" there is just two short line fragments atop prose columns.

Band-split retries stay exempt, as before: they exist for tables that only assemble after recombining bands.

## Results

- Multi-column reading order: **451 → 460 / 884** machine-checked order tests; header/footer and all other categories unchanged.
- Table structure tests: **446/1022 — completely unchanged** across both iterations of this change: the veto removes no genuine table.
- Regression corpus: 15 documents change, every diff a parallel-prose grid becoming coherent paragraphs (one technical memorandum un-scrambles 378 woven lines while keeping all 912 genuine table lines). Semantic scorer: every mover up, table-structure score *improves* on the one changed doc that has tables (the fake grids were hurting it), reading-order jumps (e.g. 0.84→0.90 on a three-column commentary).
- Full test suite passes unchanged.

## Note on the trade-off

A real two-column descriptive table with narrow wrapped cells theoretically shares some signals. Structurally it does not share the decisive one: a genuine table's wrapped text lives within one cell, so cross-physical-row lowercase flow in the same column is itself the projection failure being vetoed. Empirically: zero movement across 1,022 table tests and corpus TEDS flat-to-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects parallel‑prose table grids on all unsplit pages so multi‑column prose renders as paragraphs instead of woven tables. Previously the rejector ran only on chart pages; now it runs everywhere, and a compact header no longer shields candidates when cross‑row prose continuations strictly outnumber rows. Band‑split retries remain exempt; genuine tables are unaffected.

**Reviewer notes**
- Gating: apply the parallel‑prose veto on all unsplit pages (`reject_parallel_prose = !was_split`), removing the chart‑page gate.
- Header rule: a compact header blocks only when continuations ≤ row count; strict “> rows” bypass fixes the prior equality edge.
- Behavior: two‑column text renders as paragraphs; real table detection unchanged.

<sup>Written for commit bfe3f5503299fc5b27b03b2ccdc78dd3c5c7ef62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

