### PR TITLE
fix(rtl): only letters vote in RTL text detection

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -2850,6 +2850,25 @@ mod tests {
     }
 
     #[test]
+    fn test_is_rtl_text_weak_chars_do_not_vote() {
+        // Arabic-Indic digits (U+0660-0669) are bidi class AN, not strong RTL:
+        // a digits-only line must stay neutral, like ASCII-digit lines.
+        assert!(!is_rtl_text(["\u{0661}\u{0662}\u{0663}"].iter()));
+        // Extended Arabic-Indic digits (U+06F0-06F9) likewise
+        assert!(!is_rtl_text(["\u{06F1}\u{06F2}\u{06F3}"].iter()));
+        // Arabic decimal/thousands separators (U+066B/U+066C) with digits
+        assert!(!is_rtl_text(
+            ["\u{0661}\u{066B}\u{0662}\u{0663}\u{066C}\u{0664}"].iter()
+        ));
+        // Arabic letters alongside Arabic-Indic digits → still RTL
+        assert!(is_rtl_text(
+            ["\u{0645}\u{0631}\u{062D}\u{0628}\u{0627} \u{0661}\u{0662}"].iter()
+        ));
+        // Arabic letters with combining marks (NSM) → still RTL
+        assert!(is_rtl_text(["\u{0645}\u{064E}\u{0631}\u{064D}"].iter()));
+    }
+
+    #[test]
     fn test_rtl_line_sorting() {
         let mut items = vec![
             TextItem {

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -2866,6 +2866,12 @@ mod tests {
         ));
         // Arabic letters with combining marks (NSM) → still RTL
         assert!(is_rtl_text(["\u{0645}\u{064E}\u{0631}\u{064D}"].iter()));
+        // Combining marks alone are NSM, not strong RTL, even though they are
+        // Other_Alphabetic: harakat-only and niqqud-only lines stay neutral
+        assert!(!is_rtl_text(["\u{064E}\u{064F}\u{0650}\u{0651}"].iter()));
+        assert!(!is_rtl_text(["\u{05B8}\u{05B4}\u{05BC}"].iter()));
+        // Marks + Arabic-Indic digits (the full weak-only mix) → still neutral
+        assert!(!is_rtl_text(["\u{0661}\u{064E}\u{0662}"].iter()));
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -132,11 +132,13 @@ where
     // Only letters vote: the RTL blocks embed weak-directionality characters
     // (Arabic-Indic digits, number separators, combining marks) that are bidi
     // class AN/NSM per UAX #9, not strong RTL — a digits-only line must stay
-    // neutral, matching how ASCII digits don't vote LTR.
+    // neutral, matching how ASCII digits don't vote LTR. Combining marks need
+    // their own check: vowel points like U+064E are Other_Alphabetic, so
+    // is_alphabetic() alone would let a marks-only line vote RTL.
     let (mut rtl, mut ltr) = (0u32, 0u32);
     for t in texts {
         for c in t.as_ref().chars() {
-            if !c.is_alphabetic() {
+            if !c.is_alphabetic() || unicode_normalization::char::is_combining_mark(c) {
                 continue;
             }
             if is_rtl_char(c) {

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -129,12 +129,19 @@ where
     I: Iterator<Item = S>,
     S: AsRef<str>,
 {
+    // Only letters vote: the RTL blocks embed weak-directionality characters
+    // (Arabic-Indic digits, number separators, combining marks) that are bidi
+    // class AN/NSM per UAX #9, not strong RTL — a digits-only line must stay
+    // neutral, matching how ASCII digits don't vote LTR.
     let (mut rtl, mut ltr) = (0u32, 0u32);
     for t in texts {
         for c in t.as_ref().chars() {
+            if !c.is_alphabetic() {
+                continue;
+            }
             if is_rtl_char(c) {
                 rtl += 1;
-            } else if c.is_alphabetic() && !is_cjk_char(c) {
+            } else if !is_cjk_char(c) {
                 ltr += 1;
             }
         }


### PR DESCRIPTION
## Problem

`is_rtl_text` counts any character in the RTL Unicode blocks as an RTL vote, but the Arabic blocks embed weak-directionality characters — Arabic-Indic digits (U+0660–0669, U+06F0–06F9), number separators (U+066B/U+066C), and combining marks — that are bidi class AN/NSM per UAX #9, not strong RTL.

A line containing only Arabic-Indic digits therefore votes RTL (`rtl > 0, ltr = 0`) and `sort_line_items` reverses its item order — producing digit-reversed numbers like `0,11` instead of `11,0` — while the equivalent ASCII-digit line stays neutral.

## Fix

Require `is_alphabetic()` for the RTL vote, mirroring the rule the LTR side already had: only letters vote in either direction. Digit-only and punctuation-only lines keep their natural left-to-right order. Divergence is confined to lines with no strong RTL letter; lines with Arabic/Hebrew letters are unaffected.

## Testing

- New unit tests: Arabic-Indic digit-only lines (plain, extended, and with number separators) are not RTL; Arabic letters + Arabic-Indic digits still RTL; letters + combining marks still RTL.
- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` all pass.
- Full-corpus A/B against a main-built binary: only Arabic-content documents change, restoring correct digit order in numeric fragments (e.g. a temperature-gradient table now reads 11,0 / 20,0 / 32,0 instead of digit-reversed values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only letters vote in RTL text detection, and we now exclude combining marks. Previously any RTL-block character (digits, separators, combining marks) voted RTL and reversed digit-only lines; digit-, punctuation-, and marks-only lines now stay neutral and keep left-to-right order, while lines with Arabic/Hebrew letters remain RTL.

- Restricts `is_rtl_text` to count votes only for alphabetic, non-combining chars (via `unicode_normalization::char::is_combining_mark`); mirrors the LTR rule and keeps the CJK exclusion.
- Adds tests for Arabic-Indic digits, separators, combining marks, and mixed-letter cases; effect is limited to `sort_line_items` when no strong RTL letters are present.
- Merges `main` (clippy 1.98 fixes and toolchain pin); no behavior change.

<sup>Written for commit e7a3d0fd724690a1516aab71e71b291071283a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

