### PR TITLE
fix(extraction): lower confidence for empty text output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,9 @@ pub struct PdfProcessResult {
     pub ocr_reasons_by_page: Vec<PageOcrReasons>,
     /// Title from PDF metadata (if available).
     pub title: Option<String>,
-    /// Detection confidence score (0.0–1.0).
+    /// Confidence score for the returned result (0.0–1.0). In
+    /// [`ProcessMode::Full`], this is 0.0 when a TextBased PDF yields no
+    /// usable Markdown.
     pub confidence: f32,
     /// Layout complexity analysis (tables, multi-column detection).
     pub layout: LayoutComplexity,
@@ -4411,6 +4413,27 @@ fn process_document(
         None
     } else {
         markdown
+    };
+
+    // Full mode returns Markdown for a document classified as TextBased. If
+    // extraction-quality gates leave that output empty, retaining the
+    // detector's 1.0 confidence makes the silent-empty failure look certain to
+    // callers. Analyze mode intentionally omits Markdown, so its confidence
+    // remains the detector result.
+    let confidence = if options.mode == ProcessMode::Full
+        && pdf_type == PdfType::TextBased
+        && page_count > 0
+        && markdown
+            .as_ref()
+            .is_none_or(|markdown| markdown.trim().is_empty())
+    {
+        log::debug!(
+            "TextBased PDF produced no usable markdown — reducing confidence from {:.2} to 0",
+            confidence
+        );
+        0.0
+    } else {
+        confidence
     };
 
     Ok(PdfProcessResult {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use pdf_inspector::{
     extract_text_in_regions_mem, extract_text_with_positions, extract_text_with_positions_mem,
     process_pdf_mem, process_pdf_mem_with_options, process_pdf_with_options, to_markdown,
     to_markdown_from_items_with_rects_and_page_count, MarkdownOptions, PdfError, PdfOptions,
-    PdfType, TextItem,
+    PdfType, ProcessMode, TextItem,
 };
 use std::collections::HashSet;
 
@@ -1148,6 +1148,57 @@ fn test_process_pdf_mem_repairs_truncated_eof_marker() {
             .unwrap_or_default()
             .contains("Hello World"),
         "repaired PDF should still extract text"
+    );
+}
+
+#[test]
+fn test_process_pdf_mem_suppressed_extraction_has_zero_confidence() {
+    let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
+    let result = process_pdf_mem(&buf).unwrap();
+
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert!(
+        result
+            .markdown
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty(),
+        "suppressed undecodable text should not claim usable markdown"
+    );
+    assert!(result.pages_needing_ocr.contains(&1));
+    assert_eq!(
+        result.confidence, 0.0,
+        "a TextBased result with no usable markdown must not claim certainty"
+    );
+}
+
+#[test]
+fn test_process_pdf_mem_analyze_mode_retains_detection_confidence() {
+    let buf = std::fs::read("tests/fixtures/shinagawa_identity_h.pdf").unwrap();
+    let result =
+        process_pdf_mem_with_options(&buf, PdfOptions::new().mode(ProcessMode::Analyze)).unwrap();
+
+    assert_eq!(result.markdown, None);
+    assert_eq!(
+        result.confidence, 1.0,
+        "Analyze mode intentionally omits markdown and keeps detector confidence"
+    );
+}
+
+#[test]
+fn test_process_pdf_mem_sparse_usable_text_retains_confidence() {
+    let result = process_pdf_mem(&make_minimal_text_pdf()).unwrap();
+
+    assert_eq!(result.pdf_type, PdfType::TextBased);
+    assert!(result
+        .markdown
+        .as_deref()
+        .unwrap_or_default()
+        .contains("Hello World"));
+    assert_eq!(
+        result.confidence, 1.0,
+        "sparse but usable text should retain TextBased confidence"
     );
 }
 


### PR DESCRIPTION
## Problem

Full processing can classify a PDF as TextBased, suppress its undecodable text, return empty Markdown, route pages to OCR, and still report confidence 1.0. That makes an unusable result look certain to callers.

## Change

- Reduce Full-mode result confidence to 0.0 when a TextBased PDF yields no non-whitespace Markdown.
- Keep Analyze and DetectOnly confidence unchanged because those modes intentionally do not produce Markdown.
- Document the result confidence field.
- Cover suppressed output, Analyze mode, and sparse-but-usable text with regressions.

This addresses the confident-empty-extraction portion of #272.

## Validation

- New regression fails on pristine main and passes here.
- `cargo test --verbose`: 1015 lib + 168 integration + 3 bin + 2 doc tests pass.
- `cargo clippy -- -D warnings` and `cargo clippy --features ocr -- -D warnings` pass.
- Root and WASM `cargo fmt -- --check` pass.
- `git diff --check` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents overconfident empty extractions: in Full mode, TextBased PDFs that produce no usable Markdown now return confidence 0.0 instead of 1.0. This stops callers from treating unusable results as certain; Analyze and DetectOnly modes are unchanged.

- Full-mode confidence is set to 0.0 when pdf_type is TextBased and the Markdown is empty or whitespace; adds a debug log for visibility.
- Documents the `PdfProcessResult.confidence` semantics.
- Adds integration tests covering suppressed output (now 0.0), Analyze mode retaining detector confidence (1.0), and sparse-but-usable text retaining 1.0.

- Impact: No API changes. Callers that gate retries or fallbacks on confidence should treat 0.0 as an empty-extraction signal in Full mode.

<sup>Written for commit 19f2e531d929dc64d3957914905a573e9a8118c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

