### PR TITLE
ci(release): speed up package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
         with:
           workspaces: |
             wasm -> target
-          key: wasm
+          shared-key: wasm
 
       - name: Check WebAssembly bindings
         run: cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
 
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: crate-publish
+
       - name: Verify package
         run: cargo publish --dry-run
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -84,23 +84,23 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.changed == 'true' && needs.check-version.outputs.published == 'false'
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             docker-options: -e CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8
           # macos-13 was retired by GitHub; macos-15-intel is the remaining
           # Intel runner label (available through 2027).
-          - os: macos-15-intel
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
-          - os: macos-14
+          - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
-          - os: windows-latest
+          - runner: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -115,6 +115,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           manylinux: auto
+          sccache: true
           # The manylinux AArch64 GCC omits this macro while preprocessing
           # ring's assembly. AArch64 is ARMv8 by definition.
           docker-options: ${{ matrix.docker-options }}

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -65,14 +65,13 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-  publish:
-    name: Build and publish
+  build:
+    name: Build package
     needs: check-version
     if: needs.check-version.outputs.changed == 'true' && needs.check-version.outputs.package_exists == 'true' && needs.check-version.outputs.published == 'false'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -81,6 +80,13 @@ jobs:
         with:
           toolchain: "1.98.0" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: |
+            wasm -> target
+          shared-key: wasm
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -110,6 +116,33 @@ jobs:
 
       - name: Inspect package contents
         run: npm pack --dry-run ./wasm/pkg
+
+      - name: Upload package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wasm-package
+          path: wasm/pkg
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    needs: [check-version, build]
+    if: needs.check-version.outputs.changed == 'true' && needs.check-version.outputs.package_exists == 'true' && needs.check-version.outputs.published == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wasm-package
+          path: wasm/pkg
 
       - name: Publish package
         run: npm publish ./wasm/pkg --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,29 +58,29 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.changed == 'true'
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
           # napi-cross builds gnu targets against an old glibc sysroot for
           # broad distro compatibility; musl targets cross-compile with
           # zig via cargo-zigbuild (napi's -x flag).
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             build-flags: --use-napi-cross
             cflags: -D__ARM_ARCH=8
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-musl
             build-flags: -x
-          - os: ubuntu-latest
+          - runner: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-musl
             build-flags: -x
-          - os: macos-14
+          - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
-          - os: windows-latest
+          - runner: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -154,22 +154,22 @@ jobs:
   smoke-test:
     name: Smoke test ${{ matrix.target }}
     needs: [check-version, build]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - runner: blacksmith-2vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - runner: blacksmith-2vcpu-ubuntu-2404
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-24.04-arm
+          - runner: blacksmith-2vcpu-ubuntu-2404-arm
             target: aarch64-unknown-linux-gnu
-          - os: ubuntu-24.04-arm
+          - runner: blacksmith-2vcpu-ubuntu-2404-arm
             target: aarch64-unknown-linux-musl
-          - os: macos-14
+          - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
-          - os: windows-latest
+          - runner: blacksmith-2vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Moves compute-heavy Python wheel and npm native-addon matrices to Blacksmith runners while retaining GitHub’s Intel macOS runner, enables maturin sccache, and runs package smoke tests on smaller Blacksmith runners. It also adds Rust caching for crate and WebAssembly releases, shares the WebAssembly cache with regular CI, and separates the Blacksmith-hosted WebAssembly build from the GitHub-hosted publish job so publishing credentials remain isolated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up release publishing by moving heavy build matrices to Blacksmith runners, enabling Rust build caching, and splitting WebAssembly build/publish to isolate credentials. Previously Python wheels and Node native-addons built on GitHub-hosted runners; now they build on Blacksmith, while Intel macOS builds remain on GitHub.

- Runner updates: switch `publish.yml` and `publish-pypi.yml` matrices to Blacksmith labels; run smoke tests on smaller Blacksmith runners; keep `macos-15-intel` for x86_64 macOS.
- PyPI: enable `maturin` `sccache: true`.
- Rust caching: add `Swatinem/rust-cache` to crate and WebAssembly jobs; share the wasm cache with CI via `shared-key: wasm` (update in `ci.yml`).
- WebAssembly: split `publish-wasm.yml` into `build` (Blacksmith) and `publish` (GitHub with OIDC); pass the package via `actions/upload-artifact`/`actions/download-artifact`.
- No change to published artifacts; expect shorter runtimes. Rollout: ensure Blacksmith runners exist (`blacksmith-8vcpu-ubuntu-2404`, `blacksmith-6vcpu-macos-15`, `blacksmith-8vcpu-windows-2025`, `blacksmith-4vcpu-ubuntu-2404`, `blacksmith-2vcpu-ubuntu-2404(-arm)`, `blacksmith-2vcpu-windows-2025`) and npm OIDC provenance remains authorized.

<sup>Written for commit a397ac03f2562ce6b3133642d0e3ba4530847d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

