### PR TITLE
fix(layout): recover mixed-case tracked words

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -874,20 +874,24 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
 
     // Word gaps, if present, form a second mode above the letter-gap
     // cluster: split at the largest relative jump. Unimodal → one word.
+    let floor = largest_relative_gap_jump(&sorted, 1.4).unwrap_or(f32::INFINITY);
+    Some((end, floor * fs))
+}
+
+/// Find the midpoint between the two sorted gap classes with the largest
+/// relative jump, if that jump clears `minimum_jump`.
+fn largest_relative_gap_jump(sorted: &[f32], minimum_jump: f32) -> Option<f32> {
     let mut best_jump = 1.0f32;
-    let mut floor = f32::INFINITY;
+    let mut floor = None;
     for pair in sorted.windows(2) {
         let (lo, hi) = (pair[0].max(0.01), pair[1].max(0.01));
         let jump = hi / lo;
         if jump > best_jump {
             best_jump = jump;
-            floor = (lo + hi) / 2.0;
+            floor = Some((lo + hi) / 2.0);
         }
     }
-    if best_jump < 1.4 {
-        floor = f32::INFINITY;
-    }
-    Some((end, floor * fs))
+    (best_jump >= minimum_jump).then_some(floor?)
 }
 
 /// Recover mixed-case, multi-word tracking from a clearly bimodal gap series.
@@ -906,21 +910,12 @@ fn title_case_tracked_floor(
 ) -> Option<(usize, f32)> {
     let mut positive: Vec<f32> = gaps.iter().copied().filter(|gap| *gap > 0.08).collect();
     positive.sort_by(|a, b| a.total_cmp(b));
-    if positive.len() < 4 || positive[positive.len() / 2] <= 0.10 {
+    if positive.len() < 4 {
         return None;
     }
 
-    let mut best_jump = 1.0f32;
-    let mut floor = f32::INFINITY;
-    for pair in positive.windows(2) {
-        let (lo, hi) = (pair[0], pair[1]);
-        let jump = hi / lo;
-        if jump > best_jump {
-            best_jump = jump;
-            floor = (lo + hi) / 2.0;
-        }
-    }
-    if best_jump < 1.75 || positive.last().is_some_and(|last| *last - floor < 0.08) {
+    let floor = largest_relative_gap_jump(&positive, 1.75)?;
+    if positive.last().is_some_and(|last| *last - floor < 0.08) {
         return None;
     }
 
@@ -1414,6 +1409,20 @@ mod tests {
         let mut items = glyph_run("JohnDoe", 100.0, 9.0, 2.2);
         for item in items.iter_mut().skip(4) {
             item.x += 2.8;
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "John Doe");
+    }
+
+    #[test]
+    fn tracked_title_case_run_recovers_narrow_letter_gaps() {
+        // Uppercase junctions split at 0.08 em even when lowercase junctions
+        // remain below their 0.13-em threshold. The bimodal word gap must
+        // still recover the title-case words.
+        let mut items = glyph_run("JohnDoe", 100.0, 9.0, 1.1);
+        for item in items.iter_mut().skip(4) {
+            item.x += 2.1;
         }
         let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1);

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -851,7 +851,7 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
         && run_chars().any(is_spaceless_cjk);
     let all_caps = run_chars().all(|c| c.is_uppercase() || is_cjk_char(c) || !c.is_alphabetic());
     if !(spaceless_cjk || all_caps) {
-        return None;
+        return title_case_tracked_floor(group, start, end, &gaps, fs);
     }
 
     if gaps.len() >= MIN_GAPS {
@@ -888,6 +888,63 @@ fn tracked_run_space_floor(group: &[&TextItem], start: usize) -> Option<(usize, 
         floor = f32::INFINITY;
     }
     Some((end, floor * fs))
+}
+
+/// Recover mixed-case, multi-word tracking from a clearly bimodal gap series.
+///
+/// Unlike all-caps display type, a uniformly spaced lowercase sequence is a
+/// legitimate way to list variables. A wide gap by itself is therefore not
+/// enough. Require the larger gaps to split the glyph run into at least two
+/// title-case words of three or more letters; the resulting shape (`John` +
+/// `Doe`) is much more specific than an intentionally spaced variable list.
+fn title_case_tracked_floor(
+    group: &[&TextItem],
+    start: usize,
+    end: usize,
+    gaps: &[f32],
+    font_size: f32,
+) -> Option<(usize, f32)> {
+    let mut positive: Vec<f32> = gaps.iter().copied().filter(|gap| *gap > 0.08).collect();
+    positive.sort_by(|a, b| a.total_cmp(b));
+    if positive.len() < 4 || positive[positive.len() / 2] <= 0.10 {
+        return None;
+    }
+
+    let mut best_jump = 1.0f32;
+    let mut floor = f32::INFINITY;
+    for pair in positive.windows(2) {
+        let (lo, hi) = (pair[0], pair[1]);
+        let jump = hi / lo;
+        if jump > best_jump {
+            best_jump = jump;
+            floor = (lo + hi) / 2.0;
+        }
+    }
+    if best_jump < 1.75 || positive.last().is_some_and(|last| *last - floor < 0.08) {
+        return None;
+    }
+
+    let mut word_chars = Vec::new();
+    let mut current_chars = Vec::new();
+    for (index, item) in group[start..=end].iter().enumerate() {
+        let character = item.text.trim().chars().next()?;
+        current_chars.push(character);
+        if index < gaps.len() && gaps[index] > floor {
+            word_chars.push(std::mem::take(&mut current_chars));
+        }
+    }
+    word_chars.push(current_chars);
+
+    let title_word = |chars: &[char]| {
+        chars.len() >= 3
+            && chars.iter().all(|c| c.is_alphabetic())
+            && chars.first().is_some_and(|c| c.is_uppercase())
+            && chars[1..].iter().all(|c| c.is_lowercase())
+    };
+    if word_chars.len() < 2 || !word_chars.iter().all(|chars| title_word(chars)) {
+        return None;
+    }
+    Some((end, floor * font_size))
 }
 
 /// Fractional font-size band within which `merge_text_items` treats two runs as
@@ -1347,6 +1404,33 @@ mod tests {
         let merged = merge_text_items(items);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].text, "IT IS OK");
+    }
+
+    #[test]
+    fn tracked_title_case_run_keeps_word_gaps() {
+        // Resume-style mixed-case tracking has the same two-gap modes as the
+        // all-caps case above, but only the title-case word shape is strong
+        // enough to override the deliberately conservative lowercase rule.
+        let mut items = glyph_run("JohnDoe", 100.0, 9.0, 2.2);
+        for item in items.iter_mut().skip(4) {
+            item.x += 2.8;
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "John Doe");
+    }
+
+    #[test]
+    fn lowercase_bimodal_spaced_singles_keep_boundaries() {
+        // A bimodal gap alone is not sufficient for lowercase: this is still
+        // indistinguishable from an intentionally spaced variable sequence.
+        let mut items = glyph_run("abcdef", 100.0, 6.0, 2.2);
+        for item in items.iter_mut().skip(3) {
+            item.x += 2.8;
+        }
+        let merged = merge_text_items(items);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "a b c d e f");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,6 +15,14 @@ use pdf_inspector::{
 use std::collections::HashSet;
 
 fn make_text_pdf(content: &str, media_box: &str) -> Vec<u8> {
+    make_text_pdf_with_font(
+        content,
+        media_box,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    )
+}
+
+fn make_text_pdf_with_font(content: &str, media_box: &str, font_body: &str) -> Vec<u8> {
     let mut pdf = b"%PDF-1.4\n".to_vec();
     let mut offsets = vec![0usize];
 
@@ -56,12 +64,7 @@ fn make_text_pdf(content: &str, media_box: &str) -> Vec<u8> {
             content
         ),
     );
-    add_object(
-        &mut pdf,
-        &mut offsets,
-        5,
-        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
-    );
+    add_object(&mut pdf, &mut offsets, 5, font_body);
 
     let xref_start = pdf.len();
     pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
@@ -259,6 +262,46 @@ fn make_digit_run_repro_pdf() -> Vec<u8> {
 1 0 0 1 72 720 Tm (C\) Control: The total of 730 seats was approved. let log 2 = a) Tj
 ET"#;
     make_text_pdf(content, "0 0 595 842")
+}
+
+fn make_mixed_case_tracked_text_pdf() -> Vec<u8> {
+    let lines = [
+        (750.0, "John Doe"),
+        (720.0, "Software Engineer"),
+        (690.0, "Senior Software Engineer"),
+    ];
+    let mut content = String::from("BT\n/F1 18 Tf\n");
+
+    // A simple font with almost-uniform 500-unit advances. The lone 800-unit
+    // `w` makes the following positioning gap negative, so the merge pass keeps
+    // `wa` together while spacing the other glyph pairs. The resulting mixed
+    // 1-2 character fragments defeat the existing strict `x y z` repair.
+    let mut widths = vec!["500"; 91]; // codes 32..=122
+    widths[(b'w' as usize) - 32] = "800";
+    let font_body = format!(
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /FirstChar 32 /LastChar 122 /Widths [{}] >>",
+        widths.join(" ")
+    );
+
+    for (y, line) in lines {
+        let mut x = 72.0;
+        for character in line.chars() {
+            if character != ' ' {
+                content.push_str(&format!("1 0 0 1 {x:.1} {y:.1} Tm ({character}) Tj\n"));
+            }
+            // 0.70 em advance leaves a 0.20 em tracking gap after normal
+            // glyphs; a word adds another 0.28 em without exceeding the 0.5 em
+            // run-break limit.
+            if character == ' ' {
+                x += 5.0;
+            } else {
+                x += 12.6;
+            }
+        }
+    }
+
+    content.push_str("ET");
+    make_text_pdf_with_font(&content, "0 0 595 842", &font_body)
 }
 
 fn truncate_eof_marker(mut pdf: Vec<u8>) -> Vec<u8> {
@@ -524,6 +567,28 @@ fn test_digit_only_text_runs_are_preserved_in_markdown() {
     assert_eq!(
         result.markdown.expect("markdown output").trim(),
         "A) The total of 730 seats was approved.\nB) let log 2 = a\nC) Control: The total of 730 seats was approved. let log 2 = a"
+    );
+}
+
+#[test]
+fn test_mixed_case_tracked_text_rejoins_words() {
+    let pdf = make_mixed_case_tracked_text_pdf();
+
+    let items = extract_text_with_positions_mem(&pdf).expect("extract positioned text");
+    assert!(
+        items.iter().any(|item| item.text == "John Doe"),
+        "tracked title-case glyphs should merge into words, got {items:?}"
+    );
+
+    let result = process_pdf_mem(&pdf).expect("convert PDF to markdown");
+    let markdown = result.markdown.expect("markdown output");
+    assert!(
+        markdown.lines().any(|line| line.contains("John Doe")),
+        "tracked resume text should preserve words, got {markdown}"
+    );
+    assert!(
+        !markdown.contains("J o h n"),
+        "letter tracking must not split every glyph into a word: {markdown}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Fixes #211.
- Detect a conservative bimodal signature for mixed-case glyph-per-item tracking and rejoin each title-case word while retaining real word gaps.
- Keep deliberately spaced lowercase single-letter sequences unchanged, alongside the existing all-caps and spaceless-CJK handling.

## Testing
- `cargo test --target x86_64-pc-windows-gnu`
- `cargo clippy --target x86_64-pc-windows-gnu -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover mixed-case glyph-per-letter tracking into words while preserving real word gaps. Previously, mixed-case runs (e.g., JohnDoe) split into 1–2 character fragments; now a conservative bimodal gap detector rejoins title-case words without changing lowercase spaced singles or existing all-caps/CJK behavior. Fixes #211.

- Introduces a shared gap-splitting helper (largest_relative_gap_jump) and routes non-CJK, non-all-caps runs through a title-case path that requires a strong jump and at least two ≥3-letter title-case words before merging.
- Keeps lowercase single-letter sequences unchanged; preserves existing all-caps and spaceless CJK handling.
- Adds unit and integration tests, including a synthetic PDF with custom font metrics to reproduce resume-style tracking; no API or option changes.

<sup>Written for commit 87bd26d3cc648104a736e46bff9f9c8738a1a828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

