### PR TITLE
Honor undecodable-font OCR routing in per-page extraction

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1785,7 +1785,8 @@ pub(crate) fn analyze_page_images(doc: &Document, page_id: ObjectId) -> (bool, u
     (has_images, total_area, has_template_image)
 }
 
-/// Computes both `(needs_ocr_for_template_image, has_vector_text)` for a
+/// Computes `(needs_ocr_for_template_image, has_undecodable_fonts,
+/// has_vector_text)` for a
 /// page from a single shared `analyze_page_content` pass — that call
 /// decompresses and scans every content stream (page + XObjects) plus
 /// image coverage, so `extract_pages_markdown_mem` must not invoke it
@@ -1827,10 +1828,21 @@ pub(crate) fn analyze_page_images(doc: &Document, page_id: ObjectId) -> (bool, u
 /// these pages to OCR, independent of any template-image check, since
 /// outlined glyphs can't be extracted as text at all.
 ///
+/// `has_undecodable_fonts` is true when the fonts actually used for text
+/// operators cannot be mapped back to Unicode — Identity-H/V without a
+/// ToUnicode CMap, or a page whose used fonts are all custom-encoded Type3
+/// without ToUnicode. This is the Phase-3 signal `detect_from_document`
+/// flags as `suspected_garbled_text` regardless of whole-document type.
+/// A custom Type3 Encoding can map every byte to a plausible ASCII letter
+/// (e.g. a Caesar-shifted alphabet), so the extracted text passes the
+/// cipher/CID/encoding heuristics `extract_pages_markdown_mem` applies to
+/// its own output — the font-resource signal is the only detector that
+/// cannot be spoofed by what the bytes happen to look like.
+///
 /// Exposed at crate visibility so `extract_pages_markdown_mem` can apply
 /// the same gates classification needs elsewhere instead of treating the
 /// raw signals alone as sufficient — see #227/#231.
-pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool) {
+pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool, bool) {
     let analysis = analyze_page_content(doc, page_id);
 
     let needs_ocr_for_template_image = if !analysis.has_template_image {
@@ -1845,7 +1857,11 @@ pub(crate) fn page_ocr_signals(doc: &Document, page_id: ObjectId) -> (bool, bool
         looks_like_scan || insufficient_text
     };
 
-    (needs_ocr_for_template_image, analysis.has_vector_text)
+    (
+        needs_ocr_for_template_image,
+        analysis.has_identity_h_no_tounicode || analysis.has_only_type3_fonts,
+        analysis.has_vector_text,
+    )
 }
 
 /// Recursively collect image dimensions from XObject resources,
@@ -3100,7 +3116,7 @@ mod tests {
             analysis.unique_alphanum_chars >= 10,
             "sanity: masthead text is diverse, alphanum_low cannot fire"
         );
-        let (needs_ocr, _) = page_ocr_signals(&doc, page_id);
+        let (needs_ocr, _, _) = page_ocr_signals(&doc, page_id);
         assert!(
             needs_ocr,
             "template image + text below the pages_with_text floor is a scan"
@@ -3126,7 +3142,7 @@ mod tests {
             analysis.text_operator_count >= 10,
             "sanity: body text clears the floor"
         );
-        let (needs_ocr, _) = page_ocr_signals(&doc, page_id);
+        let (needs_ocr, _, _) = page_ocr_signals(&doc, page_id);
         assert!(
             !needs_ocr,
             "a text page with a background image must stay native"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,12 +607,18 @@ fn extract_pages_markdown_mem_impl(
         // embedded-font body text elsewhere would otherwise still extract
         // non-empty, non-garbled markdown and miss OCR routing entirely.
         // detect_from_document's Mixed-type per-page routing always sends
-        // these pages to OCR; mirror that here too. Both signals share one
-        // analyze_page_content pass — see page_ocr_signals's doc comment.
-        let (has_template_image, has_vector_text) = lopdf_pages
+        // these pages to OCR; mirror that here too. Finally, a custom Type3
+        // Encoding can map every byte to a plausible ASCII letter while the
+        // glyph programs render entirely different text, so the markdown
+        // passes every text-quality heuristic — mirror detection's
+        // font-resource gate (Identity-H/Type3 without ToUnicode, its
+        // Phase-3 `suspected_garbled_text` signal) here too. See #428.
+        // All signals share one analyze_page_content pass — see
+        // page_ocr_signals's doc comment.
+        let (has_template_image, has_undecodable_fonts, has_vector_text) = lopdf_pages
             .get(&page_1idx)
             .map(|&page_id| detector::page_ocr_signals(&doc, page_id))
-            .unwrap_or((false, false));
+            .unwrap_or((false, false, false));
 
         // Build markdown with document-wide font stats
         let options = MarkdownOptions {
@@ -645,6 +651,13 @@ fn extract_pages_markdown_mem_impl(
         let has_decoding_issue = has_text_quality_issue
             || (!md.is_empty() && (is_cid_garbage(&md) || detect_encoding_issues(&md)));
         if has_decoding_issue {
+            add_ocr_reason(
+                &mut ocr_reasons_by_page,
+                page_1idx,
+                OCR_REASON_SUSPECTED_GARBLED_TEXT,
+            );
+        }
+        if has_undecodable_fonts {
             add_ocr_reason(
                 &mut ocr_reasons_by_page,
                 page_1idx,

--- a/tests/fixtures/type3_custom_encoding_no_tounicode.pdf
+++ b/tests/fixtures/type3_custom_encoding_no_tounicode.pdf
@@ -1,0 +1,233 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 11 >>
+stream
+q /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >> /Length 132 >>
+stream
+BT /F1 14 Tf 28 TL 48 720 Td (UTQNHD SZRGJW XFRUQJ HTRUFSD HQFNR XYFYZX TUJS) Tj T* (YTYFQ NSHZWWJI KNAJ YMTZXFSI YBT MZSIWJI) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type3 /Name /F1 /FontBBox [0 -200 700 900] /FontMatrix [0.001 0 0 0.001 0 0] /CharProcs << /space 8 0 R /A 9 0 R /B 10 0 R /C 11 0 R /D 12 0 R /E 13 0 R /F 14 0 R /G 15 0 R /H 16 0 R /I 17 0 R /J 18 0 R /K 19 0 R /L 20 0 R /M 21 0 R /N 22 0 R /O 23 0 R /P 24 0 R /Q 25 0 R /R 26 0 R /S 27 0 R /T 28 0 R /U 29 0 R /V 30 0 R /W 31 0 R /X 32 0 R /Y 33 0 R /Z 34 0 R >> /Encoding << /Type /Encoding /Differences [32 /space 65 /A /B /C /D /E /F /G /H /I /J /K /L /M /N /O /P /Q /R /S /T /U /V /W /X /Y /Z] >> /FirstChar 32 /LastChar 90 /Widths [300 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] /Resources << /Font << /FB 7 0 R >> >> >>
+endobj
+7 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+8 0 obj
+<< /Length 8 >>
+stream
+300 0 d0
+endstream
+endobj
+9 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (V) Tj ET
+endstream
+endobj
+10 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (W) Tj ET
+endstream
+endobj
+11 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (X) Tj ET
+endstream
+endobj
+12 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (Y) Tj ET
+endstream
+endobj
+13 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (Z) Tj ET
+endstream
+endobj
+14 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (A) Tj ET
+endstream
+endobj
+15 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (B) Tj ET
+endstream
+endobj
+16 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (C) Tj ET
+endstream
+endobj
+17 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (D) Tj ET
+endstream
+endobj
+18 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (E) Tj ET
+endstream
+endobj
+19 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (F) Tj ET
+endstream
+endobj
+20 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (G) Tj ET
+endstream
+endobj
+21 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (H) Tj ET
+endstream
+endobj
+22 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (I) Tj ET
+endstream
+endobj
+23 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (J) Tj ET
+endstream
+endobj
+24 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (K) Tj ET
+endstream
+endobj
+25 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (L) Tj ET
+endstream
+endobj
+26 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (M) Tj ET
+endstream
+endobj
+27 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (N) Tj ET
+endstream
+endobj
+28 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (O) Tj ET
+endstream
+endobj
+29 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (P) Tj ET
+endstream
+endobj
+30 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (Q) Tj ET
+endstream
+endobj
+31 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (R) Tj ET
+endstream
+endobj
+32 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (S) Tj ET
+endstream
+endobj
+33 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (T) Tj ET
+endstream
+endobj
+34 0 obj
+<< /Length 39 >>
+stream
+600 0 d0 BT /FB 700 Tf 0 0 Td (U) Tj ET
+endstream
+endobj
+xref
+0 35
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000251 00000 n 
+0000000312 00000 n 
+0000000596 00000 n 
+0000001455 00000 n 
+0000001525 00000 n 
+0000001582 00000 n 
+0000001671 00000 n 
+0000001761 00000 n 
+0000001851 00000 n 
+0000001941 00000 n 
+0000002031 00000 n 
+0000002121 00000 n 
+0000002211 00000 n 
+0000002301 00000 n 
+0000002391 00000 n 
+0000002481 00000 n 
+0000002571 00000 n 
+0000002661 00000 n 
+0000002751 00000 n 
+0000002841 00000 n 
+0000002931 00000 n 
+0000003021 00000 n 
+0000003111 00000 n 
+0000003201 00000 n 
+0000003291 00000 n 
+0000003381 00000 n 
+0000003471 00000 n 
+0000003561 00000 n 
+0000003651 00000 n 
+0000003741 00000 n 
+0000003831 00000 n 
+trailer
+<< /Size 35 /Root 1 0 R >>
+startxref
+3921
+%%EOF

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4399,3 +4399,51 @@ fn test_extract_pages_markdown_agrees_with_classify_on_scan_with_native_header()
         page.markdown
     );
 }
+
+/// Regression for #428: `extract_pages_markdown`'s per-page `needs_ocr`
+/// must also agree with `classify_pdf`/`detect_pdf_type` when the
+/// undecodable-font signal — not an image — is what makes the detector
+/// distrust the page. The fixture draws all page text through a Form XObject
+/// using a custom-encoded Type3 font with no ToUnicode map: the visible
+/// glyph programs render ordinary business text, while a native extractor
+/// that trusts the Encoding names reads a Caesar-shifted string. That output
+/// is clean ASCII with plausible word shapes, so the text-quality heuristics
+/// (cipher statistics, CID garbage, encoding issues) all pass on this short
+/// sample, while detection's font-resource check correctly flags the page as
+/// `suspected_garbled_text`. The extraction API must apply the same font
+/// signal instead of returning the wrong native text as trusted Markdown.
+#[test]
+fn test_extract_pages_markdown_agrees_with_classify_on_type3_custom_encoding() {
+    let buf = std::fs::read("tests/fixtures/type3_custom_encoding_no_tounicode.pdf").unwrap();
+
+    let cls = pdf_inspector::detector::detect_pdf_type_mem(&buf).expect("fixture should classify");
+    assert!(
+        cls.pages_needing_ocr.contains(&1),
+        "classify_pdf should flag page 1 as needing OCR (Type3 without ToUnicode), got: {:?}",
+        cls.pages_needing_ocr
+    );
+
+    let ext = extract_pages_markdown_mem(&buf, None).expect("fixture should extract");
+    let page = &ext.pages[0];
+    assert!(
+        page.needs_ocr,
+        "extract_pages_markdown must agree with classify_pdf that this page needs OCR"
+    );
+    assert!(
+        ext.pages_needing_ocr.contains(&1),
+        "the document-level OCR page list must include the flagged page, got: {:?}",
+        ext.pages_needing_ocr
+    );
+    assert_eq!(
+        page.ocr_reason.as_deref(),
+        Some(pdf_inspector::OCR_REASON_SUSPECTED_GARBLED_TEXT),
+        "the detector-confirmed garble signal must be reported, got: {:?}",
+        page.ocr_reason
+    );
+    assert!(
+        page.markdown.is_empty(),
+        "a page flagged needs_ocr must not return the Type3 Encoding-name text \
+         as if extraction were trustworthy, got: {:?}",
+        page.markdown
+    );
+}


### PR DESCRIPTION
## Summary

Detection correctly routes a page to OCR when its used fonts cannot map back to Unicode, including custom-encoded Type3 fonts without ToUnicode. `extract_pages_markdown` did not consume that font-resource signal. A custom Type3 encoding can map every byte to plausible ASCII letters, so its wrong output could pass output-text heuristics and be returned with `needs_ocr=false`.

This change routes the existing detection font gate through the shared `page_ocr_signals` analysis pass:

- no additional page scan is performed;
- the page receives `suspected_garbled_text`;
- untrusted native markdown is suppressed;
- Type3 fonts with ToUnicode and pages with another decodable font remain exempt, matching detection.

Fixes #428.

## Testing

- Added the issue's deterministic stdlib-generated Type3 fixture and regression.
- The regression failed on clean `main`: detection flagged the page while per-page extraction returned `needs_ocr=false`.
- With the fix, both APIs agree the page needs OCR and the reason is `suspected_garbled_text`.
- `cargo test` — 987 unit, 3 CLI, 163 integration, and 2 documentation tests pass
- `cargo fmt --all -- --check` — passes
- `cargo clippy` — no new warnings; existing pristine-main findings are unchanged
- `git diff --check` — passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per-page extraction now honors the detector’s undecodable-font OCR gate so extraction and detection agree. Previously, pages using Identity-H/V or custom-encoded Type3 fonts without ToUnicode could return trusted markdown with needs_ocr=false; now they return needs_ocr with reason suspected_garbled_text and suppress markdown.

**Review notes**
- Routes the undecodable-font signal through the shared `page_ocr_signals`; its return now includes (template image, undecodable fonts, vector text).
- Applies OCR reason `suspected_garbled_text` and suppresses native markdown when undecodable fonts are used.
- Keeps exemptions: Type3 with ToUnicode or pages that also use any decodable font still extract natively.
- Uses the same analysis pass; no extra page scanning or performance cost.
- Adds a deterministic Type3 fixture and regression to verify extraction matches detection on needs_ocr.

<sup>Written for commit 15e07c1662ee4a71e519735b83a14bd9c8a5e1c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

