### PR TITLE
ci(actions): speed up cross-platform checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # CI does not need test debug symbols. Disabling them trims link time and
+  # keeps the cross-platform Cargo caches substantially smaller.
+  CARGO_PROFILE_TEST_DEBUG: 0
+
+# Superseded PR revisions provide no useful signal and otherwise compete with
+# the larger cross-platform matrix for runner and cache bandwidth.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -15,7 +24,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -38,7 +47,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -56,7 +65,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -78,11 +87,15 @@ jobs:
         run: cargo clippy --features ocr -- -D warnings
 
   build:
-    name: Build
-    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - os: macos-latest
+            runner: blacksmith-6vcpu-macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -101,11 +114,17 @@ jobs:
 
   ocr:
     name: OCR (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            runner: blacksmith-8vcpu-ubuntu-2404
+          - os: macos-latest
+            runner: blacksmith-6vcpu-macos-15
+          - os: windows-latest
+            runner: blacksmith-8vcpu-windows-2025
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -124,7 +143,7 @@ jobs:
 
   ocr-runtime:
     name: OCR runtime smoke
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -232,11 +251,24 @@ jobs:
           export PDF_INSPECTOR_OCR_TEST_MODELS="$PDF_INSPECTOR_MODEL_CACHE/pp-ocrv6-small/oar-ocr-v0.7.0"
           cargo test --features ocr --test ocr_tests -- --nocapture
 
-      - name: Build Node binding
-        working-directory: napi
+      # The bindings use independent Cargo target directories. Build them at
+      # the same time so this smoke job is bounded by the slower binding build
+      # instead of paying for both release builds serially.
+      - name: Build Node and Python bindings
+        shell: bash
         run: |
-          bun install --frozen-lockfile
-          bunx napi build --platform --release
+          (
+            cd napi
+            bun install --frozen-lockfile
+            bunx napi build --platform --release
+          ) &
+          node_build_pid=$!
+
+          python -m pip install 'maturin>=1,<2'
+          maturin build --release --out "$RUNNER_TEMP/python-wheels"
+
+          wait "$node_build_pid"
+          python -m pip install "$RUNNER_TEMP"/python-wheels/*.whl
 
       - name: Run Node OCR binding
         shell: bash
@@ -252,13 +284,6 @@ jobs:
           if (!['Ocr', 'Fused'].includes(result.pages[0].provenance.source)) throw new Error('unexpected source')
           if (!result.pages[0].markdown.trim()) throw new Error('empty OCR markdown')
           JS
-
-      - name: Build and install Python binding
-        shell: bash
-        run: |
-          python -m pip install 'maturin>=1,<2'
-          maturin build --release --out "$RUNNER_TEMP/python-wheels"
-          python -m pip install "$RUNNER_TEMP"/python-wheels/*.whl
 
       - name: Run Python OCR binding
         shell: bash
@@ -278,7 +303,7 @@ jobs:
 
   wasm:
     name: WebAssembly
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3531,20 +3531,15 @@ fn test_extract_pages_markdown_basic() {
 fn test_extract_pages_markdown_keeps_line_based_tables() {
     // The per-page path (used by every `--ocr auto` run) once passed an
     // empty line slice to markdown conversion, silently dropping every
-    // table that only the line-based detector finds. This fixture's table
-    // is rule-anchored: it must survive the pages API exactly as it does
-    // the whole-document API.
-    let buf = std::fs::read("tests/fixtures/bits_pilani_feedback.pdf").unwrap();
+    // table that only the line-based detector finds. Keep this synthetic
+    // table to four text items so the heuristic detector cannot qualify it
+    // (it requires at least six); the vector rules are the only structural
+    // evidence available to the pages API.
+    let buf = synthetic_vector_grid_pdf(false);
     let result = extract_pages_markdown_mem(&buf, None).unwrap();
 
-    let all_markdown: String = result
-        .pages
-        .iter()
-        .map(|p| p.markdown.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
     assert!(
-        all_markdown.contains("|BIO|"),
+        result.pages[0].markdown.contains("|A1|B1|"),
         "line-based table rows missing from pages API output"
     );
 }


### PR DESCRIPTION
## Summary

Moves CI to workload-sized Blacksmith runners, cancels superseded PR runs, reduces test linking and cache overhead, and overlaps the independent Node and Python OCR binding builds. Replaces the oversized document used by the line-table regression with a strict synthetic fixture that preserves detector coverage while removing the dominant test bottleneck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up cross-platform CI by moving jobs to workload-sized Blacksmith runners, canceling superseded PR runs, trimming Rust test debug symbols, and building Node and Python OCR bindings in parallel. Replaces an oversized real PDF in the line-table regression test with a strict synthetic grid to keep detector coverage while removing the main test bottleneck.

- CI runs on `blacksmith-*` runners for Linux, macOS, and Windows; superseded PR runs are now auto-canceled via workflow concurrency.
- Sets `CARGO_PROFILE_TEST_DEBUG=0` to cut link time and cache size; test failure backtraces may be less detailed.
- OCR smoke job builds `napi` (Node) and `maturin` (Python) bindings concurrently; no functional change to either binding.
- The table regression test now uses `synthetic_vector_grid_pdf(false)` and asserts `|A1|B1|` in page 1 markdown to ensure the pages API still emits line-based tables without the heuristic detector.

<sup>Written for commit 38bc6d77e47ec437c2d950ab097eefb168a6bdce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

