### PR TITLE
fix(lint): resolve clippy 1.98 lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           components: rustfmt
 
       - name: Check formatting
@@ -63,7 +63,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           components: clippy
 
       - name: Cache cargo
@@ -89,7 +89,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -112,7 +112,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -132,7 +132,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -285,7 +285,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown
           components: clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           components: rustfmt
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           components: clippy
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
@@ -283,7 +283,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
       - name: Verify package
         run: cargo publish --dry-run

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: ${{ matrix.target }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # action tag "stable"; the Rust version is pinned by the toolchain input
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "pdf-inspector"
 version = "1.15.0"
 edition = "2021"
+# Oldest compiler the crate builds on (slice::as_chunks). Independent of the
+# 1.98 pin in rust-toolchain.toml, which is what we develop and release with.
+rust-version = "1.88"
 autobins = false
 authors = ["Firecrawl Team"]
 description = "Fast PDF inspection, classification, and text extraction with smart scanned vs text-based detection"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+# Pinned toolchain for local development and CI (maturin-action reads this
+# file too; the GitHub workflows pin the same version explicitly because
+# dtolnay/rust-toolchain exports RUSTUP_TOOLCHAIN, which overrides this file).
+#
+# Bump deliberately in its own PR: install the new version, run
+# `cargo clippy -- -D warnings` and `cargo clippy --features ocr -- -D warnings`,
+# fix new lints, then update the version here AND in .github/workflows/*.yml.
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1951,8 +1951,10 @@ fn get_document_title(doc: &Document) -> Option<String> {
             // Handle UTF-16BE encoding (BOM: 0xFE 0xFF)
             if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
                 let utf16: Vec<u16> = bytes[2..]
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_be_bytes(*chunk))
                     .collect();
                 Some(String::from_utf16_lossy(&utf16))
             } else {

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -1345,8 +1345,10 @@ pub(crate) fn extract_text_from_operand(
             // Fallback: try UTF-16BE then Latin-1
             if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
                 let utf16: Vec<u16> = bytes[2..]
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_be_bytes(*chunk))
                     .collect();
                 let text = String::from_utf16_lossy(&utf16);
                 if text.contains('\u{FFFD}') {
@@ -1364,8 +1366,10 @@ pub(crate) fn extract_text_from_operand(
                 let nulls = bytes.iter().filter(|&&b| b == 0).count();
                 if nulls * 4 > bytes.len() {
                     let utf16: Vec<u16> = bytes
-                        .chunks_exact(2)
-                        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
+                        .map(|chunk| u16::from_be_bytes(*chunk))
                         .collect();
                     let text = String::from_utf16_lossy(&utf16);
                     if score_text(&text) > 0 {

--- a/src/tables/detect_struct.rs
+++ b/src/tables/detect_struct.rs
@@ -123,9 +123,7 @@ fn align_positions_to_columns(cell_xs: &[f32], columns: &[f32]) -> Vec<usize> {
     let mut dp = vec![vec![f32::INFINITY; columns.len() + 1]; cell_xs.len() + 1];
     let mut take = vec![vec![false; columns.len() + 1]; cell_xs.len() + 1];
 
-    for value in &mut dp[0] {
-        *value = 0.0;
-    }
+    dp[0].fill(0.0);
 
     for i in 1..=cell_xs.len() {
         for j in 1..=columns.len() {

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -322,8 +322,10 @@ pub(crate) fn decode_text_string(bytes: &[u8]) -> String {
     if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
         // UTF-16BE with BOM
         let utf16: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_be_bytes(*chunk))
             .collect();
         String::from_utf16_lossy(&utf16)
     } else {

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -623,8 +623,10 @@ fn hex_to_unicode_string(hex: &str) -> Option<String> {
 
     if bytes.len().is_multiple_of(2) {
         let units: Vec<u16> = bytes
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_be_bytes(*chunk))
             .collect();
         if let Ok(result) = String::from_utf16(&units) {
             if !result.is_empty() {
@@ -846,8 +848,8 @@ fn parse_cid_to_gid_stream(data: &[u8]) -> Option<Vec<u16>> {
         return None;
     }
     let mut map = Vec::with_capacity(data.len() / 2);
-    for chunk in data.chunks_exact(2) {
-        map.push(u16::from_be_bytes([chunk[0], chunk[1]]));
+    for chunk in data.as_chunks::<2>().0 {
+        map.push(u16::from_be_bytes(*chunk));
     }
     Some(map)
 }
@@ -1447,8 +1449,8 @@ fn bytes_to_unicode_string(bytes: &[u8]) -> Option<String> {
         return Some(bytes.iter().map(|&b| b as char).collect());
     }
     let mut out = String::new();
-    for chunk in bytes.chunks_exact(2) {
-        let cp = u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+    for chunk in bytes.as_chunks::<2>().0 {
+        let cp = u16::from_be_bytes(*chunk) as u32;
         if let Some(ch) = char::from_u32(cp) {
             out.push(ch);
         }

--- a/src/vision/oar.rs
+++ b/src/vision/oar.rs
@@ -628,12 +628,17 @@ fn rendered_page_to_rgb(page: &RenderedPage) -> Result<RgbImage, OarOcrError> {
         match page.format() {
             RenderPixelFormat::Rgb8 => output.copy_from_slice(input),
             RenderPixelFormat::Rgba8 => {
-                for (rgba, rgb) in input.chunks_exact(4).zip(output.chunks_exact_mut(3)) {
+                for (rgba, rgb) in input
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .zip(output.as_chunks_mut::<3>().0)
+                {
                     rgb.copy_from_slice(&rgba[..3]);
                 }
             }
             RenderPixelFormat::Gray8 => {
-                for (&gray, rgb) in input.iter().zip(output.chunks_exact_mut(3)) {
+                for (&gray, rgb) in input.iter().zip(output.as_chunks_mut::<3>().0) {
                     rgb.fill(gray);
                 }
             }

--- a/src/vision/pdfium.rs
+++ b/src/vision/pdfium.rs
@@ -398,7 +398,7 @@ fn bgr_to_rgb_in_place(
     }
 
     for row in pixels.chunks_exact_mut(stride) {
-        for pixel in row[..row_bytes].chunks_exact_mut(3) {
+        for pixel in row[..row_bytes].as_chunks_mut::<3>().0 {
             pixel.swap(0, 2);
         }
     }


### PR DESCRIPTION
CI's stable clippy moved to 1.98, adding `chunks_exact_to_as_chunks` and `manual_slice_fill`. Both fire on existing code (8 sites in the default build, 4 more behind `--features ocr`), so the Clippy job currently fails on every PR.

## Changes

- Replace constant-size `chunks_exact`/`chunks_exact_mut` with `as_chunks::<N>`/`as_chunks_mut::<N>` (UTF-16BE decoding in detector/fonts/text_utils/tounicode, RGB pixel handling in vision).
- Use `slice::fill` for the DP row initialization in `detect_struct`.
- **Pin the toolchain to 1.98.0** so the next stable release can't break every open PR again: `rust-toolchain.toml` covers local development and maturin builds, and the workflows pass the same version explicitly (dtolnay/rust-toolchain exports `RUSTUP_TOOLCHAIN`, which overrides the file, so both places are needed). Toolchain bumps become a deliberate PR: install, fix new lints, update both places.

No behavior change: `as_chunks::<N>().0` iterates exactly the chunks `chunks_exact(N)` yielded. Full-corpus A/B against a main-built binary is byte-identical.

## Testing

- `cargo clippy -- -D warnings` and `cargo clippy --features ocr -- -D warnings` pass on 1.98.0 (the OCR sites never surfaced in CI because the job fails on the first step).
- `cargo fmt --check` and `cargo test` (987 unit + 163 integration) pass under the pinned toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)