### PR TITLE
fix(layout): restore column detection on table pages and sparse pages

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -227,9 +227,14 @@ pub(crate) fn detect_columns(
     // than the peaks on either side.
     // Only attempt this for dense pages (>=100 items) — sparse pages with shallow
     // histogram dips are likely not multi-column.
-    // Skip on pages with detected tables — table column gaps look like gutters
-    // in the histogram but the table pipeline already handles reading order.
-    if valleys.is_empty() && page_items.len() >= 100 && !page_has_table {
+    //
+    // Pages with detected tables take this path too: the table's items have
+    // already left the flow by the time grouping runs, so a table cannot
+    // fake a gutter here, and the prose gate below rejects any residual
+    // table-shaped split. Without this, the prose REMAINDER of a
+    // table-bearing two-column page falls to single-column Y-sorting and
+    // the columns interleave line by line.
+    if valleys.is_empty() && page_items.len() >= 100 {
         let rel_valleys = find_relative_valleys(
             &histogram,
             num_bins,

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -225,15 +225,18 @@ pub(crate) fn detect_columns(
     // Justified text can leave gutter bins non-empty because item widths extend
     // to the column edge. Look for local minima that are significantly lower
     // than the peaks on either side.
-    // Only attempt this for dense pages (>=100 items) — sparse pages with shallow
-    // histogram dips are likely not multi-column.
     //
-    // Pages with detected tables take this path too: the table's items have
-    // already left the flow by the time grouping runs, so a table cannot
-    // fake a gutter here, and the prose gate below rejects any residual
-    // table-shaped split. Without this, the prose REMAINDER of a
-    // table-bearing two-column page falls to single-column Y-sorting and
-    // the columns interleave line by line.
+    // The 30-item floor admits sparse pages: OCR'd multi-column pages arrive
+    // as few long line-runs and were falling to single-column Y-sorting.
+    // Below 30 items the histogram is too shallow for even the prose gate
+    // to judge a dip.
+    //
+    // Pages with detected tables take the relative-valley path too: the
+    // table's items have already left the flow by the time grouping runs,
+    // so a table cannot fake a gutter here, and the prose gate below
+    // rejects any residual table-shaped split. Without this, the prose
+    // REMAINDER of a table-bearing two-column page falls to single-column
+    // Y-sorting and the columns interleave line by line.
     if valleys.is_empty() && page_items.len() >= 30 {
         let rel_valleys = find_relative_valleys(
             &histogram,
@@ -275,9 +278,14 @@ pub(crate) fn detect_columns(
                 }
             }
         }
-        // Try XY-cut fallback before giving up
-        if let Some(columns) = try_xy_cut_split(&page_items, x_min, x_max, page) {
-            return columns;
+        // Try XY-cut fallback before giving up. Unlike the relative-valley
+        // path above, XY-cut has no prose gate, so the table-page guard
+        // stays here: without it a table page whose valley candidate was
+        // just rejected could take an unvalidated split.
+        if !page_has_table {
+            if let Some(columns) = try_xy_cut_split(&page_items, x_min, x_max, page) {
+                return columns;
+            }
         }
         return vec![ColumnRegion { x_min, x_max }];
     }

--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -234,7 +234,7 @@ pub(crate) fn detect_columns(
     // table-shaped split. Without this, the prose REMAINDER of a
     // table-bearing two-column page falls to single-column Y-sorting and
     // the columns interleave line by line.
-    if valleys.is_empty() && page_items.len() >= 100 {
+    if valleys.is_empty() && page_items.len() >= 30 {
         let rel_valleys = find_relative_valleys(
             &histogram,
             num_bins,


### PR DESCRIPTION
## What

Two gates in relative-valley column detection were starving real multi-column pages of their gutters, dropping them to single-column Y-sorting where the columns interleave line by line:

1. **Table pages**: the `page_has_table` guard predates item claiming — by grouping time the detected table's items have already left the flow, so a table cannot fake a gutter in the histogram the guard protects. The prose gate inside relative-valley acceptance is the real defense, and it stays. Without the fallback, the prose remainder of a table-bearing two-column page wove line by line.
2. **Sparse pages**: the 100-item floor guarded against shallow histogram dips, but OCR'd multi-column pages arrive as few long line-runs (a two-column French academic page is ~60 items) and never qualified. Lowered to 30; the same prose gate judges the split.

## Results

- Multi-column reading order: **460 → 462 / 884**; table structure tests unchanged (446/1022); all other categories unchanged.
- Regression corpus: all pass. Five documents change, four are clear recoveries — a French two-column bioethics text that was fully woven now reads perfectly, a refrigerant datasheet's intro column untangles from its sidebar, an IRS publication's three-column region largely un-weaves, an annual report's prose recovers around its tables. One decorative magazine-style page that was already woven is now differently (not worse) woven; it has no semantic baseline to arbitrate, disclosed here for the record.
- Semantic scorer on baselined movers: reading order up (0.10 → 0.18 on the datasheet), no decliners.
- Full test suite passes; local review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores relative‑valley column detection on table-bearing and sparse pages to prevent interleaved reading order. Previously it required ≥100 items and no detected tables; now it runs with ≥30 items regardless of tables, and the XY‑cut fallback is re‑guarded on table pages.

- Remove the table guard from the relative‑valley path: table items are out of flow and the prose gate rejects table‑shaped splits.
- Lower the item floor from 100 to 30 to handle OCR’d multi‑column pages with few long line‑runs.
- Re‑guard the XY‑cut fallback on table pages because it has no prose gate, preventing unvalidated splits after a rejected valley.
- Impact: improved multi‑column reading order; table handling unaffected; benchmarks and tests unchanged.

<sup>Written for commit dfe64b80e718f16d711a68638eb964009a6aa35d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

