### PR TITLE
feat(bindings): expose mcid and struct-tree role on positioned text items 

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -2,7 +2,6 @@
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use std::collections::HashSet;
 use std::panic;
 
 // ---------------------------------------------------------------------------
@@ -114,6 +113,13 @@ pub struct TextItem {
     /// `page`/`mcid` pairs from [`extractStructureElements`] to attach
     /// structure-tree roles (headings, paragraphs, …) in tagged PDFs.
     pub mcid: Option<i64>,
+    /// Structure-tree role resolved from `mcid` for tagged PDFs — the standard
+    /// structure type name ("H1".."H6", "P", "Note", "Caption", "Figure", …),
+    /// or a custom tag resolved through the document's role map. `None` when
+    /// the PDF is untagged, the page has no structure tree, or the item is not
+    /// part of marked content. Lets callers separate body text from footnotes
+    /// (`Note`), running headers, and marginalia without a manual join.
+    pub role: Option<String>,
 }
 
 /// A page's regions for text extraction: (page_index_0based, bboxes).
@@ -481,22 +487,15 @@ pub fn extract_text_with_positions(
 ) -> Result<Vec<TextItem>> {
     let bytes: Vec<u8> = buffer.to_vec();
     catch_panic("extract_text_with_positions", move || {
-        let items = match pages {
-            Some(p) => {
-                let page_set: HashSet<u32> = p.into_iter().collect();
-                pdf_inspector::extractor::extract_text_with_positions_mem_pages(
-                    &bytes,
-                    Some(&page_set),
-                )
-                .map_err(|e| to_napi_err(e, "extract_text_with_positions"))?
-            }
-            None => pdf_inspector::extractor::extract_text_with_positions_mem(&bytes)
-                .map_err(|e| to_napi_err(e, "extract_text_with_positions"))?,
-        };
+        let items = pdf_inspector::extract_text_with_positions_with_roles_mem(
+            &bytes,
+            pages.as_deref(),
+        )
+        .map_err(|e| to_napi_err(e, "extract_text_with_positions"))?;
 
         Ok(items
             .into_iter()
-            .map(|item| {
+            .map(|(item, role)| {
                 let (item_type, link_url) = convert_item_type(&item.item_type);
                 TextItem {
                     text: item.text,
@@ -514,6 +513,7 @@ pub fn extract_text_with_positions(
                     item_type,
                     link_url,
                     mcid: item.mcid,
+                    role,
                 }
             })
             .collect())

--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -94,6 +94,15 @@ assert.ok(
 );
 console.log('  extractTextWithPositions mcid: OK');
 
+// role: resolved struct-tree role — undefined on untagged PDFs, a non-empty
+// structure type name (H1, P, Note, …) on tagged marked content
+assert.ok(items.every(i => i.role === undefined || typeof i.role === 'string'));
+assert.ok(
+  taggedItems.some(i => typeof i.role === 'string' && i.role.length > 0),
+  'tagged PDF text items should carry resolved struct-tree roles',
+);
+console.log('  extractTextWithPositions role: OK');
+
 // --- extractStructureElements ---
 console.log('Testing extractStructureElements...');
 const structureElements = extractStructureElements(taggedFixture);

--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -96,7 +96,10 @@ console.log('  extractTextWithPositions mcid: OK');
 
 // role: resolved struct-tree role — undefined on untagged PDFs, a non-empty
 // structure type name (H1, P, Note, …) on tagged marked content
-assert.ok(items.every(i => i.role === undefined || typeof i.role === 'string'));
+assert.ok(
+  items.every(i => i.role === undefined),
+  'untagged PDF text items should have no struct-tree role',
+);
 assert.ok(
   taggedItems.some(i => typeof i.role === 'string' && i.role.length > 0),
   'tagged PDF text items should carry resolved struct-tree roles',

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -103,6 +103,13 @@ class TextItem:
     the text is not part of marked content. Join with the (page, mcid) pairs
     from extract_structure_elements to attach structure-tree roles in tagged
     PDFs."""
+    role: Optional[str]
+    """Structure-tree role resolved from mcid for tagged PDFs — the standard
+    structure type name ("H1".."H6", "P", "Note", "Caption", "Figure", ...), or
+    a custom tag resolved through the document's role map. None when the PDF is
+    untagged, the page has no structure tree, or the item is not part of marked
+    content. Lets callers separate body text from footnotes ("Note"), running
+    headers, and marginalia without a manual join."""
 
 class StructureElement:
     """One structure-tree element reference from a tagged PDF."""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,6 +905,65 @@ pub fn extract_structure_elements<P: AsRef<Path>>(
     extract_structure_elements_mem(&buffer, pages)
 }
 
+/// Extract positioned text items paired with their resolved structure-tree
+/// role, from a PDF in memory.
+///
+/// Runs [`extract_text_with_positions_mem`] and, for tagged PDFs, resolves
+/// each item's [`TextItem::mcid`] to its structure type name ("H1".."H6",
+/// "P", "Note", "Caption", "Figure", …) via the document's `/StructTreeRoot`.
+/// This is the single-call form of joining [`extract_text_with_positions`]
+/// with [`extract_structure_elements`]: callers can separate body text from
+/// footnotes, running headers, and marginalia by role without doing the
+/// `(page, mcid)` join themselves.
+///
+/// The resolved role is `None` when the PDF is untagged, when the page has no
+/// structure tree, or when the item is not part of marked content (its
+/// `mcid` is `None`). Pass `Some(&[...])` with 1-indexed page numbers to
+/// restrict extraction to those pages, or `None` for the whole document.
+pub fn extract_text_with_positions_with_roles_mem(
+    buffer: &[u8],
+    pages: Option<&[u32]>,
+) -> Result<Vec<(TextItem, Option<String>)>, PdfError> {
+    let items = match pages {
+        Some(p) => {
+            let page_set: HashSet<u32> = p.iter().copied().collect();
+            extractor::extract_text_with_positions_mem_pages(buffer, Some(&page_set))?
+        }
+        None => extractor::extract_text_with_positions_mem(buffer)?,
+    };
+
+    // Resolve (page, mcid) → role from the struct tree. Untagged PDFs yield an
+    // empty map, so every item's role falls through to `None`.
+    let role_map: HashMap<(u32, i64), String> = extract_structure_elements_mem(buffer, pages)?
+        .into_iter()
+        .map(|e| ((e.page, e.mcid), e.role))
+        .collect();
+
+    Ok(items
+        .into_iter()
+        .map(|item| {
+            let role = item
+                .mcid
+                .and_then(|mcid| role_map.get(&(item.page, mcid)).cloned());
+            (item, role)
+        })
+        .collect())
+}
+
+/// Path-based wrapper for [`extract_text_with_positions_with_roles_mem`].
+///
+/// Reads the PDF from disk and extracts positioned text items paired with
+/// their resolved structure-tree role. Pass `None` for `pages` to return the
+/// whole document, or `Some(&[...])` to restrict to specific 1-indexed pages.
+pub fn extract_text_with_positions_with_roles<P: AsRef<Path>>(
+    path: P,
+    pages: Option<&[u32]>,
+) -> Result<Vec<(TextItem, Option<String>)>, PdfError> {
+    validate_pdf_file(&path)?;
+    let buffer = std::fs::read(path.as_ref())?;
+    extract_text_with_positions_with_roles_mem(&buffer, pages)
+}
+
 // =========================================================================
 // Region-based text extraction (for hybrid OCR pipelines)
 // =========================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,8 +869,19 @@ pub fn extract_structure_elements_mem(
 ) -> Result<Vec<StructureElement>, PdfError> {
     validate_pdf_bytes(buffer)?;
     let (doc, _page_count) = load_document_from_mem(buffer)?;
-    let Some(tree) = structure_tree::StructTree::from_doc(&doc) else {
-        return Ok(Vec::new());
+    Ok(structure_elements_from_doc(&doc, pages))
+}
+
+/// Resolve structure-tree element references from an already-loaded document.
+///
+/// Returns an empty list when the document is not tagged. Shared by
+/// [`extract_structure_elements_mem`] and
+/// [`extract_text_with_positions_with_roles_mem`] so a document parsed once
+/// can feed both the struct-tree walk and the positioned-text walk without a
+/// second load/parse.
+fn structure_elements_from_doc(doc: &Document, pages: Option<&[u32]>) -> Vec<StructureElement> {
+    let Some(tree) = structure_tree::StructTree::from_doc(doc) else {
+        return Vec::new();
     };
     let page_ids = doc.get_pages();
     let roles = tree.mcid_to_roles(&page_ids);
@@ -888,7 +899,7 @@ pub fn extract_structure_elements_mem(
         })
         .collect();
     elements.sort_unstable_by_key(|e| (e.page, e.mcid));
-    Ok(elements)
+    elements
 }
 
 /// Path-based wrapper for [`extract_structure_elements_mem`].
@@ -924,17 +935,21 @@ pub fn extract_text_with_positions_with_roles_mem(
     buffer: &[u8],
     pages: Option<&[u32]>,
 ) -> Result<Vec<(TextItem, Option<String>)>, PdfError> {
-    let items = match pages {
-        Some(p) => {
-            let page_set: HashSet<u32> = p.iter().copied().collect();
-            extractor::extract_text_with_positions_mem_pages(buffer, Some(&page_set))?
-        }
-        None => extractor::extract_text_with_positions_mem(buffer)?,
-    };
+    validate_pdf_bytes(buffer)?;
+    // Load and parse the document once, then feed both the positioned-text
+    // walk and the struct-tree role walk from the same parsed `Document`
+    // (both otherwise go through `load_document_from_mem`, so sharing one load
+    // is equivalent and avoids parsing the PDF twice).
+    let (doc, _page_count) = load_document_from_mem(buffer)?;
+
+    let page_filter: Option<HashSet<u32>> = pages.map(|p| p.iter().copied().collect());
+    let font_cmaps = FontCMaps::from_doc(&doc);
+    let ((items, _rects, _lines), _thresholds, _gid_pages) =
+        extractor::extract_positioned_text_from_doc(&doc, &font_cmaps, page_filter.as_ref())?;
 
     // Resolve (page, mcid) → role from the struct tree. Untagged PDFs yield an
     // empty map, so every item's role falls through to `None`.
-    let role_map: HashMap<(u32, i64), String> = extract_structure_elements_mem(buffer, pages)?
+    let role_map: HashMap<(u32, i64), String> = structure_elements_from_doc(&doc, pages)
         .into_iter()
         .map(|e| ((e.page, e.mcid), e.role))
         .collect();

--- a/src/python.rs
+++ b/src/python.rs
@@ -2,7 +2,6 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use std::collections::HashSet;
 
 use crate::detector::PdfType;
 use crate::types::ItemType;
@@ -378,6 +377,14 @@ pub struct PyTextItem {
     /// structure-tree roles (headings, paragraphs, ...) in tagged PDFs.
     #[pyo3(get)]
     pub mcid: Option<i64>,
+    /// Structure-tree role resolved from mcid for tagged PDFs — the standard
+    /// structure type name ("H1".."H6", "P", "Note", "Caption", "Figure", ...),
+    /// or a custom tag resolved through the document's role map. None when the
+    /// PDF is untagged, the page has no structure tree, or the item is not part
+    /// of marked content. Lets callers separate body text from footnotes
+    /// ("Note"), running headers, and marginalia without a manual join.
+    #[pyo3(get)]
+    pub role: Option<String>,
 }
 
 #[pymethods]
@@ -567,10 +574,10 @@ fn item_type_str(t: &ItemType) -> String {
     }
 }
 
-fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
+fn convert_text_items(items: Vec<(crate::TextItem, Option<String>)>) -> Vec<PyTextItem> {
     items
         .into_iter()
-        .map(|item| PyTextItem {
+        .map(|(item, role)| PyTextItem {
             text: item.text,
             x: item.x,
             y: item.y,
@@ -585,6 +592,7 @@ fn convert_text_items(items: Vec<crate::TextItem>) -> Vec<PyTextItem> {
             is_strikeout: item.is_strikeout,
             item_type: item_type_str(&item.item_type),
             mcid: item.mcid,
+            role,
         })
         .collect()
 }
@@ -843,13 +851,8 @@ fn extract_text_bytes(data: &[u8]) -> PyResult<String> {
 #[pyfunction]
 #[pyo3(signature = (path, pages=None))]
 fn extract_text_with_positions(path: &str, pages: Option<Vec<u32>>) -> PyResult<Vec<PyTextItem>> {
-    let items = match pages {
-        Some(p) => {
-            let page_set: HashSet<u32> = p.into_iter().collect();
-            crate::extract_text_with_positions_pages(path, Some(&page_set)).map_err(to_py_err)?
-        }
-        None => crate::extract_text_with_positions(path).map_err(to_py_err)?,
-    };
+    let items =
+        crate::extract_text_with_positions_with_roles(path, pages.as_deref()).map_err(to_py_err)?;
     Ok(convert_text_items(items))
 }
 
@@ -860,14 +863,8 @@ fn extract_text_with_positions_bytes(
     data: &[u8],
     pages: Option<Vec<u32>>,
 ) -> PyResult<Vec<PyTextItem>> {
-    let items = match pages {
-        Some(p) => {
-            let page_set: HashSet<u32> = p.into_iter().collect();
-            crate::extractor::extract_text_with_positions_mem_pages(data, Some(&page_set))
-                .map_err(to_py_err)?
-        }
-        None => crate::extractor::extract_text_with_positions_mem(data).map_err(to_py_err)?,
-    };
+    let items = crate::extract_text_with_positions_with_roles_mem(data, pages.as_deref())
+        .map_err(to_py_err)?;
     Ok(convert_text_items(items))
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -239,6 +239,107 @@ fn make_minimal_text_pdf() -> Vec<u8> {
     )
 }
 
+/// Build a minimal tagged (Structure Tree) PDF with two marked-content
+/// sequences: body text tagged `/P` (MCID 0) and a footnote tagged `/Note`
+/// (MCID 1). Used to verify that positioned text items carry both their
+/// Marked Content ID and the role resolved from the structure tree, so callers
+/// can separate footnote/marginal text from body text.
+fn make_tagged_note_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.5\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    fn add_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, id: usize, body: &str) {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body.as_bytes());
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    // Two marked-content sequences. The BDC property dict carries the MCID
+    // that links each run back to a structure element.
+    let content = "BT /F1 12 Tf 1 0 0 1 72 700 Tm /P <</MCID 0>> BDC (Body paragraph text) Tj EMC ET\n\
+                   BT /F1 8 Tf 1 0 0 1 72 60 Tm /Note <</MCID 1>> BDC (Editor footnote text) Tj EMC ET";
+
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        2,
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R /StructParents 0 >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        4,
+        &format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content.len(),
+            content
+        ),
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        5,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        6,
+        "<< /Type /StructTreeRoot /K [7 0 R] >>",
+    );
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        7,
+        "<< /Type /StructElem /S /Document /P 6 0 R /K [8 0 R 9 0 R] >>",
+    );
+    // Body paragraph → /P, links MCID 0 on the page.
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        8,
+        "<< /Type /StructElem /S /P /P 7 0 R /Pg 3 0 R /K 0 >>",
+    );
+    // Footnote → /Note, links MCID 1 on the page.
+    add_object(
+        &mut pdf,
+        &mut offsets,
+        9,
+        "<< /Type /StructElem /S /Note /P 7 0 R /Pg 3 0 R /K 1 >>",
+    );
+
+    let xref_start = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            offsets.len(),
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    pdf
+}
+
 fn make_digit_run_repro_pdf() -> Vec<u8> {
     let content = r#"BT
 /F1 12 Tf
@@ -1517,6 +1618,67 @@ fn test_extract_structure_elements_tagged_pdf() {
     assert!(page1.iter().all(|e| e.page == 1));
     let full_page1_count = elements.iter().filter(|e| e.page == 1).count();
     assert_eq!(page1.len(), full_page1_count);
+}
+
+#[test]
+fn test_positioned_items_carry_resolved_role_tagged() {
+    // A synthetic tagged PDF with body text (/P, MCID 0) and a footnote
+    // (/Note, MCID 1). The positioned-text-with-roles API must surface both
+    // the MCID and the role resolved from the structure tree, so callers can
+    // tell the editor's footnote apart from the author's body text.
+    let pdf = make_tagged_note_pdf();
+    let items = pdf_inspector::extract_text_with_positions_with_roles_mem(&pdf, None)
+        .expect("extract positioned text with roles");
+
+    // Body run (MCID 0) resolves to "P"; every item carrying MCID 0 does so.
+    let body: Vec<_> = items.iter().filter(|(it, _)| it.mcid == Some(0)).collect();
+    assert!(
+        !body.is_empty(),
+        "should extract the body marked-content run"
+    );
+    assert!(
+        body.iter().all(|(_, role)| role.as_deref() == Some("P")),
+        "body text (MCID 0) should resolve to role P, got {:?}",
+        body.iter().map(|(_, r)| r).collect::<Vec<_>>()
+    );
+
+    // Footnote run (MCID 1) resolves to "Note".
+    let note: Vec<_> = items.iter().filter(|(it, _)| it.mcid == Some(1)).collect();
+    assert!(
+        !note.is_empty(),
+        "should extract the footnote marked-content run"
+    );
+    assert!(
+        note.iter().all(|(_, role)| role.as_deref() == Some("Note")),
+        "footnote text (MCID 1) should resolve to role Note, got {:?}",
+        note.iter().map(|(_, r)| r).collect::<Vec<_>>()
+    );
+
+    // The body and footnote are separable by role — the whole point of the
+    // feature: recovered body text is non-empty and the two regions differ.
+    let note_text: String = note.iter().map(|(it, _)| it.text.as_str()).collect();
+    let body_text: String = body.iter().map(|(it, _)| it.text.as_str()).collect();
+    assert!(
+        body_text.contains("Body"),
+        "body region should recover body text, got {body_text:?}"
+    );
+    assert!(
+        note_text.contains("footnote"),
+        "note region should recover footnote text, got {note_text:?}"
+    );
+}
+
+#[test]
+fn test_positioned_items_role_none_untagged() {
+    // An untagged PDF has no structure tree, so every item's role is None.
+    let pdf = make_minimal_text_pdf();
+    let items = pdf_inspector::extract_text_with_positions_with_roles_mem(&pdf, None)
+        .expect("extract positioned text with roles");
+    assert!(!items.is_empty(), "untagged PDF should still extract text");
+    assert!(
+        items.iter().all(|(_, role)| role.is_none()),
+        "untagged PDF items should have no resolved role"
+    );
 }
 
 #[test]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -259,6 +259,23 @@ class TestExtractTextWithPositions:
         )
         assert any(item.mcid is not None for item in tagged)
 
+    def test_role(self):
+        # Untagged fixture: role is always None
+        items = pdf_inspector.extract_text_with_positions(
+            fixture_path("thermo-freon12.pdf")
+        )
+        assert all(item.role is None for item in items)
+        # Tagged fixture: marked content carries resolved struct-tree roles
+        # (H1, P, ...) so callers can separate body text from other regions
+        # without a manual (page, mcid) join.
+        tagged = pdf_inspector.extract_text_with_positions(
+            fixture_path("firecrawl_docs_tagged.pdf")
+        )
+        assert all(
+            item.role is None or isinstance(item.role, str) for item in tagged
+        )
+        assert any(item.role == "H1" for item in tagged)
+
 
 # ---------------------------------------------------------------------------
 # extract_structure_elements / extract_structure_elements_bytes


### PR DESCRIPTION
Implements the "cheapest version" of #215: surface the structure-tree data the crate already parses, so callers of the positioned-text APIs can separate footnotes, running headers, and marginalia from body text.

## Problem

Extracted markdown merges body text with footnotes, running headers, and marginalia into one stream. As #215 lays out, for scholarly and legal documents that is an attribution error, not a formatting one. The building blocks to fix it downstream already exist in the crate — `TextItem` carries `mcid`, and the struct tree is parsed internally — but the napi and Python bindings expose neither the resolved role nor a way to get it without a manual `(page, mcid)` join against `extract_structure_elements`.

## Change

- **Core (Rust)**: new `extract_text_with_positions_with_roles_mem(buffer, pages)` (and a path-based wrapper) returning `Vec<(TextItem, Option<String>)>`. It runs the existing positioned-text extraction, builds a `(page, mcid) → role` map from the already-parsed `/StructTreeRoot` (via `extract_structure_elements_mem`, which resolves custom tags through the document's role map), and pairs each item with its resolved structure type name — `"H1"`…`"H6"`, `"P"`, `"Note"`, `"Caption"`, `"Figure"`, etc.
- **napi**: `TextItem.role: string | null`, populated by `extractTextWithPositions`.
- **Python**: `TextItem.role: Optional[str]`, populated by both `extract_text_with_positions` and `extract_text_with_positions_bytes`; `pdf_inspector.pyi` updated.
- `role` is `None`/`null` when the PDF is untagged, the page has no structure tree, or the item is not part of marked content — so untagged documents behave exactly as before.
- wasm is unchanged: it exposes no positioned-text item type, so there is no equivalent field to add.

Both bindings now route their positioned-text calls through the single core function, which also removed some duplicated page-set plumbing.

## Tests

- `test_positioned_items_carry_resolved_role_tagged` — builds a synthetic tagged PDF in-test with `/P` body text (MCID 0) and a `/Note` footnote (MCID 1); asserts items carry the right mcid, resolve to roles `P` and `Note`, and are separable by role.
- `test_positioned_items_role_none_untagged` — untagged PDF yields `role = None` for every item.
- Binding-level assertions added to `napi/test.mjs` and `tests/test_python.py`.

`cargo fmt`, `cargo clippy -- -D warnings` (plus `--features ocr`), and the full `cargo test` suite (1015 lib + 167 integration + 2 doc-tests) all pass; the napi crate and `--features python` builds compile clean.

## Out of scope

The heuristic classification for **untagged** documents discussed in #215 (font-size clustering, position bands, separator rules) is deliberately not included — this PR is the expose-what-we-already-parse slice, which #215 calls out as the cheapest first step. The heuristic layer can build on this API.

Closes #215.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose resolved structure-tree roles on positioned text items so callers can separate body text from footnotes, running headers, and marginalia. Previously, callers had to join (page, mcid) against structure elements; now each item includes a resolved role, with untagged PDFs behaving the same.

- Core (Rust): add `extract_text_with_positions_with_roles_mem` and a path wrapper returning `Vec<(TextItem, Option<String>)>`. Resolve `(page, mcid) -> role` from `/StructTreeRoot`, now parsing the document once and sharing it via `structure_elements_from_doc` to avoid a second load. `pages` remains 1-indexed.
- `napi`: add `TextItem.role: string | null`; `extractTextWithPositions` now routes through the roles API. Untagged PDFs yield `role === undefined`.
- Python (`pdf_inspector`): add `TextItem.role: Optional[str]`; both `extract_text_with_positions` and `_bytes` route through the roles API; `pdf_inspector.pyi` updated.
- Untagged PDFs: `role` is `null`/`None`/`undefined` when untagged, a page lacks a structure tree, or an item isn’t marked; other fields and ordering are unchanged.
- wasm: unchanged.
- Tests: core integration tests assert `mcid` and roles (`P`, `Note`) and separability by role; untagged PDFs yield `role=None`. Binding tests added and tightened for JS `undefined`.

**Migration**
- No breaking changes; consumers may read `role` when present.

<sup>Written for commit 59bb89c1d318a1582d6d2b77d232b9611c36044a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

