### PR TITLE
fix(parser): recover root-bearing linearized xrefs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3900,7 +3900,7 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
 /// at the cross-reference table — a single corrupted byte in the offset is
 /// enough. lopdf trusts that pointer outright and fails to load rather than
 /// searching for the real table, unlike pypdf/pdfium which both recover by
-/// locating it directly. This finds the real (classic, non-stream) `xref`
+/// locating it directly. This finds a recoverable (classic, non-stream) `xref`
 /// table by scanning for the keyword — validating that a plausible
 /// subsection header follows, not just any standalone "xref" token, since
 /// this crate processes untrusted input and a coincidental match inside
@@ -3912,11 +3912,17 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
 /// transparently supersedes the broken one without needing to touch
 /// anything already in the file.
 ///
+/// Linearized PDFs commonly have two classic tables: the early table carries
+/// `/Root` and `/Prev`, while the final table contains only the remaining
+/// object entries. Preferring the newest table whose own trailer has `/Root`
+/// prevents the repair from selecting the rootless final table and reporting
+/// a zero-page document.
+///
 /// Doesn't cover cross-reference *streams* (`N 0 obj << /Type /XRef ...`,
 /// used by some PDF 1.5+ writers instead of a classic table) — recovering
 /// those needs the containing object's number, not just a byte offset.
 fn recover_startxref_pointer(buf: &[u8]) -> Option<Vec<u8>> {
-    let xref_pos = find_last_valid_xref_table_start(buf)?;
+    let xref_pos = find_recoverable_xref_table_start(buf)?;
 
     let mut repaired = Vec::with_capacity(buf.len() + 32);
     repaired.extend_from_slice(buf);
@@ -3927,34 +3933,100 @@ fn recover_startxref_pointer(buf: &[u8]) -> Option<Vec<u8>> {
     Some(repaired)
 }
 
+/// Returns classic xref starts from newest to oldest, filtered by the same
+/// subsection validation as the original single-table scan.
+fn valid_xref_table_starts(buf: &[u8]) -> Vec<usize> {
+    const KEYWORD: &[u8] = b"xref";
+    let mut starts = Vec::new();
+    let mut pos = buf.len().saturating_sub(KEYWORD.len());
+
+    loop {
+        if &buf[pos..pos + KEYWORD.len()] == KEYWORD
+            && (pos == 0 || buf[pos - 1].is_ascii_whitespace())
+            && buf
+                .get(pos + KEYWORD.len())
+                .is_none_or(u8::is_ascii_whitespace)
+            && looks_like_xref_subsection_header(buf, pos + KEYWORD.len())
+        {
+            starts.push(pos);
+        }
+        if pos == 0 {
+            return starts;
+        }
+        pos -= 1;
+    }
+}
+
+/// Prefer the newest classic table whose trailer directly names `/Root`; fall
+/// back to the newest valid table for unusual trailer layouts that the parser
+/// can still traverse.
+fn find_recoverable_xref_table_start(buf: &[u8]) -> Option<usize> {
+    let mut newest = None;
+    for pos in valid_xref_table_starts(buf) {
+        newest = newest.or(Some(pos));
+        if xref_trailer_has_root(buf, pos) {
+            return Some(pos);
+        }
+    }
+    newest
+}
+
+/// Checks the trailer immediately following a classic xref table for a root
+/// reference. Bounding the search at the following `startxref` prevents an
+/// unrelated `/Root` in a later object or stream from selecting the wrong
+/// table.
+fn xref_trailer_has_root(buf: &[u8], xref_pos: usize) -> bool {
+    let Some(trailer_pos) = find_standalone_keyword(buf, xref_pos, b"trailer") else {
+        return false;
+    };
+    let Some(startxref_pos) = find_standalone_keyword(buf, trailer_pos, b"startxref") else {
+        return false;
+    };
+    if startxref_pos <= trailer_pos {
+        return false;
+    }
+
+    let trailer = &buf[trailer_pos..startxref_pos];
+    let mut search_from = 0;
+    while let Some(relative_pos) = trailer[search_from..]
+        .windows(b"/Root".len())
+        .position(|window| window == b"/Root")
+    {
+        let after_name = search_from + relative_pos + b"/Root".len();
+        if trailer.get(after_name).is_none_or(u8::is_ascii_whitespace) {
+            return true;
+        }
+        search_from = search_from + relative_pos + 1;
+    }
+    false
+}
+
+fn find_standalone_keyword(buf: &[u8], start: usize, keyword: &[u8]) -> Option<usize> {
+    if start >= buf.len() {
+        return None;
+    }
+
+    buf[start..]
+        .windows(keyword.len())
+        .position(|window| window == keyword)
+        .map(|relative_pos| start + relative_pos)
+        .filter(|&pos| {
+            (pos == 0 || buf[pos - 1].is_ascii_whitespace())
+                && buf
+                    .get(pos + keyword.len())
+                    .is_none_or(u8::is_ascii_whitespace)
+        })
+}
+
 /// Finds the last standalone `xref` token in `buf` that is immediately
 /// followed by a plausible classic cross-reference subsection header
 /// (`<start-id> <count>`, e.g. "0 6") — the shape every real classic xref
 /// table starts with. A single reverse byte scan: O(n) even on a
 /// pathological buffer with many non-matching or non-standalone "xref"
 /// occurrences, unlike repeatedly re-searching a shrinking prefix.
+#[cfg(test)]
 fn find_last_valid_xref_table_start(buf: &[u8]) -> Option<usize> {
-    const KEYWORD: &[u8] = b"xref";
-    if buf.len() < KEYWORD.len() {
-        return None;
-    }
-    let mut pos = buf.len() - KEYWORD.len();
-    loop {
-        if &buf[pos..pos + KEYWORD.len()] == KEYWORD {
-            let before_ok = pos == 0 || buf[pos - 1].is_ascii_whitespace();
-            let after_ok = buf
-                .get(pos + KEYWORD.len())
-                .is_none_or(|c| c.is_ascii_whitespace());
-            if before_ok && after_ok && looks_like_xref_subsection_header(buf, pos + KEYWORD.len())
-            {
-                return Some(pos);
-            }
-        }
-        if pos == 0 {
-            return None;
-        }
-        pos -= 1;
-    }
+    valid_xref_table_starts(buf).into_iter().next()
 }
 
 /// Checks that `buf[pos..]` starts (after whitespace) with two

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3976,7 +3976,7 @@ fn find_recoverable_xref_table_start(buf: &[u8]) -> Option<usize> {
         let search_end = next_newer_table_pos;
         if newest.is_none() {
             newest = Some(pos);
-            newest_has_prev = xref_trailer_has_key_before(buf, pos, search_end, b"Prev");
+            newest_has_prev = xref_trailer_prev_points_backwards(buf, pos, search_end);
         } else if xref_trailer_has_key_before(buf, pos, search_end, b"Root") {
             return if newest_has_prev { newest } else { Some(pos) };
         }
@@ -3994,17 +3994,31 @@ fn xref_trailer_has_root(buf: &[u8], xref_pos: usize) -> bool {
 }
 
 fn xref_trailer_has_key_before(buf: &[u8], xref_pos: usize, search_end: usize, key: &[u8]) -> bool {
-    let Some(trailer_pos) = find_standalone_keyword(buf, xref_pos, search_end, b"trailer") else {
-        return false;
-    };
+    xref_trailer_top_level_token_before(buf, xref_pos, search_end, key).is_some()
+}
+
+fn xref_trailer_prev_points_backwards(buf: &[u8], xref_pos: usize, search_end: usize) -> bool {
+    xref_trailer_top_level_token_before(buf, xref_pos, search_end, b"Prev")
+        .and_then(|value| std::str::from_utf8(value).ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some_and(|offset| offset < u64::try_from(xref_pos).unwrap_or(u64::MAX))
+}
+
+fn xref_trailer_top_level_token_before<'a>(
+    buf: &'a [u8],
+    xref_pos: usize,
+    search_end: usize,
+    key: &[u8],
+) -> Option<&'a [u8]> {
+    let trailer_pos = find_standalone_keyword(buf, xref_pos, search_end, b"trailer")?;
 
     let mut pos = trailer_pos + b"trailer".len();
     if pos >= search_end {
-        return false;
+        return None;
     }
     skip_pdf_whitespace_and_comments(buf, &mut pos, search_end);
 
-    pdf_dictionary_has_top_level_key(buf, pos, search_end, key)
+    pdf_dictionary_top_level_value_token(buf, pos, search_end, key)
 }
 
 fn skip_pdf_whitespace_and_comments(buf: &[u8], pos: &mut usize, end: usize) {
@@ -4029,19 +4043,24 @@ fn is_pdf_regular(byte: u8) -> bool {
         )
 }
 
-fn pdf_dictionary_has_top_level_key(buf: &[u8], mut pos: usize, end: usize, key: &[u8]) -> bool {
+fn pdf_dictionary_top_level_value_token<'a>(
+    buf: &'a [u8],
+    mut pos: usize,
+    end: usize,
+    key: &[u8],
+) -> Option<&'a [u8]> {
     if !buf[pos..end].starts_with(b"<<") {
-        return false;
+        return None;
     }
     pos += 2;
 
     loop {
         skip_pdf_whitespace_and_comments(buf, &mut pos, end);
         if pos >= end || buf[pos..end].starts_with(b">>") {
-            return false;
+            return None;
         }
         if buf.get(pos) != Some(&b'/') {
-            return false;
+            return None;
         }
         pos += 1;
         let name_start = pos;
@@ -4049,15 +4068,23 @@ fn pdf_dictionary_has_top_level_key(buf: &[u8], mut pos: usize, end: usize, key:
             pos += 1;
         }
         if &buf[name_start..pos] == key {
-            return true;
+            skip_pdf_whitespace_and_comments(buf, &mut pos, end);
+            if pos >= end || !is_pdf_regular(buf[pos]) {
+                return None;
+            }
+            let value_start = pos;
+            while pos < end && is_pdf_regular(buf[pos]) {
+                pos += 1;
+            }
+            return Some(&buf[value_start..pos]);
         }
 
         skip_pdf_whitespace_and_comments(buf, &mut pos, end);
         if pos >= end || buf[pos..end].starts_with(b">>") {
-            return false;
+            return None;
         }
         if !skip_pdf_dictionary_value(buf, &mut pos, end, 0) {
-            return false;
+            return None;
         }
     }
 }
@@ -7863,8 +7890,7 @@ mod tests {
         let mut amended = older.to_vec();
         amended.extend_from_slice(
             format!(
-                "xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Prev {} >>\nstartxref\n0\n%%EOF",
-                older.len()
+                "xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Prev 0 >>\nstartxref\n0\n%%EOF"
             )
             .as_bytes(),
         );
@@ -7873,6 +7899,21 @@ mod tests {
             find_recoverable_xref_table_start(&amended),
             Some(older.len()),
             "a rootless amended trailer with /Prev must keep its newest revisions reachable"
+        );
+    }
+
+    #[test]
+    fn recover_rejects_rootless_xref_whose_prev_points_forward() {
+        let older = b"xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Root 1 0 R >>\nstartxref\n0\n%%EOF\n";
+        let mut malformed = older.to_vec();
+        malformed.extend_from_slice(
+            b"xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Prev 999999 >>\nstartxref\n0\n%%EOF",
+        );
+
+        assert_eq!(
+            find_recoverable_xref_table_start(&malformed),
+            Some(0),
+            "a forward /Prev value is not a chain to the older root-bearing table"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3938,6 +3938,9 @@ fn recover_startxref_pointer(buf: &[u8]) -> Option<Vec<u8>> {
 fn valid_xref_table_starts(buf: &[u8]) -> Vec<usize> {
     const KEYWORD: &[u8] = b"xref";
     let mut starts = Vec::new();
+    if buf.len() < KEYWORD.len() {
+        return starts;
+    }
     let mut pos = buf.len().saturating_sub(KEYWORD.len());
 
     loop {
@@ -3957,56 +3960,242 @@ fn valid_xref_table_starts(buf: &[u8]) -> Vec<usize> {
     }
 }
 
-/// Prefer the newest classic table whose trailer directly names `/Root`; fall
-/// back to the newest valid table for unusual trailer layouts that the parser
-/// can still traverse.
+/// Prefer a root-bearing table that a reader can reach without losing newer
+/// object revisions. An amended file normally puts `/Root` in an older trailer
+/// and reaches it from the newest trailer through `/Prev`; in that case the
+/// newest table must remain the repair target. A linearized file instead has a
+/// root-bearing first table and a rootless final table without such a `/Prev`
+/// chain, so the first table is the useful target.
 fn find_recoverable_xref_table_start(buf: &[u8]) -> Option<usize> {
+    let starts = valid_xref_table_starts(buf);
     let mut newest = None;
-    for pos in valid_xref_table_starts(buf) {
-        newest = newest.or(Some(pos));
-        if xref_trailer_has_root(buf, pos) {
-            return Some(pos);
+    let mut newest_has_prev = false;
+    let mut next_newer_table_pos = buf.len();
+
+    for pos in starts {
+        let search_end = next_newer_table_pos;
+        if newest.is_none() {
+            newest = Some(pos);
+            newest_has_prev = xref_trailer_has_key_before(buf, pos, search_end, b"Prev");
+        } else if xref_trailer_has_key_before(buf, pos, search_end, b"Root") {
+            return if newest_has_prev { newest } else { Some(pos) };
         }
+        next_newer_table_pos = pos;
     }
     newest
 }
 
 /// Checks the trailer immediately following a classic xref table for a root
-/// reference. Bounding the search at the following `startxref` prevents an
-/// unrelated `/Root` in a later object or stream from selecting the wrong
-/// table.
+/// reference. Dictionary parsing ignores comments, strings, and nested
+/// dictionaries, where `/Root` is not a top-level trailer key.
+#[cfg(test)]
 fn xref_trailer_has_root(buf: &[u8], xref_pos: usize) -> bool {
-    let Some(trailer_pos) = find_standalone_keyword(buf, xref_pos, b"trailer") else {
-        return false;
-    };
-    let Some(startxref_pos) = find_standalone_keyword(buf, trailer_pos, b"startxref") else {
-        return false;
-    };
-    if startxref_pos <= trailer_pos {
-        return false;
-    }
-
-    let trailer = &buf[trailer_pos..startxref_pos];
-    let mut search_from = 0;
-    while let Some(relative_pos) = trailer[search_from..]
-        .windows(b"/Root".len())
-        .position(|window| window == b"/Root")
-    {
-        let after_name = search_from + relative_pos + b"/Root".len();
-        if trailer.get(after_name).is_none_or(u8::is_ascii_whitespace) {
-            return true;
-        }
-        search_from = search_from + relative_pos + 1;
-    }
-    false
+    xref_trailer_has_key_before(buf, xref_pos, buf.len(), b"Root")
 }
 
-fn find_standalone_keyword(buf: &[u8], start: usize, keyword: &[u8]) -> Option<usize> {
-    if start >= buf.len() {
+fn xref_trailer_has_key_before(buf: &[u8], xref_pos: usize, search_end: usize, key: &[u8]) -> bool {
+    let Some(trailer_pos) = find_standalone_keyword(buf, xref_pos, search_end, b"trailer") else {
+        return false;
+    };
+
+    let mut pos = trailer_pos + b"trailer".len();
+    if pos >= search_end {
+        return false;
+    }
+    skip_pdf_whitespace_and_comments(buf, &mut pos, search_end);
+
+    pdf_dictionary_has_top_level_key(buf, pos, search_end, key)
+}
+
+fn skip_pdf_whitespace_and_comments(buf: &[u8], pos: &mut usize, end: usize) {
+    while *pos < end {
+        match buf[*pos] {
+            byte if byte.is_ascii_whitespace() => *pos += 1,
+            b'%' => {
+                while *pos < end && !matches!(buf[*pos], b'\n' | b'\r') {
+                    *pos += 1;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+fn is_pdf_regular(byte: u8) -> bool {
+    !byte.is_ascii_whitespace()
+        && !matches!(
+            byte,
+            b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'
+        )
+}
+
+fn pdf_dictionary_has_top_level_key(buf: &[u8], mut pos: usize, end: usize, key: &[u8]) -> bool {
+    if !buf[pos..end].starts_with(b"<<") {
+        return false;
+    }
+    pos += 2;
+
+    loop {
+        skip_pdf_whitespace_and_comments(buf, &mut pos, end);
+        if pos >= end || buf[pos..end].starts_with(b">>") {
+            return false;
+        }
+        if buf.get(pos) != Some(&b'/') {
+            return false;
+        }
+        pos += 1;
+        let name_start = pos;
+        while pos < end && is_pdf_regular(buf[pos]) {
+            pos += 1;
+        }
+        if &buf[name_start..pos] == key {
+            return true;
+        }
+
+        skip_pdf_whitespace_and_comments(buf, &mut pos, end);
+        if pos >= end || buf[pos..end].starts_with(b">>") {
+            return false;
+        }
+        if !skip_pdf_dictionary_value(buf, &mut pos, end, 0) {
+            return false;
+        }
+    }
+}
+
+fn skip_pdf_dictionary_value(buf: &[u8], pos: &mut usize, end: usize, depth: usize) -> bool {
+    skip_pdf_whitespace_and_comments(buf, pos, end);
+    match buf.get(*pos) {
+        Some(b'(' | b'<' | b'[' | b'/') => skip_pdf_object(buf, pos, end, depth),
+        _ => {
+            let mut saw_token = false;
+            loop {
+                skip_pdf_whitespace_and_comments(buf, pos, end);
+                match buf.get(*pos) {
+                    Some(byte) if is_pdf_regular(*byte) => {
+                        saw_token = true;
+                        while *pos < end && is_pdf_regular(buf[*pos]) {
+                            *pos += 1;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            saw_token
+        }
+    }
+}
+
+fn skip_pdf_object(buf: &[u8], pos: &mut usize, end: usize, depth: usize) -> bool {
+    const MAX_NESTING_DEPTH: usize = 64;
+    if depth > MAX_NESTING_DEPTH {
+        return false;
+    }
+
+    skip_pdf_whitespace_and_comments(buf, pos, end);
+    match buf.get(*pos) {
+        None => false,
+        Some(b'(') => {
+            *pos += 1;
+            let mut parentheses = 0usize;
+            while *pos < end {
+                match buf[*pos] {
+                    b'\\' => *pos = (*pos + 2).min(end),
+                    b'(' => {
+                        parentheses += 1;
+                        *pos += 1;
+                    }
+                    b')' => {
+                        if parentheses == 0 {
+                            *pos += 1;
+                            return true;
+                        }
+                        parentheses -= 1;
+                        *pos += 1;
+                    }
+                    _ => *pos += 1,
+                }
+            }
+            false
+        }
+        Some(b'<') if buf.get(*pos + 1) == Some(&b'<') => {
+            *pos += 2;
+            loop {
+                skip_pdf_whitespace_and_comments(buf, pos, end);
+                if *pos >= end {
+                    return false;
+                }
+                if buf[*pos..end].starts_with(b">>") {
+                    *pos += 2;
+                    return true;
+                }
+                if buf.get(*pos) != Some(&b'/') {
+                    return false;
+                }
+                *pos += 1;
+                while *pos < end && is_pdf_regular(buf[*pos]) {
+                    *pos += 1;
+                }
+                skip_pdf_whitespace_and_comments(buf, pos, end);
+                if *pos >= end || buf[*pos..end].starts_with(b">>") {
+                    return false;
+                }
+                if !skip_pdf_dictionary_value(buf, pos, end, depth + 1) {
+                    return false;
+                }
+            }
+        }
+        Some(b'<') => {
+            *pos += 1;
+            while *pos < end && buf[*pos] != b'>' {
+                *pos += 1;
+            }
+            if *pos < end {
+                *pos += 1;
+                true
+            } else {
+                false
+            }
+        }
+        Some(b'[') => {
+            *pos += 1;
+            loop {
+                skip_pdf_whitespace_and_comments(buf, pos, end);
+                if *pos >= end {
+                    return false;
+                }
+                if buf[*pos] == b']' {
+                    *pos += 1;
+                    return true;
+                }
+                if !skip_pdf_object(buf, pos, end, depth + 1) {
+                    return false;
+                }
+            }
+        }
+        Some(b'/') => {
+            *pos += 1;
+            while *pos < end && is_pdf_regular(buf[*pos]) {
+                *pos += 1;
+            }
+            true
+        }
+        Some(byte) if is_pdf_regular(*byte) => {
+            while *pos < end && is_pdf_regular(buf[*pos]) {
+                *pos += 1;
+            }
+            true
+        }
+        Some(_) => false,
+    }
+}
+
+fn find_standalone_keyword(buf: &[u8], start: usize, end: usize, keyword: &[u8]) -> Option<usize> {
+    let end = end.min(buf.len());
+    if start >= end {
         return None;
     }
 
-    buf[start..]
+    buf[start..end]
         .windows(keyword.len())
         .position(|window| window == keyword)
         .map(|relative_pos| start + relative_pos)
@@ -7650,6 +7839,41 @@ mod tests {
         // accepted as a real subsection header.
         let buf = b"xref\n0 6garbage\n%%EOF";
         assert_eq!(find_last_valid_xref_table_start(buf), None);
+    }
+
+    #[test]
+    fn find_xref_scan_does_not_panic_on_input_shorter_than_keyword() {
+        for buf in [b"".as_slice(), b"x", b"xr", b"xr@", b"xref"] {
+            valid_xref_table_starts(buf);
+        }
+    }
+
+    #[test]
+    fn trailer_root_detection_ignores_comments_and_nested_entries() {
+        let comment = b"xref\n0 1\n0000000000 65535 f \ntrailer\n%% /Root 9 0 R\n<< /Size 1 >>\nstartxref\n0\n%%EOF";
+        assert!(!xref_trailer_has_root(comment, 0));
+
+        let nested = b"xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 1 /Metadata << /Root 9 0 R >> >>\nstartxref\n0\n%%EOF";
+        assert!(!xref_trailer_has_root(nested, 0));
+    }
+
+    #[test]
+    fn recover_prefers_newest_rootless_xref_when_prev_forms_chain() {
+        let older = b"xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Root 1 0 R >>\nstartxref\n0\n%%EOF\n";
+        let mut amended = older.to_vec();
+        amended.extend_from_slice(
+            format!(
+                "xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 2 /Prev {} >>\nstartxref\n0\n%%EOF",
+                older.len()
+            )
+            .as_bytes(),
+        );
+
+        assert_eq!(
+            find_recoverable_xref_table_start(&amended),
+            Some(older.len()),
+            "a rootless amended trailer with /Prev must keep its newest revisions reachable"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4229,10 +4229,11 @@ fn find_standalone_keyword(buf: &[u8], start: usize, end: usize, keyword: &[u8])
             break;
         }
 
+        let before_ok = pos == start || buf[pos - 1].is_ascii_whitespace();
         let after_ok = buf
             .get(pos + keyword.len())
             .is_none_or(u8::is_ascii_whitespace);
-        if after_ok && buf[pos..end].starts_with(keyword) {
+        if before_ok && after_ok && buf[pos..end].starts_with(keyword) {
             return Some(pos);
         }
         pos += 1;
@@ -7896,6 +7897,16 @@ mod tests {
         let buf = b"xref\n0 1\n0000000000 65535 f \n%% trailer placeholder\ntrailer\n<< /Size 1 /Root 1 0 R >>\nstartxref\n0\n%%EOF";
 
         assert!(xref_trailer_has_root(buf, 0));
+    }
+
+    #[test]
+    fn standalone_keyword_requires_leading_token_boundary() {
+        let buf = b"xtrailer\n";
+        assert_eq!(
+            find_standalone_keyword(buf, 0, buf.len(), b"trailer"),
+            None,
+            "a keyword embedded in a larger token must not match"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4222,16 +4222,29 @@ fn find_standalone_keyword(buf: &[u8], start: usize, end: usize, keyword: &[u8])
         return None;
     }
 
-    buf[start..end]
-        .windows(keyword.len())
-        .position(|window| window == keyword)
-        .map(|relative_pos| start + relative_pos)
-        .filter(|&pos| {
-            (pos == 0 || buf[pos - 1].is_ascii_whitespace())
-                && buf
+    let mut pos = start;
+    while pos < end {
+        match buf[pos] {
+            byte if byte.is_ascii_whitespace() => pos += 1,
+            b'%' => {
+                while pos < end && !matches!(buf[pos], b'\n' | b'\r') {
+                    pos += 1;
+                }
+            }
+            _ => {
+                let before_ok = pos == 0 || buf[pos - 1].is_ascii_whitespace();
+                let after_ok = buf
                     .get(pos + keyword.len())
-                    .is_none_or(u8::is_ascii_whitespace)
-        })
+                    .is_none_or(u8::is_ascii_whitespace);
+                if before_ok && after_ok && buf[pos..end].starts_with(keyword) {
+                    return Some(pos);
+                }
+                pos += 1;
+            }
+        }
+    }
+
+    None
 }
 
 /// Finds the last standalone `xref` token in `buf` that is immediately
@@ -7882,6 +7895,13 @@ mod tests {
 
         let nested = b"xref\n0 1\n0000000000 65535 f \ntrailer\n<< /Size 1 /Metadata << /Root 9 0 R >> >>\nstartxref\n0\n%%EOF";
         assert!(!xref_trailer_has_root(nested, 0));
+    }
+
+    #[test]
+    fn trailer_keyword_detection_skips_comments_before_trailer() {
+        let buf = b"xref\n0 1\n0000000000 65535 f \n%% trailer placeholder\ntrailer\n<< /Size 1 /Root 1 0 R >>\nstartxref\n0\n%%EOF";
+
+        assert!(xref_trailer_has_root(buf, 0));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4224,24 +4224,18 @@ fn find_standalone_keyword(buf: &[u8], start: usize, end: usize, keyword: &[u8])
 
     let mut pos = start;
     while pos < end {
-        match buf[pos] {
-            byte if byte.is_ascii_whitespace() => pos += 1,
-            b'%' => {
-                while pos < end && !matches!(buf[pos], b'\n' | b'\r') {
-                    pos += 1;
-                }
-            }
-            _ => {
-                let before_ok = pos == 0 || buf[pos - 1].is_ascii_whitespace();
-                let after_ok = buf
-                    .get(pos + keyword.len())
-                    .is_none_or(u8::is_ascii_whitespace);
-                if before_ok && after_ok && buf[pos..end].starts_with(keyword) {
-                    return Some(pos);
-                }
-                pos += 1;
-            }
+        skip_pdf_whitespace_and_comments(buf, &mut pos, end);
+        if pos >= end {
+            break;
         }
+
+        let after_ok = buf
+            .get(pos + keyword.len())
+            .is_none_or(u8::is_ascii_whitespace);
+        if after_ok && buf[pos..end].starts_with(keyword) {
+            return Some(pos);
+        }
+        pos += 1;
     }
 
     None

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4388,6 +4388,86 @@ fn test_process_pdf_recovers_corrupted_startxref_pointer() {
     );
 }
 
+fn make_padded_linearized_pdf() -> Vec<u8> {
+    fn first_xref(main_xref_offset: usize, offsets: &[usize; 7]) -> Vec<u8> {
+        let mut out = b"%PDF-1.4\n".to_vec();
+        out.extend_from_slice(b"6 0 obj\n<< /Linearized 1 /N 1 /O 1 /T 9999 >>\nendobj\n");
+        out.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+        for offset in &offsets[1..] {
+            out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        out.extend_from_slice(
+            format!(
+                "trailer\n<< /Size 7 /Root 1 0 R /Prev {main_xref_offset:010} >>\n\
+                 startxref\n0\n%%EOF\n"
+            )
+            .as_bytes(),
+        );
+        out
+    }
+
+    let mut offsets = [0usize; 7];
+    offsets[6] = b"%PDF-1.4\n".len();
+    let prefix_len = first_xref(0, &offsets).len();
+
+    let content = b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET";
+    let bodies = [
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content.len(),
+            String::from_utf8_lossy(content)
+        )
+        .into_bytes(),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+    ];
+
+    let mut body = Vec::new();
+    for (index, object_body) in bodies.iter().enumerate() {
+        offsets[index + 1] = prefix_len + body.len();
+        body.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        body.extend_from_slice(object_body);
+        body.extend_from_slice(b"\nendobj\n");
+    }
+
+    let main_xref_offset = prefix_len + body.len();
+    let mut pdf = first_xref(main_xref_offset, &offsets);
+    let first_xref_offset =
+        b"%PDF-1.4\n".len() + b"6 0 obj\n<< /Linearized 1 /N 1 /O 1 /T 9999 >>\nendobj\n".len();
+    debug_assert_eq!(pdf.len(), prefix_len);
+    pdf.extend_from_slice(&body);
+
+    pdf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for offset in &offsets[1..=5] {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size 6 >>\nstartxref\n{first_xref_offset}\n%%EOF\n").as_bytes(),
+    );
+    pdf.extend(std::iter::repeat_n(0u8, 600));
+    pdf
+}
+
+#[test]
+fn test_process_pdf_repairs_padded_linearized_xref_chain() {
+    let buf = make_padded_linearized_pdf();
+    let result = process_pdf_mem(&buf)
+        .expect("a padded linearized PDF should recover through its root-bearing xref");
+
+    assert_eq!(result.page_count, 1, "the root-bearing xref was not used");
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .is_some_and(|md| md.contains("Hello World")),
+        "the recovered page should retain its text, got {:?}",
+        result.markdown
+    );
+}
+
 /// Regression for #227: `extract_pages_markdown`'s per-page `needs_ocr`
 /// must agree with `classify_pdf`/`detect_pdf_type` on the same page. The
 /// fixture is a full-page raster "scan" with a single line of genuine


### PR DESCRIPTION
## Problem

Issue #345's scanned PDF reports `page_count: 0` and rejects conversion with `OCR is required`. The file is linearized and has more than 512 bytes of padding after its final `%%EOF`.

The document has two classic xref tables:

- an early table whose trailer contains `/Root` and `/Prev`;
- the final table, which completes the object list but has no `/Root` in its own trailer.

lopdf cannot find the final EOF through the padding, so container repair runs. The old repair selected the newest classic xref without inspecting its trailer. That loads the rootless final table, leaves the catalog unreachable, and produces a zero-page result even though the root-bearing table and its `/Prev` chain are intact.

## Change

- Enumerate validated classic xref starts from newest to oldest.
- Prefer the newest table whose own trailer names `/Root`, which also recovers the rest of the chain through `/Prev`.
- Keep the newest valid table as a fallback for unusual trailer layouts.
- Add a synthetic, stdlib-only linearized PDF regression with two xref tables and 600 trailing NUL bytes. It fails on main with `page_count == 0` and now returns one text page containing `Hello World`.

The sample from the issue was also checked locally: it now reports four scanned pages (still requiring OCR) instead of zero pages.

## Tests

- `cargo test --lib` — 987 passed.
- `cargo test --test integration_tests test_process_pdf_repairs_padded_linearized_xref_chain -- --nocapture` — 1 passed.
- `cargo clippy --lib -- -D warnings` — clean.
- `cargo fmt` — clean.

Fixes #345

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover linearized PDFs with padded EOF by preferring a root-bearing classic xref and requiring standalone token boundaries for `xref`/`trailer`. Previously repair always chose the newest classic xref and could pick a rootless final table, producing page_count: 0; now it selects the newest xref whose trailer has `/Root`, or keeps the newest rootless table only when its `/Prev` points backward, preserving revisions and restoring a reachable catalog.

- Scans classic xref tables newest→oldest; bounds trailer searches to before the next xref; enforces leading/trailing token boundaries for standalone keywords.
- Parses trailer dictionaries for top‑level keys only; ignores comments, strings, and nested dictionaries; reuses a whitespace/comment scanner; guards short inputs.
- Retains the newest rootless table only if `/Prev` points backward; rejects forward `/Prev` and falls back to the newest root-bearing table; keeps the newest valid table when no root-bearing trailer exists.
- Adds a stdlib‑only regression PDF with 600 trailing NULs and unit tests for commented “trailer”, nested/commented `/Root`, backward/forward `/Prev`, and keyword boundary checks; the sample in #345 now reports four scanned pages instead of zero.

Fixes #345.

<sup>Written for commit 9ddc2a9ee085d466c34e1c1b9d2956c84adf47be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

