### PR TITLE
fix(markdown): reject page-flow table projections, correct misestimated base font size

### DIFF
--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -579,24 +579,23 @@ pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
         if text.trim().chars().filter(|c| c.is_alphabetic()).count() < 3 {
             continue;
         }
-        // Judge the line by its dominant item (most characters), not its
-        // first: a small section-number or bullet prefix must not decide
-        // the line's size.
-        let Some(dominant) = line
-            .items
-            .iter()
-            .max_by_key(|it| it.text.trim().chars().count())
-        else {
+        // Judge the line by its character-weighted dominant size (the same
+        // routine heading tiering uses): a small section-number or bullet
+        // prefix must not decide the line's size.
+        let Some(dominant_size) = super::heading::dominant_font_size(line) else {
             continue;
         };
         text_lines += 1;
-        if dominant.font_size / base_size >= 1.2 {
-            let key = (dominant.font_size * 10.0) as i32;
+        if dominant_size / base_size >= 1.2 {
+            let key = (dominant_size * 10.0).round() as i32;
             *promoted.entry(key).or_insert(0) += 1;
             // Body-style evidence: real body lines run long. Headings —
             // even many of them — are short, so a heading-dense page
-            // never accumulates wordy lines at the promoted size.
-            if text.split_whitespace().count() >= 6 {
+            // never accumulates wordy lines at the promoted size. Narrow
+            // columns wrap body text to few words per physical line, so
+            // character mass counts as well.
+            let trimmed = text.trim();
+            if trimmed.split_whitespace().count() >= 6 || trimmed.chars().count() >= 30 {
                 *promoted_wordy.entry(key).or_insert(0) += 1;
             }
         }
@@ -615,7 +614,7 @@ pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
     // Only adopt the new base when the promoted lines at that size mostly
     // read like body text (long lines). A genuinely heading-dense page
     // keeps its structure.
-    let key = (corrected * 10.0) as i32;
+    let key = (corrected * 10.0).round() as i32;
     let wordy = promoted_wordy.get(&key).copied().unwrap_or(0);
     let at_size = promoted.get(&key).copied().unwrap_or(0);
     if wordy * 2 < at_size {
@@ -768,6 +767,30 @@ mod tests {
         for i in 0..12 {
             lines.push(line_of(
                 "body paragraph text continues along here nicely",
+                11.0,
+                false,
+                700.0 - 14.0 * i as f32,
+            ));
+        }
+        for i in 0..4 {
+            lines.push(line_of(
+                "footnote text",
+                9.0,
+                false,
+                100.0 - 11.0 * i as f32,
+            ));
+        }
+        assert_eq!(correct_base_size(&lines, 9.0), 11.0);
+    }
+
+    #[test]
+    fn correct_base_size_handles_narrow_wrapped_body() {
+        // Narrow columns wrap body text to few words per physical line;
+        // character mass must still read as body style.
+        let mut lines: Vec<crate::types::TextLine> = Vec::new();
+        for i in 0..12 {
+            lines.push(line_of(
+                "internationalization considerations",
                 11.0,
                 false,
                 700.0 - 14.0 * i as f32,

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -560,6 +560,53 @@ pub(crate) fn compute_paragraph_threshold(lines: &[TextLine], base_size: f32) ->
 /// Discover distinct heading font-size tiers in the document.
 /// Returns tiers sorted largest-first (tier 0 = H1, tier 1 = H2, …).
 /// Sizes within 0.5pt are clustered into the same tier. Capped at 4 tiers.
+/// Correct a misestimated base font size. The provided base — including a
+/// `MarkdownOptions::base_font_size` value, which internal callers always
+/// derive from document-wide font statistics — is treated as a prior and
+/// only overridden by overwhelming page-local evidence. Item-count font
+/// stats let
+/// footnotes, captions, and folio text outvote the body on some pages;
+/// the tell is an implausible share of text lines clearing the 1.2x
+/// heading gate (real documents are mostly body text). When at least a
+/// third of the text lines would be "headings", the dominant promoted
+/// size IS the body — adopt it as the base.
+pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
+    let mut text_lines = 0usize;
+    let mut promoted: HashMap<i32, usize> = HashMap::new();
+    for line in lines {
+        let text = line.text();
+        if text.trim().chars().filter(|c| c.is_alphabetic()).count() < 3 {
+            continue;
+        }
+        let Some(first) = line.items.first() else {
+            continue;
+        };
+        text_lines += 1;
+        if first.font_size / base_size >= 1.2 {
+            *promoted.entry((first.font_size * 10.0) as i32).or_insert(0) += 1;
+        }
+    }
+    let promoted_total: usize = promoted.values().sum();
+    if text_lines < 8 || promoted_total * 3 < text_lines {
+        return base_size;
+    }
+    let corrected = promoted
+        .iter()
+        .max_by(|(size_a, count_a), (size_b, count_b)| {
+            count_a.cmp(count_b).then_with(|| size_b.cmp(size_a))
+        })
+        .map(|(size, _)| *size as f32 / 10.0)
+        .unwrap_or(base_size);
+    log::debug!(
+        "correct_base_size: {}/{} text lines clear the heading gate — base {} -> {}",
+        promoted_total,
+        text_lines,
+        base_size,
+        corrected
+    );
+    corrected
+}
+
 pub(crate) fn compute_heading_tiers(lines: &[TextLine], base_size: f32) -> Vec<f32> {
     let mut heading_sizes: Vec<f32> = Vec::new();
 
@@ -688,6 +735,45 @@ pub(crate) fn detect_header_level(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn correct_base_size_adopts_dominant_promoted_size() {
+        // Footnote-weighted stats picked 9pt, but the page's text is 11pt:
+        // an implausible share of lines clears the heading gate.
+        let mut lines: Vec<crate::types::TextLine> = Vec::new();
+        for i in 0..12 {
+            lines.push(line_of(
+                "body paragraph text continues here",
+                11.0,
+                false,
+                700.0 - 14.0 * i as f32,
+            ));
+        }
+        for i in 0..4 {
+            lines.push(line_of(
+                "footnote text",
+                9.0,
+                false,
+                100.0 - 11.0 * i as f32,
+            ));
+        }
+        assert_eq!(correct_base_size(&lines, 9.0), 11.0);
+    }
+
+    #[test]
+    fn correct_base_size_keeps_ordinary_documents() {
+        let mut lines: Vec<crate::types::TextLine> = Vec::new();
+        lines.push(line_of("Chapter One Introduction", 16.0, true, 720.0));
+        for i in 0..14 {
+            lines.push(line_of(
+                "regular body text at the document base size",
+                10.0,
+                false,
+                690.0 - 13.0 * i as f32,
+            ));
+        }
+        assert_eq!(correct_base_size(&lines, 10.0), 10.0);
+    }
 
     fn line_of(text: &str, font_size: f32, bold: bool, y: f32) -> crate::types::TextLine {
         let item = crate::types::TextItem {

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -573,17 +573,32 @@ pub(crate) fn compute_paragraph_threshold(lines: &[TextLine], base_size: f32) ->
 pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
     let mut text_lines = 0usize;
     let mut promoted: HashMap<i32, usize> = HashMap::new();
+    let mut promoted_wordy: HashMap<i32, usize> = HashMap::new();
     for line in lines {
         let text = line.text();
         if text.trim().chars().filter(|c| c.is_alphabetic()).count() < 3 {
             continue;
         }
-        let Some(first) = line.items.first() else {
+        // Judge the line by its dominant item (most characters), not its
+        // first: a small section-number or bullet prefix must not decide
+        // the line's size.
+        let Some(dominant) = line
+            .items
+            .iter()
+            .max_by_key(|it| it.text.trim().chars().count())
+        else {
             continue;
         };
         text_lines += 1;
-        if first.font_size / base_size >= 1.2 {
-            *promoted.entry((first.font_size * 10.0) as i32).or_insert(0) += 1;
+        if dominant.font_size / base_size >= 1.2 {
+            let key = (dominant.font_size * 10.0) as i32;
+            *promoted.entry(key).or_insert(0) += 1;
+            // Body-style evidence: real body lines run long. Headings —
+            // even many of them — are short, so a heading-dense page
+            // never accumulates wordy lines at the promoted size.
+            if text.split_whitespace().count() >= 6 {
+                *promoted_wordy.entry(key).or_insert(0) += 1;
+            }
         }
     }
     let promoted_total: usize = promoted.values().sum();
@@ -597,6 +612,15 @@ pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
         })
         .map(|(size, _)| *size as f32 / 10.0)
         .unwrap_or(base_size);
+    // Only adopt the new base when the promoted lines at that size mostly
+    // read like body text (long lines). A genuinely heading-dense page
+    // keeps its structure.
+    let key = (corrected * 10.0) as i32;
+    let wordy = promoted_wordy.get(&key).copied().unwrap_or(0);
+    let at_size = promoted.get(&key).copied().unwrap_or(0);
+    if wordy * 2 < at_size {
+        return base_size;
+    }
     log::debug!(
         "correct_base_size: {}/{} text lines clear the heading gate — base {} -> {}",
         promoted_total,
@@ -743,7 +767,7 @@ mod tests {
         let mut lines: Vec<crate::types::TextLine> = Vec::new();
         for i in 0..12 {
             lines.push(line_of(
-                "body paragraph text continues here",
+                "body paragraph text continues along here nicely",
                 11.0,
                 false,
                 700.0 - 14.0 * i as f32,

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -598,15 +598,18 @@ pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
             // ALL-CAPS headings stay heading evidence.
             let trimmed = text.trim();
             let words: Vec<&str> = trimmed.split_whitespace().collect();
-            let lowercase_words = words
+            // "Not uppercase" rather than "lowercase" so uncased scripts
+            // (CJK, etc.) count as prose-shaped too; Title Case and
+            // ALL-CAPS headings still fail the test.
+            let prose_words = words
                 .iter()
                 .filter(|w| {
                     w.chars()
                         .find(|c| c.is_alphabetic())
-                        .is_some_and(|c| c.is_lowercase())
+                        .is_some_and(|c| !c.is_uppercase())
                 })
                 .count();
-            let prose_shaped = trimmed.chars().count() >= 30 && lowercase_words * 2 >= words.len();
+            let prose_shaped = trimmed.chars().count() >= 30 && prose_words * 2 >= words.len();
             if words.len() >= 6 || prose_shaped {
                 *promoted_wordy.entry(key).or_insert(0) += 1;
             }

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -593,9 +593,21 @@ pub(crate) fn correct_base_size(lines: &[TextLine], base_size: f32) -> f32 {
             // even many of them — are short, so a heading-dense page
             // never accumulates wordy lines at the promoted size. Narrow
             // columns wrap body text to few words per physical line, so
-            // character mass counts as well.
+            // character mass also counts — but only for lines whose words
+            // mostly start lowercase (running prose); long Title Case or
+            // ALL-CAPS headings stay heading evidence.
             let trimmed = text.trim();
-            if trimmed.split_whitespace().count() >= 6 || trimmed.chars().count() >= 30 {
+            let words: Vec<&str> = trimmed.split_whitespace().collect();
+            let lowercase_words = words
+                .iter()
+                .filter(|w| {
+                    w.chars()
+                        .find(|c| c.is_alphabetic())
+                        .is_some_and(|c| c.is_lowercase())
+                })
+                .count();
+            let prose_shaped = trimmed.chars().count() >= 30 && lowercase_words * 2 >= words.len();
+            if words.len() >= 6 || prose_shaped {
                 *promoted_wordy.entry(key).or_insert(0) += 1;
             }
         }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -696,6 +696,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
     let base_size = options
         .base_font_size
         .unwrap_or(font_stats.most_common_size);
+    let base_size = super::analysis::correct_base_size(&lines, base_size);
 
     // Merge drop caps with following text
     let lines = merge_drop_caps(lines, base_size);
@@ -1286,6 +1287,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
     let base_size = options
         .base_font_size
         .unwrap_or(font_stats.most_common_size);
+    let base_size = super::analysis::correct_base_size(&lines, base_size);
 
     // Merge drop caps with following text
     let lines = merge_drop_caps(lines, base_size);

--- a/src/markdown/heading.rs
+++ b/src/markdown/heading.rs
@@ -62,7 +62,7 @@ fn dominant_font(line: &TextLine) -> Option<String> {
 /// whole heading even though the title itself has the document's heading
 /// size. Character weighting makes the longer title win while preserving the
 /// exact size for ordinary one-item lines.
-fn dominant_font_size(line: &TextLine) -> Option<f32> {
+pub(super) fn dominant_font_size(line: &TextLine) -> Option<f32> {
     let mut weights: HashMap<i32, usize> = HashMap::new();
     for item in &line.items {
         let bucket = (item.font_size * 10.0).round() as i32;

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -690,22 +690,37 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // list markers ("1.", "2)", …), the second the item text. Rendering
     // these as tables loses the list; the page flow keeps it.
     // A leading "1. | <text>" row is the list's own first item, not a
-    // table header — the compact-header protection must not treat it as
-    // one for the ordinal branches.
-    let first_row_is_ordinal = table
-        .cells
-        .iter()
-        .find(|row| row.iter().any(|cell| !cell.trim().is_empty()))
-        .and_then(|row| row.first())
-        .map(|first| {
-            let t = first.trim();
-            t.len() <= 4
-                && t.ends_with(['.', ')'])
-                && !t[..t.len() - 1].is_empty()
-                && t[..t.len() - 1].chars().all(|c| c.is_ascii_digit())
-        })
-        .unwrap_or(false);
-    let ordinal_header_blocks = header_blocks && !first_row_is_ordinal;
+    // table header — but only when the whole first column actually has
+    // the list shape (mostly ordinal markers); a lone punctuation-styled
+    // rank must not disable the compact-header protection.
+    let is_ordinal_marker = |cell: &str| {
+        let t = cell.trim();
+        t.len() <= 4
+            && t.ends_with(['.', ')'])
+            && !t[..t.len() - 1].is_empty()
+            && t[..t.len() - 1].chars().all(|c| c.is_ascii_digit())
+    };
+    let first_column_list_shape = {
+        let mut markers = 0usize;
+        let mut filled = 0usize;
+        for row in &table.cells {
+            let first = row.first().map(|s| s.trim()).unwrap_or("");
+            if first.is_empty() {
+                continue;
+            }
+            filled += 1;
+            if is_ordinal_marker(first)
+                || first
+                    .split_whitespace()
+                    .next()
+                    .is_some_and(is_ordinal_marker)
+            {
+                markers += 1;
+            }
+        }
+        filled >= 4 && markers * 10 >= filled * 7
+    };
+    let ordinal_header_blocks = header_blocks && !first_column_list_shape;
     let ordinal_list =
         !ordinal_header_blocks && table.columns.len() == 2 && table.cells.len() >= 4 && {
             let mut markers = 0;

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -665,8 +665,23 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
                 && t.chars().filter(|c| c.is_alphabetic()).count() * 2 >= t.chars().count().max(1)
         })
         .count();
-    let word_fragment_grid = table.columns.len() >= 4
+    // Categorical grids repeat a small value vocabulary down their
+    // columns; flowing text almost never repeats a cell. A fully
+    // populated word grid is only rejected when its cells are almost all
+    // distinct AND the continuations strongly outnumber the rows.
+    let distinct_cells: std::collections::HashSet<String> = table
+        .cells
+        .iter()
+        .flatten()
+        .map(|c| c.trim().to_ascii_lowercase())
+        .filter(|c| !c.is_empty())
+        .collect();
+    let mostly_distinct = distinct_cells.len() * 4 >= non_empty * 3;
+    let word_fragment_grid = !header_blocks
+        && table.columns.len() >= 4
         && non_empty >= 8
+        && (non_empty < table.cells.len() * table.columns.len()
+            || (mostly_distinct && continuation_fragments > table.cells.len() * 2))
         && single_token_alpha * 4 >= non_empty * 3
         && continuation_fragments >= 4
         && continuation_columns.iter().filter(|&&value| value).count() >= 2;
@@ -674,25 +689,43 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // Numbered lists projected onto a two-column grid: the first column is
     // list markers ("1.", "2)", …), the second the item text. Rendering
     // these as tables loses the list; the page flow keeps it.
-    let ordinal_list = table.columns.len() == 2 && table.cells.len() >= 4 && {
-        let mut markers = 0;
-        let mut filled_first = 0;
-        for row in &table.cells {
-            let first = row.first().map(|s| s.trim()).unwrap_or("");
-            if first.is_empty() {
-                continue;
+    // A leading "1. | <text>" row is the list's own first item, not a
+    // table header — the compact-header protection must not treat it as
+    // one for the ordinal branches.
+    let first_row_is_ordinal = table
+        .cells
+        .iter()
+        .find(|row| row.iter().any(|cell| !cell.trim().is_empty()))
+        .and_then(|row| row.first())
+        .map(|first| {
+            let t = first.trim();
+            t.len() <= 4
+                && t.ends_with(['.', ')'])
+                && !t[..t.len() - 1].is_empty()
+                && t[..t.len() - 1].chars().all(|c| c.is_ascii_digit())
+        })
+        .unwrap_or(false);
+    let ordinal_header_blocks = header_blocks && !first_row_is_ordinal;
+    let ordinal_list =
+        !ordinal_header_blocks && table.columns.len() == 2 && table.cells.len() >= 4 && {
+            let mut markers = 0;
+            let mut filled_first = 0;
+            for row in &table.cells {
+                let first = row.first().map(|s| s.trim()).unwrap_or("");
+                if first.is_empty() {
+                    continue;
+                }
+                filled_first += 1;
+                let is_marker = first.len() <= 4
+                    && first.ends_with(['.', ')'])
+                    && first[..first.len() - 1].chars().all(|c| c.is_ascii_digit())
+                    && !first[..first.len() - 1].is_empty();
+                if is_marker {
+                    markers += 1;
+                }
             }
-            filled_first += 1;
-            let is_marker = first.len() <= 4
-                && first.ends_with(['.', ')'])
-                && first[..first.len() - 1].chars().all(|c| c.is_ascii_digit())
-                && !first[..first.len() - 1].is_empty();
-            if is_marker {
-                markers += 1;
-            }
-        }
-        filled_first >= 4 && markers * 10 >= filled_first * 7
-    };
+            filled_first >= 4 && markers * 10 >= filled_first * 7
+        };
 
     let is_parallel = !header_blocks
         && non_empty >= 5
@@ -727,45 +760,50 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // Long prose cells are required: reference tables whose wrapped
     // entries continue in every column (short citation fragments) look
     // continuation-dominated too, but they never read as running text.
-    let continuation_dominated = not_fully_populated
+    let continuation_dominated = !header_blocks
+        && not_fully_populated
         && long_prose >= 4
         // ...and long prose must be a real share of the grid: a large data
         // table with a handful of wordy cells and many wrapped-cell
         // continuations is not a weave.
         && long_prose * 10 >= non_empty
-        && continuation_fragments >= table.cells.len().max(8)
+        // Continuations must strictly outnumber the rows (with an absolute
+        // floor), preserving the compact-header rule's spirit for every
+        // rejection branch.
+        && continuation_fragments > table.cells.len().max(7)
         && continuation_columns.iter().filter(|&&value| value).count() >= 3;
     // Numbered list items ("1. Restructuring ...") woven beside sidebar
     // fragments: the first column is a monotone ordinal-prefixed list.
-    let ordinal_prefix_list = table.columns.len() == 2 && table.cells.len() >= 4 && {
-        let mut values: Vec<u32> = Vec::new();
-        let mut filled_first = 0;
-        for row in &table.cells {
-            let first = row.first().map(|s| s.trim()).unwrap_or("");
-            if first.is_empty() {
-                continue;
-            }
-            filled_first += 1;
-            let mut parts = first.splitn(2, char::is_whitespace);
-            let marker = parts.next().unwrap_or("");
-            let rest = parts.next().unwrap_or("").trim();
-            if marker.len() <= 4
-                && marker.ends_with(['.', ')'])
-                && marker[..marker.len() - 1]
-                    .chars()
-                    .all(|c| c.is_ascii_digit())
-                && !marker[..marker.len() - 1].is_empty()
-                && rest.split_whitespace().count() >= 2
-            {
-                if let Ok(v) = marker[..marker.len() - 1].parse() {
-                    values.push(v);
+    let ordinal_prefix_list =
+        !ordinal_header_blocks && table.columns.len() == 2 && table.cells.len() >= 4 && {
+            let mut values: Vec<u32> = Vec::new();
+            let mut filled_first = 0;
+            for row in &table.cells {
+                let first = row.first().map(|s| s.trim()).unwrap_or("");
+                if first.is_empty() {
+                    continue;
+                }
+                filled_first += 1;
+                let mut parts = first.splitn(2, char::is_whitespace);
+                let marker = parts.next().unwrap_or("");
+                let rest = parts.next().unwrap_or("").trim();
+                if marker.len() <= 4
+                    && marker.ends_with(['.', ')'])
+                    && marker[..marker.len() - 1]
+                        .chars()
+                        .all(|c| c.is_ascii_digit())
+                    && !marker[..marker.len() - 1].is_empty()
+                    && rest.split_whitespace().count() >= 2
+                {
+                    if let Ok(v) = marker[..marker.len() - 1].parse() {
+                        values.push(v);
+                    }
                 }
             }
-        }
-        filled_first >= 4
-            && values.len() * 10 >= filled_first * 7
-            && values.windows(2).all(|w| w[1] >= w[0])
-    };
+            filled_first >= 4
+                && values.len() * 10 >= filled_first * 7
+                && values.windows(2).all(|w| w[1] >= w[0])
+        };
     let is_parallel = is_parallel
         || word_fragment_grid
         || ordinal_list

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -564,7 +564,7 @@ fn is_running_furniture_table(
 /// table-shaped candidates remain eligible on chart pages.
 fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     if table.kind != crate::tables::TableKind::Data
-        || !(2..=3).contains(&table.columns.len())
+        || !(2..=6).contains(&table.columns.len())
         || table.rows.len() < 3
     {
         return false;
@@ -622,16 +622,26 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // direct physical-row transition from an unterminated cell in the same
     // column. This is the shape produced when independent prose columns are
     // accidentally projected onto one table grid.
+    // Prose flowing through a grid is often interrupted by empty cells
+    // (the interleaved fragment occupies the other column on that row), so
+    // each cell is compared against the last non-empty cell above it in the
+    // same column, not just the immediately preceding row.
     let mut continuation_fragments = 0;
     let mut continuation_columns = vec![false; table.columns.len()];
-    for rows in table.cells.windows(2) {
-        for (column, has_continuation) in continuation_columns.iter_mut().enumerate() {
-            let previous = rows[0].get(column).map(String::as_str).unwrap_or("");
-            let current = rows[1].get(column).map(String::as_str).unwrap_or("");
-            if is_cross_row_prose_continuation(previous, current) {
-                continuation_fragments += 1;
-                *has_continuation = true;
+    for (column, has_continuation) in continuation_columns.iter_mut().enumerate() {
+        let mut previous_non_empty: Option<&str> = None;
+        for row in &table.cells {
+            let current = row.get(column).map(String::as_str).unwrap_or("");
+            if current.trim().is_empty() {
+                continue;
             }
+            if let Some(previous) = previous_non_empty {
+                if is_cross_row_prose_continuation(previous, current) {
+                    continuation_fragments += 1;
+                    *has_continuation = true;
+                }
+            }
+            previous_non_empty = Some(current);
         }
     }
 
@@ -640,6 +650,50 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     // produces: the "header" is then just two short line fragments at the
     // top of parallel prose columns.
     let header_blocks = has_compact_header && continuation_fragments <= table.cells.len();
+
+    // Citation blocks over-fragmented into wide grids: nearly every cell is
+    // a bare word and the rows read on as prose. Real wide tables carry
+    // numbers, units, or multi-word values.
+    let single_token_alpha = table
+        .cells
+        .iter()
+        .flatten()
+        .filter(|cell| {
+            let t = cell.trim();
+            !t.is_empty()
+                && t.split_whitespace().count() == 1
+                && t.chars().filter(|c| c.is_alphabetic()).count() * 2 >= t.chars().count().max(1)
+        })
+        .count();
+    let word_fragment_grid = table.columns.len() >= 4
+        && non_empty >= 8
+        && single_token_alpha * 4 >= non_empty * 3
+        && continuation_fragments >= 4
+        && continuation_columns.iter().filter(|&&value| value).count() >= 2;
+
+    // Numbered lists projected onto a two-column grid: the first column is
+    // list markers ("1.", "2)", …), the second the item text. Rendering
+    // these as tables loses the list; the page flow keeps it.
+    let ordinal_list = table.columns.len() == 2 && table.cells.len() >= 4 && {
+        let mut markers = 0;
+        let mut filled_first = 0;
+        for row in &table.cells {
+            let first = row.first().map(|s| s.trim()).unwrap_or("");
+            if first.is_empty() {
+                continue;
+            }
+            filled_first += 1;
+            let is_marker = first.len() <= 4
+                && first.ends_with(['.', ')'])
+                && first[..first.len() - 1].chars().all(|c| c.is_ascii_digit())
+                && !first[..first.len() - 1].is_empty();
+            if is_marker {
+                markers += 1;
+            }
+        }
+        filled_first >= 4 && markers * 10 >= filled_first * 7
+    };
+
     let is_parallel = !header_blocks
         && non_empty >= 5
         // Independent prose columns have asynchronous line/paragraph breaks;
@@ -657,6 +711,67 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
             || (rows_with_parallel_prose >= 1 && has_numbered_section_heading))
         && continuation_fragments >= 3
         && continuation_columns.iter().filter(|&&value| value).count() >= 2;
+    let not_fully_populated = non_empty < table.cells.len() * table.columns.len();
+    // Small 2-column weaves rarely accumulate 3 cross-row continuations —
+    // there aren't enough rows — but long prose in both columns plus a
+    // continuation in each is already the projection signature.
+    let tiny_grid_weave = !header_blocks
+        && table.cells.len() <= 4
+        && not_fully_populated
+        && long_prose >= 4
+        && continuation_fragments >= 2
+        && continuation_columns.iter().filter(|&&value| value).count() >= 2;
+    // Wide multi-column projections of page text: continuations outnumber
+    // the rows and appear in 3+ columns. Genuine wide tables wrap inside
+    // one or two description columns; they never flow everywhere at once.
+    // Long prose cells are required: reference tables whose wrapped
+    // entries continue in every column (short citation fragments) look
+    // continuation-dominated too, but they never read as running text.
+    let continuation_dominated = not_fully_populated
+        && long_prose >= 4
+        // ...and long prose must be a real share of the grid: a large data
+        // table with a handful of wordy cells and many wrapped-cell
+        // continuations is not a weave.
+        && long_prose * 10 >= non_empty
+        && continuation_fragments >= table.cells.len().max(8)
+        && continuation_columns.iter().filter(|&&value| value).count() >= 3;
+    // Numbered list items ("1. Restructuring ...") woven beside sidebar
+    // fragments: the first column is a monotone ordinal-prefixed list.
+    let ordinal_prefix_list = table.columns.len() == 2 && table.cells.len() >= 4 && {
+        let mut values: Vec<u32> = Vec::new();
+        let mut filled_first = 0;
+        for row in &table.cells {
+            let first = row.first().map(|s| s.trim()).unwrap_or("");
+            if first.is_empty() {
+                continue;
+            }
+            filled_first += 1;
+            let mut parts = first.splitn(2, char::is_whitespace);
+            let marker = parts.next().unwrap_or("");
+            let rest = parts.next().unwrap_or("").trim();
+            if marker.len() <= 4
+                && marker.ends_with(['.', ')'])
+                && marker[..marker.len() - 1]
+                    .chars()
+                    .all(|c| c.is_ascii_digit())
+                && !marker[..marker.len() - 1].is_empty()
+                && rest.split_whitespace().count() >= 2
+            {
+                if let Ok(v) = marker[..marker.len() - 1].parse() {
+                    values.push(v);
+                }
+            }
+        }
+        filled_first >= 4
+            && values.len() * 10 >= filled_first * 7
+            && values.windows(2).all(|w| w[1] >= w[0])
+    };
+    let is_parallel = is_parallel
+        || word_fragment_grid
+        || ordinal_list
+        || ordinal_prefix_list
+        || tiny_grid_weave
+        || continuation_dominated;
     log::debug!(
         "chart table hypothesis: {}x{}, non_empty={}, long_prose={}, parallel_rows={}/{}, section_heading={}, continuation_fragments={}, continuation_columns={}, reject={}",
         table.rows.len(),
@@ -2632,6 +2747,218 @@ mod tests {
             left_image < right_image,
             "chart blocks must retain column order when physical bands are present:\n{markdown}"
         );
+    }
+
+    #[test]
+    fn weave_and_list_projections_are_rejected() {
+        // Tiny 2-column weave: prose continues down each column across an
+        // empty cell, so lookback (not just adjacent rows) must connect it.
+        let tiny_weave = crate::tables::Table::new(
+            vec![70.0, 300.0],
+            vec![320.0, 300.0, 280.0],
+            vec![
+                vec![
+                    "spawning aggregations, 45% were unknown, 33% were".into(),
+                    "of exploited grouper aggregations globally, as noted by".into(),
+                ],
+                vec![
+                    "".into(),
+                    "fisher interviews, monitoring, or underwater surveys done".into(),
+                ],
+                vec![
+                    "decreasing, and 5% were already gone from the region".into(),
+                    "records collected over the previous two survey decades".into(),
+                ],
+            ],
+            (0..5).collect(),
+        );
+        assert!(is_parallel_prose_table(&tiny_weave), "tiny grid weave");
+
+        // Wide projection: continuations outnumber rows and flow in 3+
+        // columns of long prose fragments.
+        let wide_weave = crate::tables::Table::new(
+            vec![60.0, 160.0, 260.0, 360.0, 460.0],
+            vec![400.0, 380.0, 360.0, 340.0, 320.0, 300.0],
+            vec![
+                vec![
+                    "check all of your emotions carefully before".into(),
+                    "causes strong visceral reactions and it".into(),
+                    "if a claim ever seems clearly designed to".into(),
+                    "chapters we are still reviewing in the".into(),
+                    "".into(),
+                ],
+                vec![
+                    "sharing anything further with your own".into(),
+                    "should always give you pause and reason".into(),
+                    "provoke rather than genuinely inform the".into(),
+                    "focusing our efforts on researching a".into(),
+                    "".into(),
+                ],
+                vec![
+                    "closest colleagues and all of their many".into(),
+                    "before finally deciding to pass along the".into(),
+                    "reader it deserves careful scrutiny and".into(),
+                    "wicked problem, and these are certainly".into(),
+                    "".into(),
+                ],
+                vec![
+                    "networks of trusted contacts and friends".into(),
+                    "message along to anyone else who asks it".into(),
+                    "verification through multiple separate and".into(),
+                    "not simple topics anyone can summarize".into(),
+                    "".into(),
+                ],
+                vec![
+                    "who might spread it much further still and".into(),
+                    "in the entire organization or well beyond".into(),
+                    "independent sources of record and archive".into(),
+                    "quickly for the busy executive readers".into(),
+                    "".into(),
+                ],
+                vec![
+                    "without ever checking any part of it first".into(),
+                    "the original recipients list and beyond it".into(),
+                    "before acting on the contents of anything".into(),
+                    "who needs only the short version of this".into(),
+                    "".into(),
+                ],
+            ],
+            (0..24).collect(),
+        );
+        assert!(
+            is_parallel_prose_table(&wide_weave),
+            "continuation-dominated"
+        );
+
+        // Reference-table protection: wrapped short citation fragments
+        // continue in every column but never read as running text
+        // (long_prose = 0) — must stay a table.
+        let reference_grid = crate::tables::Table::new(
+            vec![70.0, 220.0, 370.0],
+            vec![400.0, 380.0, 360.0, 340.0, 320.0, 300.0],
+            vec![
+                vec![
+                    "§1.338(h)(10)-1(f)".into(),
+                    "§1.331-1(d), and".into(),
+                    "§1.331-1T(d) and".into(),
+                ],
+                vec!["".into(), "§1.332-6".into(), "§1.332-6T".into()],
+                vec!["§1.382-2T(h)(4)(vi)".into(), "section".into(), "11T".into()],
+                vec!["§1.382-8(a)".into(), "and (c)(5) of this".into(), "".into()],
+                vec![
+                    "The last sentence of".into(),
+                    "paragraph (a)(2)(ii)".into(),
+                    "paragraph (a) of".into(),
+                ],
+                vec![
+                    "§1.382-2T(h)(4)(vi)(B)".into(),
+                    "section".into(),
+                    "11T".into(),
+                ],
+            ],
+            (0..16).collect(),
+        );
+        assert!(!is_parallel_prose_table(&reference_grid), "reference grid");
+
+        // Citation block over-fragmented into a wide word grid.
+        let word_grid = crate::tables::Table::new(
+            vec![60.0, 130.0, 200.0, 270.0, 340.0, 410.0],
+            vec![400.0, 380.0, 360.0, 340.0],
+            vec![
+                vec![
+                    "Songfang".into(),
+                    "Huang,".into(),
+                    "and".into(),
+                    "Fei Huang.".into(),
+                    "2023.".into(),
+                    "Rrhf:".into(),
+                ],
+                vec![
+                    "Rank".into(),
+                    "responses".into(),
+                    "to align".into(),
+                    "language".into(),
+                    "models".into(),
+                    "with".into(),
+                ],
+                vec![
+                    "human".into(),
+                    "feedback".into(),
+                    "without".into(),
+                    "tears.".into(),
+                    "arXiv".into(),
+                    "preprint".into(),
+                ],
+                vec![
+                    "arXiv:2304".into(),
+                    "".into(),
+                    "".into(),
+                    "".into(),
+                    "".into(),
+                    "".into(),
+                ],
+            ],
+            (0..19).collect(),
+        );
+        assert!(is_parallel_prose_table(&word_grid), "word-fragment grid");
+
+        // Numbered list projected onto marker|text columns.
+        let marker_list = crate::tables::Table::new(
+            vec![70.0, 100.0],
+            vec![400.0, 380.0, 360.0, 340.0],
+            vec![
+                vec!["1.".into(), "Edward Bernays".into()],
+                vec!["2.".into(), "Wikipedia. Public Relations".into()],
+                vec!["3.".into(), "Pinterest. Retrieved June 10, 2021.".into()],
+                vec!["4.".into(), "Museum of Public Relations".into()],
+            ],
+            (0..8).collect(),
+        );
+        assert!(is_parallel_prose_table(&marker_list), "ordinal marker list");
+
+        // Numbered list items woven beside sidebar fragments.
+        let prefixed_list = crate::tables::Table::new(
+            vec![70.0, 340.0],
+            vec![400.0, 380.0, 360.0, 340.0],
+            vec![
+                vec![
+                    "1. Restructuring the administration of the program".into(),
+                    "".into(),
+                ],
+                vec![
+                    "2. Shifting priorities for resource allocation".into(),
+                    "freedom to decide".into(),
+                ],
+                vec![
+                    "3. Pursuing regulatory reform across agencies".into(),
+                    "".into(),
+                ],
+                vec![
+                    "4. Reinvesting savings from system reorganization".into(),
+                    "control over resources".into(),
+                ],
+            ],
+            (0..6).collect(),
+        );
+        assert!(
+            is_parallel_prose_table(&prefixed_list),
+            "ordinal-prefixed list"
+        );
+
+        // Ranked data tables use bare numbers (no list-marker punctuation)
+        // and stay tables.
+        let ranked = crate::tables::Table::new(
+            vec![70.0, 340.0],
+            vec![400.0, 380.0, 360.0, 340.0],
+            vec![
+                vec!["1".into(), "Golden Eagle Aviation".into()],
+                vec!["2".into(), "Northern Star Freight".into()],
+                vec!["3".into(), "Pacific Rim Cargo".into()],
+                vec!["4".into(), "Atlas Air Services".into()],
+            ],
+            (0..8).collect(),
+        );
+        assert!(!is_parallel_prose_table(&ranked), "ranked table");
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -1440,13 +1440,20 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     // perfect: every last-column cell a page number, values strictly
     // increasing, and every first-column cell a multi-word title.
     // Leader-dot residue ("..19") only reads as a page number when the
-    // fragment actually shows leader dots somewhere; otherwise a leading
-    // period is decimal notation and must not be stripped.
+    // page column itself (or a dedicated dots-only leader cell) shows
+    // leader dots; an ellipsis inside a title is prose, and a leading
+    // period elsewhere is decimal notation that must not be stripped.
+    let page_col = num_cols - 1;
     let has_leader_dots = cells.iter().any(|row| {
-        row.iter().any(|c| {
+        let page_cell_leader = row.get(page_col).is_some_and(|c| {
             let t = c.trim();
-            t.starts_with("..") || t.starts_with('\u{2026}') || t.ends_with("..")
-        })
+            t.starts_with("..") || t.starts_with('\u{2026}')
+        });
+        let dots_only_cell = row.iter().any(|c| {
+            let t = c.trim();
+            t.len() >= 2 && t.chars().all(|ch| ch == '.' || ch == '\u{2026}')
+        });
+        page_cell_leader || dots_only_cell
     });
     fn clean_page_cell(cell: &str, has_leader_dots: bool) -> &str {
         if has_leader_dots {
@@ -1478,16 +1485,28 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
             });
         // Short fragments carry little evidence: ascending numbers with
         // multi-word labels also describe a small data summary. Require a
-        // contents-specific signal — every title carries a section-number
-        // token ("Section 6.3", "2.1.4 Methods", "4. A Jewel …") or the
-        // fragment shows leader dots.
+        // contents-specific signal — every title carries genuine section
+        // syntax ("Section 6.3", "2.1.4 Methods", "4. A Jewel …") or the
+        // fragment shows leader dots. Years, IDs, and measurements do not
+        // qualify: a bare all-digit token only counts as an ordinal when
+        // it starts the title with a list-marker suffix, and dotted tokens
+        // must be multi-part section numbers with short groups.
         let section_numbered = |title: &str| {
-            title.split_whitespace().any(|tok| {
+            let mut words = title.split_whitespace();
+            let first = words.next().unwrap_or("");
+            let leading_ordinal = first.len() <= 3
+                && first.ends_with(['.', ')'])
+                && !first[..first.len() - 1].is_empty()
+                && first[..first.len() - 1].chars().all(|c| c.is_ascii_digit());
+            let dotted_section = title.split_whitespace().any(|tok| {
                 let tok = tok.trim_end_matches([':', '.']);
-                !tok.is_empty()
-                    && tok.chars().all(|c| c.is_ascii_digit() || c == '.')
-                    && tok.chars().any(|c| c.is_ascii_digit())
-            })
+                let groups: Vec<&str> = tok.split('.').collect();
+                groups.len() >= 2
+                    && groups.iter().all(|g| {
+                        !g.is_empty() && g.len() <= 3 && g.chars().all(|c| c.is_ascii_digit())
+                    })
+            });
+            leading_ordinal || dotted_section
         };
         if !has_leader_dots && !titles.iter().all(|t| section_numbered(t)) {
             return false;

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -1439,13 +1439,29 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     // carry less evidence than a full contents page, so they must be
     // perfect: every last-column cell a page number, values strictly
     // increasing, and every first-column cell a multi-word title.
+    // Leader-dot residue ("..19") only reads as a page number when the
+    // fragment actually shows leader dots somewhere; otherwise a leading
+    // period is decimal notation and must not be stripped.
+    let has_leader_dots = cells.iter().any(|row| {
+        row.iter().any(|c| {
+            let t = c.trim();
+            t.starts_with("..") || t.starts_with('\u{2026}') || t.ends_with("..")
+        })
+    });
+    fn clean_page_cell(cell: &str, has_leader_dots: bool) -> &str {
+        if has_leader_dots {
+            cell.trim_start_matches(['.', '\u{2026}', ' '])
+        } else {
+            cell.trim()
+        }
+    }
     if cells.len() < 5 {
         let last_col = num_cols - 1;
         let vals: Vec<u32> = cells
             .iter()
             .filter_map(|row| {
                 let cell = row.get(last_col).map(String::as_str).unwrap_or("");
-                page_number_value(cell.trim_start_matches(['.', '\u{2026}', ' ']))
+                page_number_value(clean_page_cell(cell, has_leader_dots))
             })
             .collect();
         // A fragment row can lose its title to a neighboring grid; judge
@@ -1460,6 +1476,22 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
             && titles.iter().all(|c| {
                 c.split_whitespace().count() >= 2 && c.chars().any(|ch| ch.is_alphabetic())
             });
+        // Short fragments carry little evidence: ascending numbers with
+        // multi-word labels also describe a small data summary. Require a
+        // contents-specific signal — every title carries a section-number
+        // token ("Section 6.3", "2.1.4 Methods", "4. A Jewel …") or the
+        // fragment shows leader dots.
+        let section_numbered = |title: &str| {
+            title.split_whitespace().any(|tok| {
+                let tok = tok.trim_end_matches([':', '.']);
+                !tok.is_empty()
+                    && tok.chars().all(|c| c.is_ascii_digit() || c == '.')
+                    && tok.chars().any(|c| c.is_ascii_digit())
+            })
+        };
+        if !has_leader_dots && !titles.iter().all(|t| section_numbered(t)) {
+            return false;
+        }
         return vals.len() == cells.len() && titles_ok && vals.windows(2).all(|w| w[1] > w[0]);
     }
     let last = num_cols - 1;
@@ -1470,7 +1502,7 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     // "Mineral | CEC" tables from real contents. Check the actual first row,
     // not the first non-empty one, so a blank header cell still rejects.
     let first_last = cells[0].get(last).map(|s| s.trim()).unwrap_or("");
-    if page_number_value(first_last.trim_start_matches(['.', '\u{2026}', ' '])).is_none() {
+    if page_number_value(clean_page_cell(first_last, has_leader_dots)).is_none() {
         return false;
     }
 
@@ -1483,7 +1515,7 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
             continue;
         }
         filled += 1;
-        if let Some(v) = page_number_value(cell.trim_start_matches(['.', '\u{2026}', ' '])) {
+        if let Some(v) = page_number_value(clean_page_cell(cell, has_leader_dots)) {
             page_vals.push(v);
         }
     }

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -1432,8 +1432,35 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     let num_cols = cells.first().map(|r| r.len()).unwrap_or(0);
     // A page-number TOC is a narrow list (title + page, optionally a leader
     // column). Wider grids are data tables, not contents.
-    if !(2..=3).contains(&num_cols) || cells.len() < 5 {
+    if !(2..=3).contains(&num_cols) || cells.len() < 2 {
         return false;
+    }
+    // 3-4 row fragments (a chapter's sections split into their own grid)
+    // carry less evidence than a full contents page, so they must be
+    // perfect: every last-column cell a page number, values strictly
+    // increasing, and every first-column cell a multi-word title.
+    if cells.len() < 5 {
+        let last_col = num_cols - 1;
+        let vals: Vec<u32> = cells
+            .iter()
+            .filter_map(|row| {
+                let cell = row.get(last_col).map(String::as_str).unwrap_or("");
+                page_number_value(cell.trim_start_matches(['.', '\u{2026}', ' ']))
+            })
+            .collect();
+        // A fragment row can lose its title to a neighboring grid; judge
+        // only the titles that are present.
+        let titles: Vec<&str> = cells
+            .iter()
+            .filter_map(|row| row.first())
+            .map(|c| c.trim())
+            .filter(|c| !c.is_empty())
+            .collect();
+        let titles_ok = titles.len() >= 2
+            && titles.iter().all(|c| {
+                c.split_whitespace().count() >= 2 && c.chars().any(|ch| ch.is_alphabetic())
+            });
+        return vals.len() == cells.len() && titles_ok && vals.windows(2).all(|w| w[1] > w[0]);
     }
     let last = num_cols - 1;
 
@@ -1443,7 +1470,7 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
     // "Mineral | CEC" tables from real contents. Check the actual first row,
     // not the first non-empty one, so a blank header cell still rejects.
     let first_last = cells[0].get(last).map(|s| s.trim()).unwrap_or("");
-    if page_number_value(first_last).is_none() {
+    if page_number_value(first_last.trim_start_matches(['.', '\u{2026}', ' '])).is_none() {
         return false;
     }
 
@@ -1456,7 +1483,7 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
             continue;
         }
         filled += 1;
-        if let Some(v) = page_number_value(cell) {
+        if let Some(v) = page_number_value(cell.trim_start_matches(['.', '\u{2026}', ' '])) {
             page_vals.push(v);
         }
     }
@@ -2631,6 +2658,44 @@ mod tests {
             !detect_tables(&items, 12.0, false).is_empty(),
             "adjacent old/new fragments must retain the live revised cells"
         );
+    }
+
+    #[test]
+    fn small_toc_fragments_are_classified() {
+        // 3-row section fragment: multi-word titles, strictly ascending pages.
+        let rows = |v: &[(&str, &str)]| -> Vec<Vec<String>> {
+            v.iter()
+                .map(|(a, b)| vec![a.to_string(), b.to_string()])
+                .collect()
+        };
+        assert!(is_table_of_contents(&rows(&[
+            ("Section 4.1: Examining Relationships", "29"),
+            ("Section 4.2: Correlation Assumptions", "31"),
+            ("Section 4.3: Chapter Four Self-Test", "33"),
+        ])));
+        // 2-row fragment under the same strict rules.
+        assert!(is_table_of_contents(&rows(&[
+            ("Section 6.3 Repeated Measures ANOVA", "54"),
+            ("Section 6.4: Chapter Six Self-Test", "62"),
+        ])));
+        // Leader dots glued to the page number, one title lost to a
+        // neighboring grid.
+        assert!(is_table_of_contents(&rows(&[
+            ("4. A Jewel in the Austrian Crown.", "..19"),
+            ("5. Meeting the Relatives..", "..37"),
+            ("", "..41"),
+            ("7. To the Bottom of the World......", ".53"),
+        ])));
+        // Single-word labels with ascending numbers stay a data table.
+        assert!(!is_table_of_contents(&rows(&[
+            ("Total", "54"),
+            ("Margin", "62"),
+        ])));
+        // Non-ascending page cells stay a data table.
+        assert!(!is_table_of_contents(&rows(&[
+            ("Net income before adjustments", "54"),
+            ("Gross margin excluding one-offs", "42"),
+        ])));
     }
 
     #[test]

--- a/src/tables/detect_heuristic.rs
+++ b/src/tables/detect_heuristic.rs
@@ -1494,7 +1494,7 @@ pub(super) fn is_page_number_toc(cells: &[Vec<String>]) -> bool {
         let section_numbered = |title: &str| {
             let mut words = title.split_whitespace();
             let first = words.next().unwrap_or("");
-            let leading_ordinal = first.len() <= 3
+            let leading_ordinal = first.len() <= 4
                 && first.ends_with(['.', ')'])
                 && !first[..first.len() - 1].is_empty()
                 && first[..first.len() - 1].chars().all(|c| c.is_ascii_digit());

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -2082,6 +2082,10 @@ fn detect_row_stripe_table(
         debug!("  row-stripe rejected: dominant prose cell (chart/figure region over body text)");
         return None;
     }
+    if row_stripe_cells_are_prose(&cells) {
+        debug!("  row-stripe rejected: prose fragments behind stripes");
+        return None;
+    }
 
     let column_centers: Vec<f32> = (0..num_cols)
         .map(|c| (col_edges[c] + col_edges[c + 1]) / 2.0)
@@ -2126,6 +2130,39 @@ fn has_dominant_prose_cell(cells: &[Vec<String>]) -> bool {
         }
     }
     max_cell_words >= 60 && max_cell_words * 3 >= total_words
+}
+
+/// Stripes drawn behind flowing body text produce a grid of paragraph
+/// fragments: nearly every cell is long, multi-sentence prose. Real
+/// row-stripe tables (zebra-striped financial rows) carry short values.
+/// Mirrors the cell-rect prose-in-frame cap.
+fn row_stripe_cells_are_prose(cells: &[Vec<String>]) -> bool {
+    let num_cols = cells.iter().map(Vec::len).max().unwrap_or(0);
+    let mut counted = 0usize;
+    let mut total_chars = 0usize;
+    let mut sentence_cells = 0usize;
+    let mut sentence_columns = vec![false; num_cols];
+    for row in cells {
+        for (col, cell) in row.iter().enumerate() {
+            let t = cell.trim();
+            if t.is_empty() {
+                continue;
+            }
+            counted += 1;
+            total_chars += t.chars().count();
+            if t.split_whitespace().count() >= 10 && t.contains(['.', ',']) {
+                sentence_cells += 1;
+                sentence_columns[col] = true;
+            }
+        }
+    }
+    // Flowing text fills every column with sentences; a genuine striped
+    // narrative table (Q&A, requirements) keeps them in one description
+    // column beside short labels.
+    counted > 0
+        && total_chars / counted > 90
+        && sentence_cells * 2 >= counted
+        && sentence_columns.iter().filter(|&&v| v).count() >= 2
 }
 
 fn row_stripe_is_sparse_prose_outline(cells: &[Vec<String>]) -> bool {
@@ -3435,6 +3472,32 @@ fn cluster_x_positions(items: &[(usize, &TextItem)], min_threshold: f32) -> Vec<
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn row_stripe_prose_fragments_are_rejected() {
+        let prose = vec![
+            vec![
+                "The other potentially invasive fouler is the tropical American species in low abundances near the harbor entrance today."
+                    .to_string(),
+                "Mytilopsis sallei and M. adamsi which has been recorded invasive in Singapore, Australia, Thailand among other regions of the coast."
+                    .to_string(),
+            ],
+            vec![
+                "Figure 3. Non-indigenous macrofoulers from Manila Bay with IAS, based on more intensive biofouling ecological monitoring efforts."
+                    .to_string(),
+                "Newer estimates on the number of possible IAS in Manila Bay is likely more than 30 species, when research started on this topic."
+                    .to_string(),
+            ],
+        ];
+        assert!(super::row_stripe_cells_are_prose(&prose));
+
+        let zebra = vec![
+            vec!["Revenue".to_string(), "$1,240".to_string()],
+            vec!["Cost of goods".to_string(), "$310".to_string()],
+            vec!["Net margin".to_string(), "24%".to_string()],
+        ];
+        assert!(!super::row_stripe_cells_are_prose(&zebra));
+    }
+
     use super::*;
     use crate::types::ItemType;
 

--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -75,7 +75,19 @@ fn format_toc_as_list(cells: &[Vec<String>], footnotes: &[String]) -> String {
             continue;
         };
 
+        // Leader dots glued to the page number ("..19") still read as a
+        // page cell; the dots are the leader, not the value.
         let last_cell = trimmed[last_idx];
+        let last_cell = if last_cell.starts_with('.') || last_cell.starts_with('\u{2026}') {
+            let stripped = last_cell.trim_start_matches(['.', '\u{2026}', ' ']);
+            if !stripped.is_empty() && is_page_number_cell(stripped) {
+                stripped
+            } else {
+                last_cell
+            }
+        } else {
+            last_cell
+        };
         let last_is_page = is_page_number_cell(last_cell);
 
         let (title_cells, trailing) = if last_is_page && last_idx > 0 {


### PR DESCRIPTION
Two structural-quality fixes:

- **Page-flow table projections**: multi-column prose weaves, over-fragmented citation blocks, numbered lists, and small TOC fragments were being rendered as tables by the heuristic and row-stripe detectors. The parallel-prose veto now covers these shapes (continuation lookback across empty cells, continuation-dominance with a proportional long-prose share, word-fragment and ordinal-list branches, strict small-TOC classification).
- **Base font size correction**: on pages where item-count font stats let footnotes outvote the body, body paragraphs were promoted to headings wholesale. The base is now treated as a prior and corrected when an implausible share of text lines clears the heading gate.

Unit tests cover each new branch plus protective negatives (wordy reference grids, ranked tables, zebra-striped narrative tables stay tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects page‑flow content misclassified as tables and fixes base font size picks that wrongly promoted body text to headings.

- Page‑flow table veto: supports 2–6 columns with continuation lookback across empty cells; adds branches for word‑fragment citation grids (only when cells are mostly distinct), marker|text two‑column lists and ordinal‑prefixed lists (first column must look like a list; ordinal markers up to 3 digits), tiny two‑column weaves, and wide continuation‑dominated grids gated by a proportional long‑prose share and continuations > rows; honors compact‑header protection.
- Row‑stripe guard: rejects stripes drawn behind flowing prose (sentence‑heavy cells across 2+ columns), so chart/figure stripes don’t become tables.
- TOC fragments: classifies 2–4 row fragments only when the last column is strictly ascending page numbers and titles are multi‑word; leader stripping is conditional and scoped to the page column or dots‑only cells; formatter recognizes leader‑glued page cells; 2‑row fragments require genuine section syntax (leading ordinal up to three digits or dotted section numbers).
- Base font size: treats the provided base as a prior and adopts the dominant promoted size only when ≥1/3 of character‑weighted lines clear the 1.2× gate and those lines read like body text (long lines with mostly lowercase starts; uncased scripts count as prose‑shaped); prevents wholesale heading promotion and handles narrow wrapped columns.

<sup>Written for commit 84e305b2f63b85c3ff1a992ae21c328905cb0bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

