### PR TITLE
feat(tables): recover embedded and stacked tables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,14 @@ pub struct PagesExtractionResult {
     pub is_complex: bool,
 }
 
+pub(crate) struct InternalPagesExtraction {
+    pub(crate) result: PagesExtractionResult,
+    #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+    pub(crate) page_count: u32,
+    #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+    pub(crate) supplemental_ocr_regions: BTreeMap<u32, Vec<PdfRect>>,
+}
+
 /// Extract formatted markdown for pages of a PDF, with layout
 /// classification metadata.
 ///
@@ -467,7 +475,7 @@ pub fn extract_pages_markdown_mem(
         false,
         false,
     )
-    .map(|(result, _)| result)
+    .map(|extraction| extraction.result)
 }
 
 #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
@@ -476,7 +484,7 @@ pub(crate) fn extract_pages_markdown_mem_for_ocr(
     pages: Option<&[u32]>,
     password: Option<&str>,
     markdown_options: &MarkdownOptions,
-) -> Result<(PagesExtractionResult, u32), PdfError> {
+) -> Result<InternalPagesExtraction, PdfError> {
     extract_pages_markdown_mem_impl(
         buffer,
         pages,
@@ -494,7 +502,7 @@ fn extract_pages_markdown_mem_impl(
     markdown_options: &MarkdownOptions,
     strip_repeated_headers_footers: bool,
     preserve_ocr_candidates: bool,
-) -> Result<(PagesExtractionResult, u32), PdfError> {
+) -> Result<InternalPagesExtraction, PdfError> {
     validate_pdf_bytes(buffer)?;
     let (doc, page_count) = load_document_from_mem_with_password(buffer, password)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
@@ -558,6 +566,8 @@ fn extract_pages_markdown_mem_impl(
     let mut results = Vec::with_capacity(pages_slice.len());
     let mut pages_needing_ocr = Vec::new();
     let mut ocr_reasons_by_page = BTreeMap::new();
+    #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+    let mut supplemental_ocr_regions = BTreeMap::new();
     let lopdf_pages = doc.get_pages();
 
     for &page_0idx in pages_slice {
@@ -597,6 +607,17 @@ fn extract_pages_markdown_mem_impl(
             .filter(|l| l.page == page_1idx)
             .cloned()
             .collect();
+
+        #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+        {
+            let image_regions: Vec<PdfRect> = page_items
+                .iter()
+                .filter_map(supplemental_ocr_image_region)
+                .collect();
+            if !image_regions.is_empty() {
+                supplemental_ocr_regions.insert(page_1idx, image_regions);
+            }
+        }
 
         let has_gid = gid_pages.contains(&page_1idx);
         let has_text_quality_issue = text_quality.pages_needing_ocr.contains(&page_1idx);
@@ -692,8 +713,8 @@ fn extract_pages_markdown_mem_impl(
         });
     }
 
-    Ok((
-        PagesExtractionResult {
+    Ok(InternalPagesExtraction {
+        result: PagesExtractionResult {
             pages: results,
             pages_with_tables: complexity.pages_with_tables,
             pages_with_columns: complexity.pages_with_columns,
@@ -701,8 +722,44 @@ fn extract_pages_markdown_mem_impl(
             ocr_reasons_by_page: page_ocr_reasons_vec(ocr_reasons_by_page),
             is_complex: complexity.is_complex,
         },
+        #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
         page_count,
-    ))
+        #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+        supplemental_ocr_regions,
+    })
+}
+
+/// Image regions large enough to plausibly contain rasterized document
+/// structure such as a table. Logos, icons, and decorative rules remain below
+/// these physical-size gates. OCR still has to produce a valid table inside
+/// the region before any text is fused into a clean native page.
+#[cfg(any(test, all(feature = "ocr", not(target_arch = "wasm32"))))]
+fn supplemental_ocr_image_region(item: &TextItem) -> Option<PdfRect> {
+    const MIN_WIDTH_PT: f32 = 108.0;
+    const MIN_HEIGHT_PT: f32 = 72.0;
+    const MIN_AREA_PT2: f32 = 20_000.0;
+
+    if !matches!(item.item_type, types::ItemType::Image)
+        || !item.x.is_finite()
+        || !item.y.is_finite()
+        || !item.width.is_finite()
+        || !item.height.is_finite()
+    {
+        return None;
+    }
+    let x = item.x.min(item.x + item.width);
+    let y = item.y.min(item.y + item.height);
+    let width = item.width.abs();
+    let height = item.height.abs();
+    (width >= MIN_WIDTH_PT && height >= MIN_HEIGHT_PT && width * height >= MIN_AREA_PT2).then_some(
+        PdfRect {
+            x,
+            y,
+            width,
+            height,
+            page: item.page,
+        },
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6446,6 +6503,36 @@ mod tests {
             page,
             ..test_item(text, 10.0, 10.0, text.len() as f32 * 5.0, 12.0)
         }
+    }
+
+    fn test_image_item(width: f32, height: f32) -> TextItem {
+        TextItem {
+            item_type: ItemType::Image,
+            ..test_item("[Image]", 20.0, 30.0, width, height)
+        }
+    }
+
+    #[test]
+    fn supplemental_ocr_regions_require_substantial_physical_images() {
+        let substantial = supplemental_ocr_image_region(&test_image_item(200.0, 120.0)).unwrap();
+        assert_eq!(substantial.width, 200.0);
+        assert_eq!(substantial.height, 120.0);
+
+        assert!(supplemental_ocr_image_region(&test_image_item(100.0, 200.0)).is_none());
+        assert!(supplemental_ocr_image_region(&test_image_item(200.0, 60.0)).is_none());
+        assert!(supplemental_ocr_image_region(&test_image_item(120.0, 100.0)).is_none());
+        assert!(
+            supplemental_ocr_image_region(&test_item("text", 0.0, 0.0, 300.0, 300.0)).is_none()
+        );
+    }
+
+    #[test]
+    fn supplemental_ocr_regions_normalize_negative_image_dimensions() {
+        let region = supplemental_ocr_image_region(&test_image_item(-200.0, -120.0)).unwrap();
+        assert_eq!(region.x, -180.0);
+        assert_eq!(region.y, -90.0);
+        assert_eq!(region.width, 200.0);
+        assert_eq!(region.height, 120.0);
     }
 
     #[test]

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -850,6 +850,7 @@ enum TableOutputMode {
 
 struct TableDetectionOutput {
     mode: TableOutputMode,
+    pages_with_detected_tables: HashSet<u32>,
     pages_with_tables: HashSet<u32>,
     markdown_by_page: HashMap<u32, Vec<PositionedMarkdown>>,
     #[cfg(feature = "ocr")]
@@ -860,6 +861,7 @@ impl TableDetectionOutput {
     fn new(mode: TableOutputMode) -> Self {
         Self {
             mode,
+            pages_with_detected_tables: HashSet::new(),
             pages_with_tables: HashSet::new(),
             markdown_by_page: HashMap::new(),
             #[cfg(feature = "ocr")]
@@ -873,9 +875,10 @@ impl TableDetectionOutput {
         table: &crate::tables::Table,
         chart_order: Option<ChartProseOrder>,
     ) {
-        self.pages_with_tables.insert(page);
+        self.pages_with_detected_tables.insert(page);
         match self.mode {
             TableOutputMode::Markdown => {
+                self.pages_with_tables.insert(page);
                 self.markdown_by_page
                     .entry(page)
                     .or_default()
@@ -889,6 +892,7 @@ impl TableDetectionOutput {
             #[cfg(feature = "ocr")]
             TableOutputMode::CompleteTables => {
                 if crate::tables::is_complete_data_table(table) {
+                    self.pages_with_tables.insert(page);
                     self.complete_tables.push((page, table.clone()));
                 }
             }
@@ -897,6 +901,10 @@ impl TableDetectionOutput {
 
     fn has_tables_on_page(&self, page: u32) -> bool {
         self.pages_with_tables.contains(&page)
+    }
+
+    fn has_detected_tables_on_page(&self, page: u32) -> bool {
+        self.pages_with_detected_tables.contains(&page)
     }
 }
 
@@ -2002,7 +2010,7 @@ fn convert_items_with_rects_lines_and_table_output(
         // 5. Thin-rect border synthesis: last resort for PDFs that draw table
         //    borders as thin filled rectangles (common in spreadsheet exports).
         //    Only runs when ALL other methods found nothing on this page.
-        if !table_output.has_tables_on_page(page) {
+        if !table_output.has_detected_tables_on_page(page) {
             let page_rects: Vec<&crate::types::PdfRect> =
                 rects.iter().filter(|r| r.page == page).collect();
             let mut synth_lines: Vec<crate::types::PdfLine> = Vec::new();
@@ -2408,6 +2416,35 @@ mod tests {
     use super::*;
     use analysis::detect_header_level;
     use classify::{is_code_like, is_list_item};
+
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn complete_table_output_marks_only_pages_with_emitted_tables() {
+        let mut output = TableDetectionOutput::new(TableOutputMode::CompleteTables);
+        let incomplete = crate::tables::Table::new(
+            vec![100.0, 200.0],
+            vec![300.0],
+            vec![vec!["header a".into(), "header b".into()]],
+            vec![0, 1],
+        );
+        output.record(1, &incomplete, None);
+        assert!(output.has_detected_tables_on_page(1));
+        assert!(!output.has_tables_on_page(1));
+        assert!(output.complete_tables.is_empty());
+
+        let complete = crate::tables::Table::new(
+            vec![100.0, 200.0],
+            vec![300.0, 280.0],
+            vec![
+                vec!["header a".into(), "header b".into()],
+                vec!["value a".into(), "value b".into()],
+            ],
+            vec![0, 1, 2, 3],
+        );
+        output.record(1, &complete, None);
+        assert!(output.has_tables_on_page(1));
+        assert_eq!(output.complete_tables.len(), 1);
+    }
 
     #[test]
     fn test_is_list_item() {

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -841,16 +841,70 @@ fn is_parallel_prose_table(table: &crate::tables::Table) -> bool {
     is_parallel
 }
 
-fn positioned_table(
-    table: &crate::tables::Table,
-    chart_order: Option<ChartProseOrder>,
-) -> PositionedMarkdown {
-    PositionedMarkdown::new(
-        table.rows.first().copied().unwrap_or(0.0),
-        table.columns.first().copied().unwrap_or(0.0),
-        crate::tables::table_to_markdown(table),
-        chart_order,
-    )
+#[derive(Clone, Copy)]
+enum TableOutputMode {
+    Markdown,
+    #[cfg(feature = "ocr")]
+    CompleteTables,
+}
+
+struct TableDetectionOutput {
+    mode: TableOutputMode,
+    pages_with_tables: HashSet<u32>,
+    markdown_by_page: HashMap<u32, Vec<PositionedMarkdown>>,
+    #[cfg(feature = "ocr")]
+    complete_tables: Vec<(u32, crate::tables::Table)>,
+}
+
+impl TableDetectionOutput {
+    fn new(mode: TableOutputMode) -> Self {
+        Self {
+            mode,
+            pages_with_tables: HashSet::new(),
+            markdown_by_page: HashMap::new(),
+            #[cfg(feature = "ocr")]
+            complete_tables: Vec::new(),
+        }
+    }
+
+    fn record(
+        &mut self,
+        page: u32,
+        table: &crate::tables::Table,
+        chart_order: Option<ChartProseOrder>,
+    ) {
+        self.pages_with_tables.insert(page);
+        match self.mode {
+            TableOutputMode::Markdown => {
+                self.markdown_by_page
+                    .entry(page)
+                    .or_default()
+                    .push(PositionedMarkdown::new(
+                        table.rows.first().copied().unwrap_or(0.0),
+                        table.columns.first().copied().unwrap_or(0.0),
+                        crate::tables::table_to_markdown(table),
+                        chart_order,
+                    ));
+            }
+            #[cfg(feature = "ocr")]
+            TableOutputMode::CompleteTables => {
+                if crate::tables::is_complete_data_table(table) {
+                    self.complete_tables.push((page, table.clone()));
+                }
+            }
+        }
+    }
+
+    fn has_tables_on_page(&self, page: u32) -> bool {
+        self.pages_with_tables.contains(&page)
+    }
+}
+
+#[derive(Default)]
+struct MarkdownConversionOutput {
+    markdown: String,
+    #[cfg(feature = "ocr")]
+    detected_tables: Vec<(u32, crate::tables::Table)>,
 }
 
 /// Derive a side-by-side split from rect hint regions.
@@ -1399,6 +1453,64 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     pdf_lines: &[crate::types::PdfLine],
     context: MarkdownDocumentContext<'_>,
 ) -> String {
+    convert_items_with_rects_lines_and_table_output(
+        items,
+        options,
+        rects,
+        pdf_lines,
+        context,
+        TableOutputMode::Markdown,
+    )
+    .markdown
+}
+
+/// Run the ordinary Markdown table pipeline but return only structurally
+/// complete data tables. Supplemental OCR uses this to keep detector behavior
+/// identical without parsing the serialized Markdown back into tables.
+#[cfg(feature = "ocr")]
+pub(crate) fn complete_table_markdown_from_items(
+    items: Vec<TextItem>,
+    options: MarkdownOptions,
+    document_page_count: u32,
+) -> String {
+    let conversion = convert_items_with_rects_lines_and_table_output(
+        items,
+        options,
+        &[],
+        &[],
+        MarkdownDocumentContext {
+            page_thresholds: &HashMap::new(),
+            struct_roles: None,
+            struct_tables: &[],
+            page_count: document_page_count,
+            prefiltered_page_number_pages: None,
+            prefiltered_page_number_mask: None,
+            precomputed_chart_regions: None,
+        },
+        TableOutputMode::CompleteTables,
+    );
+    let mut output = String::new();
+    for (_, table) in conversion.detected_tables {
+        let markdown = crate::tables::table_to_markdown(&table);
+        if markdown.is_empty() {
+            continue;
+        }
+        if !output.is_empty() && !output.ends_with("\n\n") {
+            output.push('\n');
+        }
+        output.push_str(&markdown);
+    }
+    output
+}
+
+fn convert_items_with_rects_lines_and_table_output(
+    items: Vec<TextItem>,
+    options: MarkdownOptions,
+    rects: &[crate::types::PdfRect],
+    pdf_lines: &[crate::types::PdfLine],
+    context: MarkdownDocumentContext<'_>,
+    table_output_mode: TableOutputMode,
+) -> MarkdownConversionOutput {
     use crate::tables::{
         content_width, detect_tables_from_lines, detect_tables_from_rects,
         detect_tables_from_struct_tree, detect_tables_with_page_width, try_build_rect_guided_table,
@@ -1416,7 +1528,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     } = context;
 
     if items.is_empty() {
-        return String::new();
+        return MarkdownConversionOutput::default();
     }
 
     // Table detection must retain the original collection because short
@@ -1472,7 +1584,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
 
     // Detect tables on each page
     let mut table_items: HashSet<usize> = HashSet::new();
-    let mut page_tables: HashMap<u32, Vec<PositionedMarkdown>> = HashMap::new();
+    let mut table_output = TableDetectionOutput::new(table_output_mode);
 
     // Running headers/footers repeat verbatim at the same position on many
     // pages. When such a block wraps a long title over aligned lines, the
@@ -1687,10 +1799,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                             }
                         }
                     }
-                    page_tables
-                        .entry(page)
-                        .or_default()
-                        .push(positioned_table(table, chart_prose_order));
+                    table_output.record(page, table, chart_prose_order);
                 }
             }
 
@@ -1714,10 +1823,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                         }
                     }
                 }
-                page_tables
-                    .entry(page)
-                    .or_default()
-                    .push(positioned_table(table, chart_prose_order));
+                table_output.record(page, table, chart_prose_order);
             }
 
             // 2. Line-based detection on unclaimed items (when rects didn't find tables)
@@ -1732,10 +1838,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                             }
                         }
                     }
-                    page_tables
-                        .entry(page)
-                        .or_default()
-                        .push(positioned_table(table, chart_prose_order));
+                    table_output.record(page, table, chart_prose_order);
                 }
             }
 
@@ -1771,10 +1874,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                                 }
                             }
                         }
-                        page_tables
-                            .entry(page)
-                            .or_default()
-                            .push(positioned_table(&table, chart_prose_order));
+                        table_output.record(page, &table, chart_prose_order);
                         for &band_idx in &inside_map {
                             rect_claimed.insert(band_idx);
                         }
@@ -1832,10 +1932,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                                 }
                             }
                         }
-                        page_tables
-                            .entry(page)
-                            .or_default()
-                            .push(positioned_table(&table, chart_prose_order));
+                        table_output.record(page, &table, chart_prose_order);
                     }
                 };
 
@@ -1897,10 +1994,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                             }
                         }
                     }
-                    page_tables
-                        .entry(page)
-                        .or_default()
-                        .push(positioned_table(&table, chart_prose_order));
+                    table_output.record(page, &table, chart_prose_order);
                 }
             }
         }
@@ -1908,7 +2002,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         // 5. Thin-rect border synthesis: last resort for PDFs that draw table
         //    borders as thin filled rectangles (common in spreadsheet exports).
         //    Only runs when ALL other methods found nothing on this page.
-        if !page_tables.contains_key(&page) {
+        if !table_output.has_tables_on_page(page) {
             let page_rects: Vec<&crate::types::PdfRect> =
                 rects.iter().filter(|r| r.page == page).collect();
             let mut synth_lines: Vec<crate::types::PdfLine> = Vec::new();
@@ -1959,10 +2053,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                             table_items.insert(global_idx);
                         }
                     }
-                    page_tables
-                        .entry(page)
-                        .or_default()
-                        .push(positioned_table(table, chart_prose_order));
+                    table_output.record(page, table, chart_prose_order);
                 }
             }
         }
@@ -1971,7 +2062,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         // any band, retry heuristic detection with all items as a single band.
         // This catches borderless tables whose text-column alignment was
         // misclassified as page-layout columns.
-        if was_split && !page_tables.contains_key(&page) && !merged_band.0.is_empty() {
+        if was_split && !table_output.has_tables_on_page(page) && !merged_band.0.is_empty() {
             let (ref band_items, ref band_index_map, _, _) = merged_band;
             log::debug!(
                 "page {}: merged-band retry ({} items, was_split={})",
@@ -2028,13 +2119,16 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
                         }
                     }
                 }
-                page_tables
-                    .entry(page)
-                    .or_default()
-                    .push(positioned_table(table, chart_prose_order));
+                table_output.record(page, table, chart_prose_order);
             }
         }
     }
+
+    #[cfg(feature = "ocr")]
+    let mut detected_tables = table_output.complete_tables;
+    #[cfg(feature = "ocr")]
+    detected_tables.sort_by_key(|(page, _)| *page);
+    let mut page_tables = table_output.markdown_by_page;
 
     // Images are also removed before line grouping, so give them the same
     // logical chart-page position as tables before reinsertion.
@@ -2293,7 +2387,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
     // Convert to markdown, inserting tables and images at appropriate positions
     let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
     band_split_page_set.extend(page_chart_prose_splits.keys().copied());
-    to_markdown_from_lines_with_tables_and_images(
+    let markdown = to_markdown_from_lines_with_tables_and_images(
         lines,
         options,
         page_tables,
@@ -2301,7 +2395,12 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         &page_chart_map,
         &band_split_page_set,
         effective_struct_roles,
-    )
+    );
+    MarkdownConversionOutput {
+        markdown,
+        #[cfg(feature = "ocr")]
+        detected_tables,
+    }
 }
 
 #[cfg(test)]

--- a/src/tables/detect_lines.rs
+++ b/src/tables/detect_lines.rs
@@ -10,6 +10,7 @@ use crate::tables::Table;
 use crate::types::{PdfLine, PdfRect, TextItem};
 
 use super::detect_rects::{assign_items_to_grid, snap_edges};
+use super::grid::join_cell_items;
 
 const RULE_Y_TOLERANCE: f32 = 2.0;
 const RULE_JOIN_GAP: f32 = 6.0;
@@ -1352,22 +1353,42 @@ fn refine_segment_grid_text_rows(
         return None;
     }
 
-    let mut cells = vec![vec![String::new(); column_count]; anchored_rows.len()];
+    let mut cell_items = vec![vec![Vec::new(); column_count]; anchored_rows.len()];
     let mut item_indices = Vec::new();
     for (row_index, (_, row_items)) in anchored_rows.iter().enumerate() {
         for (item_index, item) in row_items {
             let center_x = item.x + item.width.max(0.0) / 2.0;
-            let column = (0..column_count).find(|&index| {
+            let Some(column) = (0..column_count).find(|&index| {
                 center_x >= table.columns[index] - RULE_Y_TOLERANCE
                     && center_x <= table.columns[index + 1] + RULE_Y_TOLERANCE
-            })?;
-            if !cells[row_index][column].is_empty() {
-                cells[row_index][column].push(' ');
-            }
-            cells[row_index][column].push_str(item.text.trim());
+            }) else {
+                continue;
+            };
+            cell_items[row_index][column].push(*item);
             item_indices.push(*item_index);
         }
     }
+
+    let cells: Vec<Vec<String>> = cell_items
+        .iter_mut()
+        .map(|row| {
+            row.iter_mut()
+                .map(|items| {
+                    if crate::text_utils::is_rtl_text(items.iter().map(|item| &item.text)) {
+                        crate::text_utils::sort_rtl_cell_items(
+                            items,
+                            |item| item.x,
+                            |item| item.y,
+                            |item| item.text.as_str(),
+                        );
+                    } else {
+                        items.sort_by(|left, right| left.x.total_cmp(&right.x));
+                    }
+                    join_cell_items(items)
+                })
+                .collect()
+        })
+        .collect();
 
     // Wrapped prose inside a wide cell can expose many baselines without any
     // row schema. Require repeated baselines that independently populate at
@@ -3021,6 +3042,51 @@ mod tests {
         );
 
         assert!(refine_segment_grid_text_rows(&items, &rules, 1, &physical).is_none());
+    }
+
+    #[test]
+    fn text_row_refinement_skips_items_outside_column_bands() {
+        let columns = vec![60.0, 160.0, 260.0];
+        let rules = vec![(500.0, 60.0, 260.0), (400.0, 60.0, 260.0)];
+        let mut items = vec![make_item("margin note", 30.0, 480.0, 1)];
+        for (row, y) in [480.0, 460.0, 440.0].into_iter().enumerate() {
+            items.push(make_item(&format!("label-{row}"), 80.0, y, 1));
+            items.push(make_item(&format!("value-{row}"), 180.0, y, 1));
+        }
+        let physical = Table::new(
+            columns,
+            vec![500.0],
+            vec![vec!["label".into(), "value".into()]],
+            Vec::new(),
+        );
+
+        let refined = refine_segment_grid_text_rows(&items, &rules, 1, &physical)
+            .expect("an out-of-band item must not abort otherwise valid refinement");
+        assert_eq!(refined.cells.len(), 3);
+        assert_eq!(refined.cells[0], ["label-0", "value-0"]);
+        assert!(!refined.item_indices.contains(&0));
+    }
+
+    #[test]
+    fn text_row_refinement_joins_rtl_fragments_in_reading_order() {
+        let columns = vec![60.0, 160.0, 260.0];
+        let rules = vec![(500.0, 60.0, 260.0), (400.0, 60.0, 260.0)];
+        let mut items = Vec::new();
+        for y in [480.0, 460.0, 440.0] {
+            items.push(make_item("שתיים", 80.0, y, 1));
+            items.push(make_item("אחד", 120.0, y, 1));
+            items.push(make_item("1", 180.0, y, 1));
+        }
+        let physical = Table::new(
+            columns,
+            vec![500.0],
+            vec![vec!["header".into(), "value".into()]],
+            Vec::new(),
+        );
+
+        let refined = refine_segment_grid_text_rows(&items, &rules, 1, &physical)
+            .expect("repeated RTL rows should refine");
+        assert_eq!(refined.cells[0][0], "אחד שתיים");
     }
 
     #[test]

--- a/src/tables/detect_lines.rs
+++ b/src/tables/detect_lines.rs
@@ -1201,6 +1201,203 @@ fn derive_columns_from_horizontal_segments(horizontals: &[(f32, f32, f32)]) -> O
     Some(qualifying)
 }
 
+/// Build independently scoped grids when several horizontal-segment tables
+/// share a page.
+///
+/// The legacy implicit-grid path derives its row and column edges from every
+/// horizontal segment on the page. Stacked tables with different spans can
+/// therefore be joined through the prose between them, while the combined
+/// endpoint frequency drops real outer columns. Logical rule spans already
+/// identify the independent bands; validate each band through the same legacy
+/// grid path before allowing the scoped set to compete with the page-wide grid.
+fn build_independent_segment_grid_tables(
+    items: &[TextItem],
+    horizontals: &[HorizontalRule],
+    page: u32,
+) -> Vec<Table> {
+    let logical_rules = merge_horizontal_segments(horizontals);
+    let rule_runs: Vec<Vec<HorizontalRule>> = group_rules_by_span(&logical_rules)
+        .into_iter()
+        .flat_map(|span_group| split_independent_rule_runs(&span_group, items, page))
+        .filter(|rules| rules.len() >= 3)
+        .collect();
+    if rule_runs.len() < 2 {
+        return Vec::new();
+    }
+
+    let scopes: Vec<(f32, f32, f32, f32)> = rule_runs
+        .iter()
+        .map(|rules| {
+            let x_left = rules
+                .iter()
+                .map(|rule| rule.1)
+                .fold(f32::INFINITY, f32::min);
+            let y_bottom = rules
+                .iter()
+                .map(|rule| rule.0)
+                .fold(f32::INFINITY, f32::min);
+            let x_right = rules
+                .iter()
+                .map(|rule| rule.2)
+                .fold(f32::NEG_INFINITY, f32::max);
+            let y_top = rules
+                .iter()
+                .map(|rule| rule.0)
+                .fold(f32::NEG_INFINITY, f32::max);
+            (x_left, y_bottom, x_right, y_top)
+        })
+        .collect();
+    // Local density is safe for truly stacked bands. Overlapping bands can be
+    // side-by-side fragments of one wide table, so preserve the page-wide
+    // density check that rejects those partial hypotheses.
+    let use_scoped_density = scopes.iter().enumerate().all(|(index, left)| {
+        scopes[index + 1..]
+            .iter()
+            .all(|right| left.3.min(right.3) - left.1.max(right.1) <= RULE_Y_TOLERANCE)
+    });
+
+    let mut tables = Vec::new();
+    for (rules, scope) in rule_runs.into_iter().zip(scopes) {
+        let (x_left, y_bottom, x_right, y_top) = scope;
+
+        let scoped_lines: Vec<PdfLine> = horizontals
+            .iter()
+            .filter(|&&(y, x_min, x_max)| {
+                y >= y_bottom - RULE_Y_TOLERANCE
+                    && y <= y_top + RULE_Y_TOLERANCE
+                    && x_min >= x_left - RULE_JOIN_GAP
+                    && x_max <= x_right + RULE_JOIN_GAP
+            })
+            .map(|&(y, x_min, x_max)| PdfLine {
+                x1: x_min,
+                y1: y,
+                x2: x_max,
+                y2: y,
+                page,
+            })
+            .collect();
+        let detected = if use_scoped_density {
+            detect_segment_grid_in_scope(items, &scoped_lines, page, scope)
+        } else {
+            detect_tables_from_lines_inner(items, &scoped_lines, page, false, false)
+        };
+        tables.extend(detected.into_iter().map(|table| {
+            refine_segment_grid_text_rows(items, &rules, page, &table).unwrap_or(table)
+        }));
+    }
+
+    let tables = select_non_overlapping_hypotheses(tables);
+    if tables.len() < 2 {
+        return Vec::new();
+    }
+    log::debug!(
+        "detect_lines p{}: recovered {} independent horizontal-segment grids",
+        page,
+        tables.len()
+    );
+    tables
+}
+
+/// Run one independent segment-grid hypothesis against only the text in its
+/// physical band, then translate the detector's local item indices back to the
+/// caller's collection. Keeping this adaptation outside the legacy detector
+/// avoids adding a second density mode to every line-table strategy.
+fn detect_segment_grid_in_scope(
+    items: &[TextItem],
+    lines: &[PdfLine],
+    page: u32,
+    (x_left, y_bottom, x_right, y_top): (f32, f32, f32, f32),
+) -> Vec<Table> {
+    let scoped_indices: Vec<usize> = items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| {
+            let center_x = item.x + item.width.max(0.0) / 2.0;
+            item.page == page
+                && center_x >= x_left - RULE_JOIN_GAP
+                && center_x <= x_right + RULE_JOIN_GAP
+                && item.y >= y_bottom - RULE_Y_TOLERANCE
+                && item.y <= y_top + RULE_Y_TOLERANCE
+        })
+        .map(|(index, _)| index)
+        .collect();
+    let scoped_items: Vec<TextItem> = scoped_indices
+        .iter()
+        .map(|&index| items[index].clone())
+        .collect();
+    let mut tables = detect_tables_from_lines_inner(&scoped_items, lines, page, false, false);
+    for table in &mut tables {
+        for index in &mut table.item_indices {
+            *index = scoped_indices[*index];
+        }
+    }
+    tables
+}
+
+/// Replace broad physical row bands with repeated text baselines when the
+/// segment grid proves the columns but only sparse booktabs-style rules were
+/// painted for the rows.
+fn refine_segment_grid_text_rows(
+    items: &[TextItem],
+    rules: &[HorizontalRule],
+    page: u32,
+    table: &Table,
+) -> Option<Table> {
+    let column_count = table.columns.len().saturating_sub(1);
+    if column_count < 2 {
+        return None;
+    }
+    let anchored_rows = collect_anchored_rows(items, rules, page);
+    if anchored_rows.len() <= table.cells.len() || anchored_rows.len() > 80 {
+        return None;
+    }
+
+    let mut cells = vec![vec![String::new(); column_count]; anchored_rows.len()];
+    let mut item_indices = Vec::new();
+    for (row_index, (_, row_items)) in anchored_rows.iter().enumerate() {
+        for (item_index, item) in row_items {
+            let center_x = item.x + item.width.max(0.0) / 2.0;
+            let column = (0..column_count).find(|&index| {
+                center_x >= table.columns[index] - RULE_Y_TOLERANCE
+                    && center_x <= table.columns[index + 1] + RULE_Y_TOLERANCE
+            })?;
+            if !cells[row_index][column].is_empty() {
+                cells[row_index][column].push(' ');
+            }
+            cells[row_index][column].push_str(item.text.trim());
+            item_indices.push(*item_index);
+        }
+    }
+
+    // Wrapped prose inside a wide cell can expose many baselines without any
+    // row schema. Require repeated baselines that independently populate at
+    // least half of the physical columns before treating baselines as rows.
+    let min_dense_columns = column_count.div_ceil(2).max(2);
+    let dense_rows = cells
+        .iter()
+        .filter(|row| row.iter().filter(|cell| !cell.is_empty()).count() >= min_dense_columns)
+        .count();
+    if dense_rows < 3 || dense_rows * 2 < cells.len() {
+        return None;
+    }
+
+    item_indices.sort_unstable();
+    item_indices.dedup();
+    log::debug!(
+        "detect_lines p{}: refined segment grid from {} physical rows to {} text rows ({} dense)",
+        page,
+        table.cells.len(),
+        cells.len(),
+        dense_rows
+    );
+    Some(Table::new(
+        table.columns.clone(),
+        anchored_rows.iter().map(|(y, _)| *y).collect(),
+        cells,
+        item_indices,
+    ))
+}
+
 /// Detect tables from line segments on a given page.
 ///
 /// Lines are classified as horizontal or vertical, snapped into grid edges,
@@ -1543,6 +1740,7 @@ fn detect_tables_from_lines_inner(
         return Vec::new();
     }
     let mut alternatives = Vec::new();
+    let mut independent_segment_tables = Vec::new();
     if allow_alternatives {
         if let Some(table) = build_dense_row_anchor_table(items, &horizontals, &verticals, page) {
             alternatives.push(table);
@@ -1553,6 +1751,11 @@ fn detect_tables_from_lines_inner(
             &verticals,
             page,
         ));
+        if verticals.len() < 2 {
+            independent_segment_tables =
+                build_independent_segment_grid_tables(items, &horizontals, page);
+            alternatives.extend(independent_segment_tables.iter().cloned());
+        }
     }
     // Booktabs and response-form tables commonly draw horizontal rules only.
     // Their rules describe table bands, not row/cell boundaries, so infer
@@ -1815,7 +2018,7 @@ fn detect_tables_from_lines_inner(
     // The grid must capture a meaningful portion of the page's text items.
     // Chart/graph grids on textbook pages capture scattered labels but miss
     // the bulk of the page content (explanatory text, problem statements).
-    let page_item_count = items.iter().filter(|i| i.page == page).count();
+    let page_item_count = items.iter().filter(|item| item.page == page).count();
     if page_item_count > 0 {
         let capture_ratio = item_indices.len() as f32 / page_item_count as f32;
         // If the grid captures less than 20% of items, it's not a real table
@@ -1860,16 +2063,23 @@ fn detect_tables_from_lines_inner(
         page, num_rows, num_cols, item_indices.len(), page_item_count, non_empty_rows, cols_with_content
     );
 
-    select_table_hypothesis(
-        vec![Table::new(
-            col_edges,
-            row_edges_desc[..num_rows].to_vec(),
-            cells,
-            item_indices,
-        )],
-        alternatives,
-        page,
-    )
+    let legacy_table = Table::new(
+        col_edges,
+        row_edges_desc[..num_rows].to_vec(),
+        cells,
+        item_indices,
+    );
+    let legacy_tables = if overlaps_multiple_tables(&legacy_table, &independent_segment_tables) {
+        log::debug!(
+            "detect_lines p{}: rejected page-wide grid spanning multiple independent segment grids",
+            page
+        );
+        Vec::new()
+    } else {
+        vec![legacy_table]
+    };
+
+    select_table_hypothesis(legacy_tables, alternatives, page)
 }
 
 #[cfg(test)]
@@ -2671,6 +2881,146 @@ mod tests {
             t.cells.len()
         );
         assert_eq!(t.cells[0].len(), 3, "expected 3 columns");
+    }
+
+    #[test]
+    fn test_stacked_horizontal_segment_grids_are_scoped_independently() {
+        let table_specs = [
+            (
+                [700.0, 675.0, 570.0],
+                [60.0, 145.0, 250.0, 360.0],
+                [687.0, 660.0, 640.0, 620.0, 600.0, 580.0],
+                "upper",
+            ),
+            (
+                [450.0, 425.0, 315.0],
+                [80.0, 190.0, 320.0, 500.0],
+                [437.0, 410.0, 390.0, 370.0, 350.0, 325.0],
+                "lower",
+            ),
+        ];
+        let mut lines = Vec::new();
+        let mut items = Vec::new();
+        for (row_edges, col_edges, text_rows, label) in table_specs {
+            for y in row_edges {
+                for pair in col_edges.windows(2) {
+                    lines.push(make_hline(y, pair[0], pair[1], 1));
+                }
+            }
+            for (row, y) in text_rows.into_iter().enumerate() {
+                for (column, x_pair) in col_edges.windows(2).enumerate() {
+                    let x = (x_pair[0] + x_pair[1]) / 2.0;
+                    items.push(make_item(&format!("{label}-{row}-{column}"), x, y, 1));
+                }
+            }
+        }
+        // A scoped table must compete against text in its own rule band, not
+        // unrelated prose elsewhere on a dense page.
+        for index in 0..160 {
+            items.push(make_item(
+                &format!("outside prose {index}"),
+                550.0,
+                790.0 - index as f32 * 4.0,
+                1,
+            ));
+        }
+
+        let tables = detect_tables_from_lines(&items, &lines, 1);
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].cells.len(), 6);
+        assert_eq!(tables[0].cells[0].len(), 3);
+        assert_eq!(tables[0].cells[0][0], "upper-0-0");
+        assert_eq!(tables[1].cells.len(), 6);
+        assert_eq!(tables[1].cells[0].len(), 3);
+        assert_eq!(tables[1].cells[0][0], "lower-0-0");
+    }
+
+    #[test]
+    fn test_one_segment_grid_plus_decorative_rules_does_not_enable_split_recovery() {
+        let row_edges = [700.0, 665.0, 615.0, 570.0];
+        let col_edges = [60.0, 145.0, 250.0, 360.0];
+        let mut horizontals = Vec::new();
+        for y in row_edges {
+            for pair in col_edges.windows(2) {
+                horizontals.push((y, pair[0], pair[1]));
+            }
+        }
+        horizontals.extend([
+            (450.0, 40.0, 220.0),
+            (410.0, 55.0, 260.0),
+            (365.0, 75.0, 300.0),
+        ]);
+        let mut items = Vec::new();
+        for (row, y_pair) in row_edges.windows(2).enumerate() {
+            let y = (y_pair[0] + y_pair[1]) / 2.0;
+            for (column, x_pair) in col_edges.windows(2).enumerate() {
+                let x = (x_pair[0] + x_pair[1]) / 2.0;
+                items.push(make_item(&format!("cell-{row}-{column}"), x, y, 1));
+            }
+        }
+
+        assert!(build_independent_segment_grid_tables(&items, &horizontals, 1).is_empty());
+    }
+
+    #[test]
+    fn test_side_by_side_segment_grids_do_not_enable_stacked_recovery() {
+        let row_edges = [700.0, 665.0, 615.0, 570.0];
+        let table_columns = [[60.0, 110.0, 160.0], [180.0, 230.0, 280.0]];
+        let mut horizontals = Vec::new();
+        let mut items = Vec::new();
+        for col_edges in table_columns {
+            for &y in &row_edges {
+                for pair in col_edges.windows(2) {
+                    horizontals.push((y, pair[0], pair[1]));
+                }
+            }
+            for (row, y_pair) in row_edges.windows(2).enumerate() {
+                let y = (y_pair[0] + y_pair[1]) / 2.0;
+                for (column, x_pair) in col_edges.windows(2).enumerate() {
+                    let x = (x_pair[0] + x_pair[1]) / 2.0;
+                    items.push(make_item(&format!("cell-{row}-{column}"), x, y, 1));
+                }
+            }
+        }
+        for index in 0..60 {
+            items.push(make_item(
+                &format!("outside prose {index}"),
+                350.0,
+                790.0 - index as f32 * 4.0,
+                1,
+            ));
+        }
+
+        assert!(build_independent_segment_grid_tables(&items, &horizontals, 1).is_empty());
+    }
+
+    #[test]
+    fn test_single_column_continuations_do_not_refine_physical_rows() {
+        let columns = vec![60.0, 160.0, 260.0, 360.0];
+        let rules = vec![
+            (500.0, 60.0, 360.0),
+            (475.0, 60.0, 360.0),
+            (350.0, 60.0, 360.0),
+        ];
+        let mut items = vec![
+            make_item("Description", 80.0, 487.0, 1),
+            make_item("Amount", 180.0, 487.0, 1),
+            make_item("Status", 280.0, 487.0, 1),
+        ];
+        for (index, y) in [460.0, 440.0, 420.0, 400.0, 380.0].into_iter().enumerate() {
+            items.push(make_item(&format!("wrapped line {index}"), 80.0, y, 1));
+        }
+        let physical = Table::new(
+            columns,
+            vec![500.0, 475.0],
+            vec![
+                vec!["Description".into(), "Amount".into(), "Status".into()],
+                vec!["wrapped body".into(), String::new(), String::new()],
+            ],
+            (0..items.len()).collect(),
+        );
+
+        assert!(refine_segment_grid_text_rows(&items, &rules, 1, &physical).is_none());
     }
 
     #[test]

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -847,13 +847,15 @@ pub fn detect_tables_from_rects(
         // (row stripes don't overlap so each is its own cluster of 1),
         // try all page rects directly as a row-stripe table.
         // Require ≥15 rects and ≥10 result rows to avoid decorative fill false positives.
-        if tables.is_empty() && clusters.is_empty() && page_rects.len() >= 15 {
-            if let Some(table) = detect_row_stripe_table(items, &page_rects, page) {
+        let row_stripe_rects =
+            without_page_backgrounds(&page_rects, PageBackgroundRemoval::Repeated);
+        if tables.is_empty() && clusters.is_empty() && row_stripe_rects.len() >= 15 {
+            if let Some(table) = detect_row_stripe_table(items, &row_stripe_rects, page) {
                 if table.rows.len() >= 10 {
                     debug!(
                         "page {}: row-stripe fallback succeeded ({} rects, {} rows)",
                         page,
-                        page_rects.len(),
+                        row_stripe_rects.len(),
                         table.rows.len()
                     );
                     tables.push(table);
@@ -3727,6 +3729,40 @@ mod tests {
         assert_eq!(tables.len(), 1, "a real repeated cell grid must survive");
         assert_eq!(tables[0].rows.len(), 4);
         assert_eq!(tables[0].columns.len(), 3);
+    }
+
+    #[test]
+    fn minority_page_backgrounds_do_not_expand_row_stripe_fallback() {
+        let page_fill = PdfRect {
+            x: 0.0,
+            y: 0.0,
+            width: 600.0,
+            height: 800.0,
+            page: 1,
+        };
+        let mut rects = vec![page_fill; DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS];
+        let mut items = Vec::new();
+        for row in 0..25 {
+            let y = 200.0 + row as f32 * 20.0;
+            rects.push(PdfRect {
+                x: 40.0,
+                y,
+                width: 510.0,
+                height: 16.0,
+                page: 1,
+            });
+            items.push(make_item(&format!("row {row}"), 60.0, y + 5.0, 9.0));
+            items.push(make_item(&format!("value {row}"), 320.0, y + 5.0, 9.0));
+        }
+
+        let (tables, _) = detect_tables_from_rects(&items, &rects, 1);
+        assert_eq!(tables.len(), 1, "the row-stripe table should survive");
+        assert_eq!(
+            tables[0].rows.len(),
+            25,
+            "page fills must not add full-page rows to the fallback grid"
+        );
+        assert_eq!(tables[0].columns.len(), 2);
     }
 
     #[test]

--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -549,6 +549,23 @@ pub fn detect_tables_from_rects(
         page_rects.push((x, y, w, h));
     }
 
+    // Some generators repeat a page-sized clipping/fill rectangle for nearly
+    // every content operation. When those duplicates overwhelmingly dominate
+    // the drawing geometry, they manufacture full-page X/Y edges and make
+    // every synthetic grid cell appear covered. Remove only that strong
+    // duplicate-background shape; a minority of page fills can coexist with
+    // genuine cell geometry and must remain available to the detectors.
+    let normalized_rects =
+        without_page_backgrounds(&page_rects, PageBackgroundRemoval::Overwhelming);
+    if normalized_rects.len() < page_rects.len() {
+        debug!(
+            "page {}: removed {} overwhelming page-background rects",
+            page,
+            page_rects.len() - normalized_rects.len()
+        );
+        page_rects = normalized_rects;
+    }
+
     // Remove rects that are much wider than typical cell rects — these are
     // page-spanning clipping paths or row-spanning background fills that
     // would add spurious X-edges and corrupt the grid.  We use the median
@@ -680,7 +697,8 @@ pub fn detect_tables_from_rects(
                 // re-cluster the remaining geometry, and evaluate valid table
                 // candidates as a competing hypothesis before the chart
                 // rejection wins.
-                let normalized = without_dominant_page_backgrounds(&group_rects);
+                let normalized =
+                    without_page_backgrounds(&group_rects, PageBackgroundRemoval::Repeated);
                 let normalized_table = (normalized.len() < group_rects.len())
                     .then(|| {
                         cluster_rects(&normalized, 3.0, 6)
@@ -2232,11 +2250,22 @@ fn row_stripe_is_sparse_prose_outline(cells: &[Vec<String>]) -> bool {
     long_dense_cells * 2 >= dense_count
 }
 
-/// Remove repeated page-scale fills from a chart-like cluster so the actual
-/// cell/bar geometry can be evaluated independently. A small number of
-/// coincident origin frames may be meaningful table structure, so repetition
-/// only becomes normalization evidence when it dominates the cluster.
-fn without_dominant_page_backgrounds(rects: &[(f32, f32, f32, f32)]) -> Vec<(f32, f32, f32, f32)> {
+#[derive(Clone, Copy)]
+enum PageBackgroundRemoval {
+    /// Repeated page fills interfere with chart-vs-grid classification even
+    /// when real cell geometry remains the majority.
+    Repeated,
+    /// Top-level normalization is more conservative: page fills must comprise
+    /// at least 75% of all useful drawing rectangles.
+    Overwhelming,
+}
+
+/// Apply the shared page-scale classification and removal policy used by the
+/// top-level detector and chart recovery.
+fn without_page_backgrounds(
+    rects: &[(f32, f32, f32, f32)],
+    policy: PageBackgroundRemoval,
+) -> Vec<(f32, f32, f32, f32)> {
     let x_max = rects
         .iter()
         .map(|&(x, _, width, _)| x + width)
@@ -2245,13 +2274,16 @@ fn without_dominant_page_backgrounds(rects: &[(f32, f32, f32, f32)]) -> Vec<(f32
         .iter()
         .map(|&(_, y, _, height)| y + height)
         .fold(0.0_f32, f32::max);
-    let is_page_scale = |&(x, y, width, height): &(f32, f32, f32, f32)| {
+    let is_page_scale = |&&(x, y, width, height): &&(f32, f32, f32, f32)| {
         x < 5.0 && y < 5.0 && width >= x_max * 0.9 && height >= y_max * 0.9
     };
+    let page_scale_count = rects.iter().filter(is_page_scale).count();
 
-    if rects.iter().filter(|rect| is_page_scale(rect)).count()
-        < DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS
-    {
+    let meets_policy = match policy {
+        PageBackgroundRemoval::Repeated => true,
+        PageBackgroundRemoval::Overwhelming => page_scale_count * 4 >= rects.len() * 3,
+    };
+    if page_scale_count < DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS || !meets_policy {
         return rects.to_vec();
     }
 
@@ -2358,7 +2390,8 @@ fn is_repeated_cell_grid(group_rects: &[(f32, f32, f32, f32)]) -> bool {
 
 fn repeated_cell_grid_overrides_bar_hypothesis(group_rects: &[(f32, f32, f32, f32)]) -> bool {
     is_repeated_cell_grid(group_rects)
-        && without_dominant_page_backgrounds(group_rects).len() == group_rects.len()
+        && without_page_backgrounds(group_rects, PageBackgroundRemoval::Repeated).len()
+            == group_rects.len()
 }
 
 /// Detect horizontal segmented stacks from aligned rows of touching rects.
@@ -3600,11 +3633,100 @@ mod tests {
 
         let mut dominant = vec![page_fill; DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS];
         dominant.push(cell);
-        assert_eq!(without_dominant_page_backgrounds(&dominant), vec![cell]);
+        assert_eq!(
+            without_page_backgrounds(&dominant, PageBackgroundRemoval::Repeated),
+            vec![cell]
+        );
 
         let mut incidental = vec![page_fill; DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS - 1];
         incidental.push(cell);
-        assert_eq!(without_dominant_page_backgrounds(&incidental), incidental);
+        assert_eq!(
+            without_page_backgrounds(&incidental, PageBackgroundRemoval::Repeated),
+            incidental
+        );
+    }
+
+    #[test]
+    fn overwhelming_page_backgrounds_are_removed_before_grid_detection() {
+        let page_fill = PdfRect {
+            x: 0.0,
+            y: 0.0,
+            width: 600.0,
+            height: 800.0,
+            page: 1,
+        };
+        let mut rects = vec![page_fill; 12];
+        rects.extend([
+            PdfRect {
+                x: 70.0,
+                y: 320.0,
+                width: 240.0,
+                height: 260.0,
+                page: 1,
+            },
+            PdfRect {
+                x: 330.0,
+                y: 400.0,
+                width: 200.0,
+                height: 48.0,
+                page: 1,
+            },
+            PdfRect {
+                x: 115.0,
+                y: 70.0,
+                width: 150.0,
+                height: 12.0,
+                page: 1,
+            },
+        ]);
+        let items = vec![
+            make_item("body prose", 70.0, 700.0, 10.0),
+            make_item("continued body prose", 300.0, 620.0, 10.0),
+            make_item("Figure 6", 340.0, 430.0, 9.0),
+            make_item("caption", 410.0, 410.0, 9.0),
+            make_item("footnote", 120.0, 74.0, 8.0),
+        ];
+
+        let (tables, _) = detect_tables_from_rects(&items, &rects, 1);
+        assert!(
+            tables.is_empty(),
+            "duplicate page backgrounds must not manufacture a full-page table"
+        );
+    }
+
+    #[test]
+    fn minority_page_backgrounds_preserve_real_cell_grid() {
+        let page_fill = PdfRect {
+            x: 0.0,
+            y: 0.0,
+            width: 600.0,
+            height: 800.0,
+            page: 1,
+        };
+        let mut rects = vec![page_fill; DOMINANT_PAGE_BACKGROUND_MIN_REPETITIONS];
+        let mut items = Vec::new();
+        for row in 0..4 {
+            for col in 0..3 {
+                rects.push(PdfRect {
+                    x: 100.0 + col as f32 * 100.0,
+                    y: 600.0 - row as f32 * 24.0,
+                    width: 100.0,
+                    height: 24.0,
+                    page: 1,
+                });
+                items.push(make_item(
+                    "42",
+                    110.0 + col as f32 * 100.0,
+                    607.0 - row as f32 * 24.0,
+                    9.0,
+                ));
+            }
+        }
+
+        let (tables, _) = detect_tables_from_rects(&items, &rects, 1);
+        assert_eq!(tables.len(), 1, "a real repeated cell grid must survive");
+        assert_eq!(tables[0].rows.len(), 4);
+        assert_eq!(tables[0].columns.len(), 3);
     }
 
     #[test]

--- a/src/tables/format.rs
+++ b/src/tables/format.rs
@@ -59,6 +59,21 @@ pub fn table_to_markdown(table: &Table) -> String {
     output
 }
 
+/// True when a detected data table survives formatting cleanup with a header,
+/// at least one body row, and at least two columns.
+///
+/// Supplemental OCR uses this at the structured-table boundary so incomplete
+/// detections cannot modify an otherwise clean native page.
+#[cfg(any(test, feature = "ocr"))]
+pub(crate) fn is_complete_data_table(table: &Table) -> bool {
+    if table.kind != TableKind::Data {
+        return false;
+    }
+
+    let (cleaned_cells, _) = clean_table_cells(&table.cells);
+    cleaned_cells.len() >= 2 && cleaned_cells.first().is_some_and(|row| row.len() >= 2)
+}
+
 /// Render a table-of-contents as a flat per-row text block.
 ///
 /// Each row becomes one line: non-empty cells joined with spaces, and the
@@ -910,6 +925,29 @@ mod tests {
         let md = table_to_markdown(&table);
         assert!(md.contains("|Only|"));
         assert!(md.contains("|---|"));
+    }
+
+    #[test]
+    fn complete_data_table_requires_header_body_and_two_columns() {
+        let complete = Table {
+            columns: vec![100.0, 200.0, 300.0],
+            rows: vec![500.0, 480.0, 460.0],
+            cells: vec![
+                vec!["Metric".into(), "Value".into()],
+                vec!["Accuracy".into(), "95%".into()],
+            ],
+            item_indices: vec![],
+            kind: TableKind::Data,
+        };
+        assert!(is_complete_data_table(&complete));
+
+        let mut single_row = complete.clone();
+        single_row.cells.truncate(1);
+        assert!(!is_complete_data_table(&single_row));
+
+        let mut toc = complete;
+        toc.kind = TableKind::Toc;
+        assert!(!is_complete_data_table(&toc));
     }
 
     #[test]

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -22,6 +22,9 @@ pub(crate) use detect_lines::{
 pub(crate) use detect_rects::cluster_rects;
 pub use detect_rects::{detect_chart_regions, detect_tables_from_rects, RectHintRegion};
 pub use detect_struct::detect_tables_from_struct_tree;
+#[cfg(any(test, feature = "ocr"))]
+#[cfg(feature = "ocr")]
+pub(crate) use format::is_complete_data_table;
 pub use format::table_to_markdown;
 pub use structured::{cells_to_markdown, StructuredCell};
 

--- a/src/vision/fusion.rs
+++ b/src/vision/fusion.rs
@@ -5,9 +5,12 @@ use std::time::Instant;
 
 use thiserror::Error;
 
-use crate::markdown::{to_markdown_from_items_with_rects_and_page_count, MarkdownOptions};
+use crate::markdown::{
+    complete_table_markdown_from_items, to_markdown_from_items_with_rects_and_page_count,
+    MarkdownOptions,
+};
 use crate::text_quality::{detect_encoding_issues, is_cid_garbage, is_garbage_text};
-use crate::types::{ItemType, TextItem};
+use crate::types::{ItemType, PdfRect, TextItem};
 use crate::PageMarkdown;
 
 use super::{
@@ -124,6 +127,16 @@ pub(crate) struct NativeFallbackCandidate {
     origin: NativeCandidateOrigin,
 }
 
+/// How OCR output for a routed page may participate in final fusion.
+#[derive(Debug, Clone)]
+pub(crate) enum OcrFusionRoute {
+    /// The page requires ordinary full-page OCR replacement or adaptive fusion.
+    FullPage,
+    /// The native page is clean; only tables detected inside these image
+    /// regions may be appended.
+    SupplementalRegions(Vec<PdfRect>),
+}
+
 impl NativeFallbackCandidate {
     /// True when an independent native recovery is substantial enough to
     /// cancel OCR for recoverable font/vector routing reasons.
@@ -193,16 +206,19 @@ pub fn fuse_ocr_pages(
     document_page_count: u32,
     options: &OcrFusionOptions,
 ) -> Result<FusedPages, OcrFusionError> {
+    let routes = full_page_routes(ocr_run);
     fuse_ocr_pages_impl(
         native_pages,
         ocr_run,
         document_page_count,
         options,
         &BTreeMap::new(),
+        &routes,
     )
 }
 
 /// OCR-pipeline fusion with trustworthy partial native candidates.
+#[cfg(test)]
 pub(crate) fn fuse_ocr_pages_adaptive(
     native_pages: &[PageMarkdown],
     ocr_run: &OcrRun,
@@ -210,12 +226,41 @@ pub(crate) fn fuse_ocr_pages_adaptive(
     options: &OcrFusionOptions,
     native_candidates: &BTreeMap<u32, NativeFallbackCandidate>,
 ) -> Result<FusedPages, OcrFusionError> {
+    let routes = full_page_routes(ocr_run);
     fuse_ocr_pages_impl(
         native_pages,
         ocr_run,
         document_page_count,
         options,
         native_candidates,
+        &routes,
+    )
+}
+
+fn full_page_routes(ocr_run: &OcrRun) -> BTreeMap<u32, OcrFusionRoute> {
+    ocr_run
+        .pages
+        .iter()
+        .map(|page| (page.rendered.page(), OcrFusionRoute::FullPage))
+        .collect()
+}
+
+/// OCR-pipeline fusion with an explicit route mode for every processed page.
+pub(crate) fn fuse_ocr_pages_adaptive_with_routes(
+    native_pages: &[PageMarkdown],
+    ocr_run: &OcrRun,
+    document_page_count: u32,
+    options: &OcrFusionOptions,
+    native_candidates: &BTreeMap<u32, NativeFallbackCandidate>,
+    routes: &BTreeMap<u32, OcrFusionRoute>,
+) -> Result<FusedPages, OcrFusionError> {
+    fuse_ocr_pages_impl(
+        native_pages,
+        ocr_run,
+        document_page_count,
+        options,
+        native_candidates,
+        routes,
     )
 }
 
@@ -225,6 +270,7 @@ fn fuse_ocr_pages_impl(
     document_page_count: u32,
     options: &OcrFusionOptions,
     native_candidates: &BTreeMap<u32, NativeFallbackCandidate>,
+    routes: &BTreeMap<u32, OcrFusionRoute>,
 ) -> Result<FusedPages, OcrFusionError> {
     validate_options(options)?;
 
@@ -273,13 +319,35 @@ fn fuse_ocr_pages_impl(
                     ));
                 }
                 warnings.extend(local.ocr.warnings.iter().cloned());
-                let ocr_markdown = to_markdown_from_items_with_rects_and_page_count(
-                    ocr_items,
-                    options.markdown.clone(),
-                    &[],
-                    document_page_count,
-                );
-                let ocr_markdown = preserve_ocr_line_breaks(&ocr_markdown, local);
+                let route = routes
+                    .get(&page_number)
+                    .ok_or(OcrFusionError::MissingOcrRoute { page: page_number })?;
+                let ocr_markdown = match route {
+                    OcrFusionRoute::SupplementalRegions(regions) => {
+                        let region_items = items_inside_regions(ocr_items, regions);
+                        let table_markdown = complete_table_markdown_from_items(
+                            region_items,
+                            options.markdown.clone(),
+                            document_page_count,
+                        );
+                        if table_markdown.is_empty() {
+                            warnings.push(
+                                "image-region OCR found no valid table; kept native content"
+                                    .to_string(),
+                            );
+                        }
+                        table_markdown
+                    }
+                    OcrFusionRoute::FullPage => {
+                        let markdown = to_markdown_from_items_with_rects_and_page_count(
+                            ocr_items,
+                            options.markdown.clone(),
+                            &[],
+                            document_page_count,
+                        );
+                        preserve_ocr_line_breaks(&markdown, local)
+                    }
+                };
                 let (markdown, source, adaptive_recommends_hosted) = if let Some(candidate) =
                     native_candidates
                         .get(&page_number)
@@ -716,6 +784,24 @@ fn is_markdown_table_line(line: &str) -> bool {
     trimmed.starts_with('|') && trimmed.ends_with('|') && trimmed.matches('|').count() >= 2
 }
 
+fn items_inside_regions(items: Vec<TextItem>, regions: &[PdfRect]) -> Vec<TextItem> {
+    items
+        .into_iter()
+        .filter(|item| {
+            let center_x = item.x + item.width / 2.0;
+            let center_y = item.y + item.height / 2.0;
+            regions.iter().any(|region| {
+                const EDGE_TOLERANCE_PT: f32 = 2.0;
+                item.page == region.page
+                    && center_x >= region.x - EDGE_TOLERANCE_PT
+                    && center_x <= region.x + region.width + EDGE_TOLERANCE_PT
+                    && center_y >= region.y - EDGE_TOLERANCE_PT
+                    && center_y <= region.y + region.height + EDGE_TOLERANCE_PT
+            })
+        })
+        .collect()
+}
+
 fn merge_native_and_ocr(native: &str, ocr: &str) -> (String, PageContentSource) {
     let native_keys = comparison_units(native);
     let mut addition_keys = Vec::new();
@@ -948,6 +1034,12 @@ pub enum OcrFusionError {
         /// Unexpected 1-indexed page number.
         page: u32,
     },
+    /// OCR input did not have an explicit full-page or supplemental route.
+    #[error("OCR page {page} has no fusion route")]
+    MissingOcrRoute {
+        /// Unrouted 1-indexed page number.
+        page: u32,
+    },
     /// Render resolution is non-finite or non-positive.
     #[error("render DPI must be positive and finite, got {value}")]
     InvalidRenderDpi {
@@ -1049,6 +1141,190 @@ mod tests {
 
     fn native_candidate(markdown: &str) -> NativeFallbackCandidate {
         assess_native_candidate(markdown.to_string(), NativeCandidateOrigin::Extractor).unwrap()
+    }
+
+    #[test]
+    fn supplemental_image_ocr_keeps_native_text_without_a_valid_table() {
+        let native = [native(0, "Native article text\n", false)];
+        let run = run(vec![routed_page(
+            1,
+            vec![positioned_span(
+                "Figure-only OCR label",
+                20.0,
+                20.0,
+                180.0,
+                35.0,
+            )],
+            Some(0.95),
+        )]);
+        let routes = BTreeMap::from([(
+            1,
+            OcrFusionRoute::SupplementalRegions(vec![PdfRect {
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 100.0,
+                page: 1,
+            }]),
+        )]);
+
+        let result = fuse_ocr_pages_adaptive_with_routes(
+            &native,
+            &run,
+            1,
+            &OcrFusionOptions::new(),
+            &BTreeMap::new(),
+            &routes,
+        )
+        .unwrap();
+
+        assert_eq!(result.pages[0].markdown, "Native article text\n");
+        assert_eq!(result.pages[0].provenance.source, PageContentSource::Native);
+        assert!(result.pages[0].provenance.warnings[0].contains("no valid table"));
+    }
+
+    #[test]
+    fn supplemental_image_ocr_fuses_a_table_inside_the_region() {
+        let native = [native(0, "Native article text\n", false)];
+        let mut spans = Vec::new();
+        for (row, (left, right)) in [
+            ("Metric", "Value"),
+            ("Accuracy", "95%"),
+            ("Recall", "93%"),
+            ("Precision", "96%"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let top = 10.0 + row as f32 * 20.0;
+            spans.push(positioned_span(left, 10.0, top, 80.0, top + 10.0));
+            spans.push(positioned_span(right, 110.0, top, 180.0, top + 10.0));
+        }
+        let run = run(vec![routed_page(1, spans, Some(0.95))]);
+        let routes = BTreeMap::from([(
+            1,
+            OcrFusionRoute::SupplementalRegions(vec![PdfRect {
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 100.0,
+                page: 1,
+            }]),
+        )]);
+
+        let result = fuse_ocr_pages_adaptive_with_routes(
+            &native,
+            &run,
+            1,
+            &OcrFusionOptions::new(),
+            &BTreeMap::new(),
+            &routes,
+        )
+        .unwrap();
+
+        assert_eq!(result.pages[0].provenance.source, PageContentSource::Fused);
+        assert!(result.pages[0].markdown.contains("|Metric|Value|"));
+        assert!(result.pages[0].markdown.contains("|Accuracy|95%|"));
+        assert_eq!(
+            result.pages[0].markdown.matches("Native article").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn supplemental_table_detection_requires_multiple_rows() {
+        let items = vec![
+            TextItem {
+                text: "Metric".to_string(),
+                x: 10.0,
+                y: 40.0,
+                width: 50.0,
+                height: 10.0,
+                font: "OCR".to_string(),
+                font_tag: String::new(),
+                font_size: 10.0,
+                page: 1,
+                is_bold: false,
+                is_italic: false,
+                is_underline: false,
+                is_strikeout: false,
+                item_type: ItemType::Text,
+                mcid: None,
+            },
+            TextItem {
+                text: "Value".to_string(),
+                x: 110.0,
+                y: 40.0,
+                width: 50.0,
+                height: 10.0,
+                font: "OCR".to_string(),
+                font_tag: String::new(),
+                font_size: 10.0,
+                page: 1,
+                is_bold: false,
+                is_italic: false,
+                is_underline: false,
+                is_strikeout: false,
+                item_type: ItemType::Text,
+                mcid: None,
+            },
+        ];
+
+        let mut options = MarkdownOptions::default();
+        options.base_font_size = Some(10.0);
+        assert!(complete_table_markdown_from_items(items, options, 1).is_empty());
+    }
+
+    #[test]
+    fn supplemental_image_ocr_filters_spans_by_region_center() {
+        let items = vec![
+            TextItem {
+                text: "inside".to_string(),
+                x: 10.0,
+                y: 10.0,
+                width: 20.0,
+                height: 10.0,
+                font: "OCR".to_string(),
+                font_tag: String::new(),
+                font_size: 10.0,
+                page: 1,
+                is_bold: false,
+                is_italic: false,
+                is_underline: false,
+                is_strikeout: false,
+                item_type: ItemType::Text,
+                mcid: None,
+            },
+            TextItem {
+                text: "outside".to_string(),
+                x: 120.0,
+                y: 10.0,
+                width: 20.0,
+                height: 10.0,
+                font: "OCR".to_string(),
+                font_tag: String::new(),
+                font_size: 10.0,
+                page: 1,
+                is_bold: false,
+                is_italic: false,
+                is_underline: false,
+                is_strikeout: false,
+                item_type: ItemType::Text,
+                mcid: None,
+            },
+        ];
+        let regions = [PdfRect {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+            page: 1,
+        }];
+
+        let filtered = items_inside_regions(items, &regions);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].text, "inside");
     }
 
     #[test]

--- a/src/vision/image_analysis.rs
+++ b/src/vision/image_analysis.rs
@@ -1,0 +1,121 @@
+//! Cheap bitmap signals used to decide whether OCR work is warranted.
+
+use crate::types::PdfRect;
+
+use super::{RenderPixelFormat, RenderedPage};
+
+/// Returns whether a PDF-space region has a document-like mix of white
+/// background, dark foreground ink, content rows, and blank separators.
+pub(super) fn region_has_document_like_ink(page: &RenderedPage, region: &PdfRect) -> bool {
+    let (x, y, width, height) = page.pdf_rect_to_pixel(region);
+    let x0 = x.floor().max(0.0).min(f64::from(page.width())) as usize;
+    let y0 = y.floor().max(0.0).min(f64::from(page.height())) as usize;
+    let x1 = (x + width).ceil().max(0.0).min(f64::from(page.width())) as usize;
+    let y1 = (y + height).ceil().max(0.0).min(f64::from(page.height())) as usize;
+    if x1 <= x0 + 4 || y1 <= y0 + 4 {
+        return false;
+    }
+
+    let pixel_count = (x1 - x0).saturating_mul(y1 - y0);
+    let step = ((pixel_count / 150_000).max(1) as f64).sqrt().ceil() as usize;
+    let bytes_per_pixel = page.format().bytes_per_pixel();
+    let mut sampled = 0usize;
+    let mut near_white = 0usize;
+    let mut dark = 0usize;
+    let mut content_rows = 0usize;
+    let mut blank_rows = 0usize;
+    for sample_y in (y0..y1).step_by(step.max(1)) {
+        let mut row_sampled = 0usize;
+        let mut row_white = 0usize;
+        let mut row_dark = 0usize;
+        for sample_x in (x0..x1).step_by(step.max(1)) {
+            let offset = sample_y * page.stride() + sample_x * bytes_per_pixel;
+            let luminance = match page.format() {
+                RenderPixelFormat::Gray8 => u16::from(page.pixels()[offset]),
+                RenderPixelFormat::Rgb8 | RenderPixelFormat::Rgba8 => {
+                    let red = u16::from(page.pixels()[offset]);
+                    let green = u16::from(page.pixels()[offset + 1]);
+                    let blue = u16::from(page.pixels()[offset + 2]);
+                    (red * 3 + green * 6 + blue) / 10
+                }
+            };
+            sampled += 1;
+            row_sampled += 1;
+            if luminance >= 235 {
+                near_white += 1;
+                row_white += 1;
+            }
+            if luminance <= 110 {
+                dark += 1;
+                row_dark += 1;
+            }
+        }
+        if row_sampled > 0 {
+            let dark_ratio = row_dark as f32 / row_sampled as f32;
+            let white_ratio = row_white as f32 / row_sampled as f32;
+            if (0.01..=0.65).contains(&dark_ratio) {
+                content_rows += 1;
+            } else if row_dark == 0 && white_ratio >= 0.9 {
+                blank_rows += 1;
+            }
+        }
+    }
+
+    if sampled == 0 {
+        return false;
+    }
+    let white_ratio = near_white as f32 / sampled as f32;
+    let dark_ratio = dark as f32 / sampled as f32;
+    white_ratio >= 0.45
+        && (0.002..=0.35).contains(&dark_ratio)
+        && content_rows >= 3
+        && blank_rows >= 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vision::PageTransform;
+
+    fn rendered_gray_page(pixels: Vec<u8>) -> RenderedPage {
+        let transform =
+            PageTransform::from_corners(20, 20, (0.0, 20.0), (20.0, 20.0), (0.0, 0.0)).unwrap();
+        RenderedPage::new(
+            1,
+            20.0,
+            20.0,
+            20,
+            20,
+            20,
+            RenderPixelFormat::Gray8,
+            pixels,
+            transform,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn requires_document_like_ink_rows() {
+        let region = PdfRect {
+            x: 0.0,
+            y: 0.0,
+            width: 20.0,
+            height: 20.0,
+            page: 1,
+        };
+        let mut document = vec![255; 400];
+        for y in [4usize, 10, 16] {
+            for x in 4usize..16 {
+                document[y * 20 + x] = 0;
+            }
+        }
+        assert!(region_has_document_like_ink(
+            &rendered_gray_page(document),
+            &region
+        ));
+        assert!(!region_has_document_like_ink(
+            &rendered_gray_page(vec![128; 400]),
+            &region
+        ));
+    }
+}

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -14,6 +14,8 @@ mod contracts;
 mod download;
 #[cfg(all(feature = "vision", not(target_arch = "wasm32")))]
 mod fusion;
+#[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
+mod image_analysis;
 #[cfg(all(feature = "model-cache", not(target_arch = "wasm32")))]
 mod models;
 #[cfg(all(feature = "ocr-oar", not(target_arch = "wasm32")))]

--- a/src/vision/pipeline.rs
+++ b/src/vision/pipeline.rs
@@ -16,9 +16,10 @@ use crate::{
 };
 
 use super::fusion::{
-    assess_native_candidate, fuse_ocr_pages_adaptive, NativeCandidateOrigin,
-    NativeFallbackCandidate,
+    assess_native_candidate, fuse_ocr_pages_adaptive_with_routes, NativeCandidateOrigin,
+    NativeFallbackCandidate, OcrFusionRoute,
 };
+use super::image_analysis::region_has_document_like_ink;
 use super::oar::onnx_runtime_library_path;
 use super::pdfium::PdfiumTextPage;
 use super::{
@@ -243,12 +244,15 @@ pub fn process_pdf_with_ocr_mem(
 
     let mut page_markdown_options = options.markdown.clone();
     page_markdown_options.include_page_numbers = false;
-    let (mut native, page_count) = crate::extract_pages_markdown_mem_for_ocr(
+    let extraction = crate::extract_pages_markdown_mem_for_ocr(
         buffer,
         selected_pages_zero_indexed.as_deref(),
         options.password.as_deref(),
         &page_markdown_options,
     )?;
+    let mut native = extraction.result;
+    let page_count = extraction.page_count;
+    let extracted_supplemental_regions = extraction.supplemental_ocr_regions;
     if let Some(invalid) = selected_pages
         .as_ref()
         .and_then(|pages| pages.iter().copied().find(|page| *page > page_count))
@@ -283,7 +287,17 @@ pub fn process_pdf_with_ocr_mem(
         }
     }
 
-    let mut routed = initially_routed.clone();
+    let mut fusion_routes: BTreeMap<u32, OcrFusionRoute> = initially_routed
+        .iter()
+        .map(|page| (*page, OcrFusionRoute::FullPage))
+        .collect();
+    if options.ocr.mode == OcrMode::Auto {
+        for (&page, regions) in &extracted_supplemental_regions {
+            fusion_routes
+                .entry(page)
+                .or_insert_with(|| OcrFusionRoute::SupplementalRegions(regions.clone()));
+        }
+    }
     let mut renderer = None;
     let mut recovered_natively = BTreeSet::new();
     if options.ocr.mode == OcrMode::Auto {
@@ -294,7 +308,7 @@ pub fn process_pdf_with_ocr_mem(
         native_probe_pages.extend(
             native_candidates
                 .keys()
-                .filter(|page| routed.contains(page))
+                .filter(|page| fusion_routes.contains_key(page))
                 .copied(),
         );
         if !native_probe_pages.is_empty() {
@@ -331,6 +345,13 @@ pub fn process_pdf_with_ocr_mem(
                     native_page.markdown = candidate.markdown().to_string();
                     native_page.needs_ocr = false;
                     native_candidates.remove(&page.page);
+                    if let Some(route) =
+                        route_after_native_recovery(page.page, &extracted_supplemental_regions)
+                    {
+                        fusion_routes.insert(page.page, route);
+                    } else {
+                        fusion_routes.remove(&page.page);
+                    }
                     recovered_natively.insert(page.page);
                 } else {
                     match native_candidates.entry(page.page) {
@@ -345,16 +366,40 @@ pub fn process_pdf_with_ocr_mem(
                     }
                 }
             }
-            routed.retain(|page| !recovered_natively.contains(page));
         }
     }
 
+    let supplemental_preflight_ms = if options.ocr.mode == OcrMode::Auto
+        && fusion_routes
+            .values()
+            .any(|route| matches!(route, OcrFusionRoute::SupplementalRegions(_)))
+    {
+        let native_renderer = match renderer {
+            Some(renderer) => renderer,
+            None => PdfiumRenderer::load()?,
+        };
+        let elapsed = filter_supplemental_routes_by_pixels(
+            &native_renderer,
+            buffer,
+            options.password.as_deref(),
+            &options.render,
+            &mut fusion_routes,
+        )?;
+        renderer = Some(native_renderer);
+        elapsed
+    } else {
+        0
+    };
+
+    // Derive the renderer input once, after every route mutation, so the
+    // route map remains the single source of truth throughout planning.
+    let routed: Vec<u32> = fusion_routes.keys().copied().collect();
     let fusion_options = OcrFusionOptions::new()
         .markdown(page_markdown_options)
         .render_dpi(options.render.dpi)
         .hosted_recommendation_confidence(options.hosted_recommendation_confidence);
     let mut fused = if routed.is_empty() {
-        fuse_ocr_pages_adaptive(
+        fuse_ocr_pages_adaptive_with_routes(
             &native.pages,
             &OcrRun {
                 pages: Vec::new(),
@@ -364,6 +409,7 @@ pub fn process_pdf_with_ocr_mem(
             page_count,
             &fusion_options,
             &native_candidates,
+            &fusion_routes,
         )?
     } else {
         // Resolve the native renderer before any network request so a missing
@@ -385,8 +431,12 @@ pub fn process_pdf_with_ocr_mem(
             page_count,
             &fusion_options,
             &native_candidates,
+            &fusion_routes,
         )?
     };
+    fused.render_time_ms = fused
+        .render_time_ms
+        .saturating_add(supplemental_preflight_ms);
     for page in &mut fused.pages {
         if recovered_natively.contains(&page.page_number) {
             page.provenance
@@ -427,6 +477,56 @@ pub fn process_pdf_with_ocr_mem(
     })
 }
 
+fn route_after_native_recovery(
+    page: u32,
+    supplemental_regions: &BTreeMap<u32, Vec<crate::types::PdfRect>>,
+) -> Option<OcrFusionRoute> {
+    supplemental_regions
+        .get(&page)
+        .cloned()
+        .map(OcrFusionRoute::SupplementalRegions)
+}
+
+/// Keep supplemental OCR lazy by cheaply checking rendered image regions for
+/// document-like foreground ink before the model store or OCR engine is
+/// touched. Full-page routes already have native extraction evidence and are
+/// never filtered here.
+fn filter_supplemental_routes_by_pixels(
+    renderer: &PdfiumRenderer,
+    pdf_bytes: &[u8],
+    password: Option<&str>,
+    render_options: &RenderOptions,
+    routes: &mut BTreeMap<u32, OcrFusionRoute>,
+) -> Result<u64, OcrPipelineError> {
+    let pages: Vec<u32> = routes
+        .iter()
+        .filter_map(|(&page, route)| {
+            matches!(route, OcrFusionRoute::SupplementalRegions(_)).then_some(page)
+        })
+        .collect();
+    if pages.is_empty() {
+        return Ok(0);
+    }
+
+    let started = Instant::now();
+    let mut preflight_options = render_options.clone();
+    preflight_options.dpi = preflight_options.dpi.min(96.0);
+    for chunk in pages.chunks(OCR_PAGE_CHUNK_SIZE) {
+        let rendered = renderer.render_pages(pdf_bytes, chunk, password, &preflight_options)?;
+        for page in rendered {
+            let Some(OcrFusionRoute::SupplementalRegions(regions)) = routes.get_mut(&page.page())
+            else {
+                continue;
+            };
+            regions.retain(|region| region_has_document_like_ink(&page, region));
+        }
+    }
+    routes.retain(|_, route| {
+        !matches!(route, OcrFusionRoute::SupplementalRegions(regions) if regions.is_empty())
+    });
+    Ok(elapsed_ms(started))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_and_fuse_ocr_chunks<R, O>(
     renderer: &R,
@@ -440,6 +540,7 @@ fn run_and_fuse_ocr_chunks<R, O>(
     document_page_count: u32,
     fusion_options: &OcrFusionOptions,
     native_candidates: &BTreeMap<u32, NativeFallbackCandidate>,
+    fusion_routes: &BTreeMap<u32, OcrFusionRoute>,
 ) -> Result<FusedPages, OcrPipelineError>
 where
     R: PageRenderer,
@@ -475,12 +576,13 @@ where
             render_options,
             ocr_options,
         )?;
-        let fused = fuse_ocr_pages_adaptive(
+        let fused = fuse_ocr_pages_adaptive_with_routes(
             &native_chunk,
             &run,
             document_page_count,
             fusion_options,
             native_candidates,
+            fusion_routes,
         )?;
         render_time_ms = render_time_ms.saturating_add(fused.render_time_ms);
         ocr_time_ms = ocr_time_ms.saturating_add(fused.ocr_time_ms);
@@ -492,7 +594,7 @@ where
 
     let native_only = select_native_pages(native_pages, |page| !routed.contains(&page));
     if !native_only.is_empty() {
-        let fused = fuse_ocr_pages_adaptive(
+        let fused = fuse_ocr_pages_adaptive_with_routes(
             &native_only,
             &OcrRun {
                 pages: Vec::new(),
@@ -502,6 +604,7 @@ where
             document_page_count,
             fusion_options,
             native_candidates,
+            fusion_routes,
         )?;
         for page in fused.pages {
             pages_by_number.insert(page.page_number, page);
@@ -1082,6 +1185,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let routed_pages = (1..=10).collect::<Vec<_>>();
+        let routes = routed_pages
+            .iter()
+            .map(|&page| (page, OcrFusionRoute::FullPage))
+            .collect();
         let ocr_options = OcrOptions::new().mode(OcrMode::Force);
 
         let fused = run_and_fuse_ocr_chunks(
@@ -1096,6 +1203,7 @@ mod tests {
             10,
             &OcrFusionOptions::new(),
             &BTreeMap::new(),
+            &routes,
         )
         .unwrap();
 
@@ -1135,6 +1243,30 @@ mod tests {
         ];
 
         assert_eq!(native_recovery_candidates(&routed, &reasons), vec![1, 3]);
+    }
+
+    #[test]
+    fn native_recovery_retains_supplemental_image_regions() {
+        let region = crate::types::PdfRect {
+            x: 10.0,
+            y: 20.0,
+            width: 200.0,
+            height: 120.0,
+            page: 2,
+        };
+        let supplemental = BTreeMap::from([(2, vec![region.clone()])]);
+
+        let route = route_after_native_recovery(2, &supplemental).unwrap();
+        let OcrFusionRoute::SupplementalRegions(regions) = route else {
+            panic!("native recovery must leave image regions on a supplemental route");
+        };
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].x, region.x);
+        assert_eq!(regions[0].y, region.y);
+        assert_eq!(regions[0].width, region.width);
+        assert_eq!(regions[0].height, region.height);
+        assert_eq!(regions[0].page, region.page);
+        assert!(route_after_native_recovery(1, &supplemental).is_none());
     }
 
     #[test]
@@ -1312,15 +1444,15 @@ mod tests {
         assert!(public.pages[0].needs_ocr);
         assert!(public.pages[0].markdown.trim().is_empty());
 
-        let (ocr, _) = crate::extract_pages_markdown_mem_for_ocr(
+        let ocr = crate::extract_pages_markdown_mem_for_ocr(
             &bytes,
             None,
             None,
             &MarkdownOptions::default(),
         )
         .unwrap();
-        assert!(ocr.pages[0].needs_ocr);
-        assert!(ocr.pages[0]
+        assert!(ocr.result.pages[0].needs_ocr);
+        assert!(ocr.result.pages[0]
             .markdown
             .contains("Order Detail Report by Account"));
     }


### PR DESCRIPTION
## Summary

Improves table recovery for stacked ruled layouts and image-embedded tables while filtering repeated page-background geometry that can create false full-page grids.

Selective OCR is restricted to substantial image regions and only fuses structurally complete detected tables into otherwise clean native pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers stacked ruled tables and image-embedded tables while avoiding false full-page grids from duplicate page-background rectangles. OCR is now restricted to substantial image regions and only appends tables when a structurally complete table is found; otherwise native text remains unchanged.

- Line-rule detector: builds independent segment-grid tables per stacked band; refines sparse physical rows using repeated text baselines; rejects a page-wide grid that spans multiple independent grids; side-by-side grids do not trigger stacked recovery.
- Rect detector: applies an “overwhelming” page-background removal policy at the top level and a “repeated” policy for chart regions; minority page fills no longer suppress real cell grids or expand row-stripe fallback.
- Markdown/OCR: table pipeline can emit only complete data tables (`is_complete_data_table` gates header+body, ≥2 columns); supplemental OCR routes filter OCR spans by region center and fuse tables only; adds low-DPI bitmap preflight to require document-like ink; render time includes this preflight.
- Extraction/fusion: collects substantial image regions per page for supplemental OCR; introduces explicit fusion routes (FullPage vs SupplementalRegions) and errors on missing routes; native recovery retains supplemental routes for image regions.

<sup>Written for commit 3da33c066890e2222d59851627c5542b85fe719c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

