### PR TITLE
fix(tables): reject layout bands in the cell-rect fallback

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -2201,6 +2201,22 @@ fn row_stripe_cells_are_prose(cells: &[Vec<String>]) -> bool {
         && sentence_columns.iter().filter(|&&v| v).count() >= 2
 }
 
+/// A row that swallowed the page's flowing prose: paragraph-scale text
+/// holding at least half the table's total. The row-granular sibling of
+/// `has_dominant_prose_cell`: a template content band (one rect, no
+/// interior row edges) boxes a whole document section into a single
+/// giant row, and the columns carved from it split that prose into
+/// sub-threshold cells — every per-cell signal stays blind, only the
+/// row sum sees it.
+fn has_dominant_prose_row(cells: &[Vec<String>]) -> bool {
+    let row_chars: Vec<usize> = cells
+        .iter()
+        .map(|row| row.iter().map(|cell| cell.len()).sum())
+        .collect();
+    let total_chars: usize = row_chars.iter().sum();
+    row_chars.iter().any(|&n| n > 500 && n * 2 >= total_chars)
+}
+
 fn row_stripe_is_sparse_prose_outline(cells: &[Vec<String>]) -> bool {
     let Some(num_cols) = cells.first().map(|row| row.len()) else {
         return false;
@@ -2933,6 +2949,14 @@ fn detect_row_stripe_table_from_cell_rects(
             "  cell-rect collapsed {} wrapped description rows",
             collapsed_rows
         );
+    }
+
+    // Reject layout bands: a template content frame boxes flowing prose
+    // into one giant row. The paragraph-wall guard below only fires
+    // under 4 non-empty rows, which header chips above the band supply.
+    if has_dominant_prose_row(&cells) {
+        debug!("  cell-rect rejected: one row holds most of the text (layout band)");
+        return None;
     }
 
     // Validate: >=2 non-empty rows, >=25% density
@@ -3891,6 +3915,36 @@ mod tests {
         let (tables, hints) = detect_tables_from_rects(&items, &rects, 1);
         assert!(tables.is_empty());
         assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn layout_band_rejects_stripe_fallback() {
+        // A template content band (drawn several times) over a page
+        // background, with header chips above: the stripe fallback must
+        // not box the band's flowing prose into one giant table row.
+        let mut rects = vec![
+            (0.0, 0.0, 612.0, 792.0),
+            (0.0, 0.0, 612.0, 792.0),
+            (28.0, 730.0, 158.0, 22.0),
+            (28.0, 702.0, 158.0, 20.0),
+            (224.0, 702.0, 156.0, 20.0),
+        ];
+        for _ in 0..4 {
+            rects.push((27.6, 60.0, 534.2, 640.0)); // the content band
+        }
+        let mut items = vec![
+            make_item("Name", 35.0, 740.0, 10.0),
+            make_item("Objective", 35.0, 712.0, 10.0),
+            make_item("user@example.com", 230.0, 712.0, 10.0),
+        ];
+        let prose = "Goal: reduce the defect rate across the production \
+                     line. Action: build a supplier scorecard covering \
+                     quality, cost, and delivery with one dashboard. \
+                     Result: defect rate down 35 percent overall.";
+        for i in 0..8 {
+            items.push(make_item(prose, 35.0, 620.0 - i as f32 * 18.0, 10.0));
+        }
+        assert!(detect_row_stripe_table_from_cell_rects(&items, &rects, 1).is_none());
     }
 
     #[test]

--- a/tests/fixtures/template_layout_band.pdf
+++ b/tests/fixtures/template_layout_band.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595 842 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260824220136+08'00') /Creator (anonymous) /Keywords () /ModDate (D:20260824220136+08'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1016
+>>
+stream
+Gau0A9lo&I&A@sBlnQdF1eEgojAVS/RV=+::+BgqaTVa4,%;*k!RS.Mlam-F=`,c:Q\Z_N0)"nM#:b@jN\&t2#OlU7f7.CojfiJB/!9s7+(;Fc+;5c-F.n2$3A4fAjBrOff.YhjHJ;dM/>'b#7]"6FjA/M^c\"`U8!!;(3mW`3>Wjm,1Te=N*6^pu8I"^\.UbM5<eU:KA2__'p2#Ck;Gs8)X?(U66L3Qf7<8d9n$%+$H3T&NO<K*6T"=L_J$6U3GN'Z^i:Fa[E'%1#NDTEMN;M7TOrf2[Wr!PR=P$2>\F*[`nC8r.#@s$$3r[E8+.\b3&Sfc#PkC/[17uD^MO[A($KanijeSRH1nPFl#IK!$@N(]k;aira!U**q!pVTQo6f*N%MfR<)M*bj>T^YL7';sn+o(bl:CHs9eBfo;"qSr.%tqd.=*^61P&q%L86^@.:Z!d#VllbIhJ4HVBXE)YVJ9p<%q(bl@,,F2_6jQ^dBr7n<ZnABE]RnHV/[HEDdY^6l%"=*qHaNod;j)c1K+D-pZMj5J)_MMA0EZ`<Ds]s,\_G+'s@5W/Yi<<B!tu\MEOmf'[K!W#O-,tbu<r1nid1;8*-nFRc6C]&Y/%rpu#Pn,9]smSHTq!;($1$DWWJ_r0MG;P\ikhCYY6IaR+>RfD#>=2"uTs]n-cI'&(.'@WFtp"Br-bA/&]'Ju^]7QIB>IXWoq71%C'N8;"T6cD06S*^,k::as/TWF=pl,Kc-kVroYTk8\\Tj706;q/dX6Pf^1l"ehG5'M2#Odp6oScku$',2UE^"Z-F#H_tWLSD'l<Yb;q>jL6kT"1QgC5-""B><NhhGn7lSL&I3,o>p:h:.T)UeQZh:g5a[(3[QHPT.a`_D%Rdc]);JgoYumS?.cbHEt%Jjp!S<uW09sI_5@dHYVdW9q@,_IhI3HrmDZ*;NWd4OgZdRQnK24+)`M@S;=:&P7ob]+V=Qe2Mt5WLL<]OSnJ3Eb75qI3nIt&MR8&le*gN,sAKJ;`(]OL?A0*T~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000843 00000 n 
+0000000902 00000 n 
+trailer
+<<
+/ID 
+[<fa4c330070d0fc7c5224489773c1e9fe><fa4c330070d0fc7c5224489773c1e9fe>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2009
+%%EOF

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1300,6 +1300,11 @@ fn test_snapshot_td9264() {
 }
 
 #[test]
+fn test_snapshot_template_layout_band() {
+    assert_snapshot("template_layout_band");
+}
+
+#[test]
 fn test_snapshot_p1244() {
     assert_snapshot("p1244-1996");
 }

--- a/tests/snapshots/td9264.md
+++ b/tests/snapshots/td9264.md
@@ -1,8 +1,17 @@
-||||(e) [Reserved]. For further guidance, see §1.1563-3T(e)(1). Par. 50. Section 1.1563-3T is added to read as follows: §1.1563-3T Rules for determining stock ownership (temporary). (a) through (d)(2)(iii) [Reserved]. For further guidance, see §1.1563-3(a)|
-|---|---|---|---|
-||through (d)(2)(iii).|||
-||(iv)|Statement|. If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include-- (A) A description of each of the controlled groups in which the corporation could be included. The description must include the name and employer identification number of each component member of each such group and the stock ownership of the component members of each such group; and (B) The following representation: [INSERT NAME AND EMPLOYER IDENTIFICATION NUMBER OF CORPORATION] ELECTS TO BE TREATED AS A COMPONENT MEMBER OF THE [INSERT DESIGNATION OF GROUP].|
-||(v)|Election|-- (A) Election filed. An election filed under paragraph (d)(2)(iv) of this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of §1.1563-3 applies or until a change in the stock ownership of the corporation results in|
+(e) [Reserved]. For further guidance, see §1.1563-3T(e)(1). Par. 50. Section 1.1563-3T is added to read as follows:
+<u>§1.1563-3T Rules for determining stock ownership (temporary)</u>.
+
+(a) through (d)(2)(iii) [Reserved]. For further guidance, see §1.1563-3(a)
+through (d)(2)(iii). (iv) <u>Statement</u>. If the application of paragraph (d)(2)(ii) or (iii) of §1.1563-3 does not result in a corporation being treated as a component member of only one controlled group of corporations on a December 31, then such corporation will be treated as a component member of only one such group on such date. Such corporation may elect the group in which it is to be included by including on or with its income tax return a statement entitled, “STATEMENT TO ELECT CONTROLLED GROUP PURSUANT TO §1.1563-3T(d)(2)(iv).” The statement must include--
+
+(A) A description of each of the controlled groups in which the corporation
+could be included. The description must include the name and employer identification number of each component member of each such group and the stock ownership of the component members of each such group; and
+
+(B) The following representation: [INSERT NAME AND EMPLOYER
+IDENTIFICATION NUMBER OF CORPORATION] ELECTS TO BE TREATED AS A COMPONENT MEMBER OF THE [INSERT DESIGNATION OF GROUP].
+
+(v) <u>Election</u>-- (A) <u>Election filed</u>. An election filed under paragraph (d)(2)(iv) of
+this section is irrevocable and effective until paragraph (d)(2)(ii) or (iii) of §1.1563-3 applies or until a change in the stock ownership of the corporation results in
 
 |termination of membership in the controlled group in which such corporation has||
 |---|---|

--- a/tests/snapshots/template_layout_band.md
+++ b/tests/snapshots/template_layout_band.md
@@ -1,0 +1,8 @@
+# Test User
+
+Objective: Quality Engineer user@example.com
+
+13800000000 Springfield
+
+Work Experience / Experience ACME Manufacturing, Quality Engineer (2023.07 - 2026.07) Goal: reduce defect rate across the production line. Action: built a supplier scorecard covering quality, cost and delivery with a shared dashboard. Result: defect rate down 35 percent, supplier cycle time cut by 23 days on average. Internship / Experience Globex Services, Junior Analyst (2021.02 - 2023.06) Goal: standardize the reporting pipeline for the operations team. Action: migrated nine manual reports into one automated dashboard with weekly refresh. Result: reporting effort down from two days to two hours per week across the team. Skills / Assessment Spreadsheets, SQL, scripting, data visualization, documentation writing, and stakeholder communication. Education / Education State University, Bachelor of Science (2017.09 - 2021.06).
+


### PR DESCRIPTION
### Summary

Resume- and form-template PDFs commonly carry decorative fill rects: a
page background, a **full-content-band rect drawn several times** (the
template's page frame, no interior y-edges), and a few header chips.
None of them are table borders, but the cell-rect fallback
(`detect_row_stripe_table_from_cell_rects`) serializes the whole page
as a markdown table:

- rows come from the rect y-edges — the content band has no interior
  y-edges, so **the entire page body lands in one table row**;
- columns come from text x-clustering, so the prose is bucketed by
  x position into pseudo-cells;
- text within a cell keeps stream order, not visual order.

The reading order of the document is destroyed.

### Why the existing guards miss it

The full-grid pass correctly rejects the cluster (sparse content — it
knows this is not a data table), but the fallback re-accepts it on cell
density. The fallback's paragraph-wall guard
(`max_cell_len > 500 && non_empty_rows < 4`) is bypassed whenever the
header chips above the band contribute 4 non-empty rows — exactly the
layout these templates have.

### The fix

Add `has_dominant_prose_row`, the row-granular sibling of the existing
`has_dominant_prose_cell` helper (which the other rect-detection paths
already call): after cell assignment, reject the table when **one row
holds more than 500 chars and at least half the region's text**.
Genuine stripe tables spread their items across rows; a rect band
boxing flowing prose concentrates it in one row. The signal has to be
row-granular: the columns carved from the band split the prose into
sub-threshold cells, so every per-cell check stays blind.

### Repro

`tests/fixtures/template_layout_band.pdf` (new, synthetic, PII-free):
2 page backgrounds + 3 header-chip rows + one content-band rect drawn
4 times + ordinary resume-shaped text inside the band.

Before:

```markdown
|Test User||||
|

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects layout-band rectangles in the cell-rect stripe fallback to preserve reading order. Previously, the fallback accepted a content-band rect and collapsed the page body into one giant table row; now it rejects when one row dominates the text.

- Adds `has_dominant_prose_row`: reject if any row has >500 characters and at least half of the region’s text.
- Applies only in `detect_row_stripe_table_from_cell_rects`; the full-grid path is unchanged.
- Updates snapshots: `td9264` now extracts flowing text at the document head. Adds `template_layout_band.pdf` fixture, a snapshot, and a unit test that ensures the fallback rejects the band case.
- No migration required; low risk to genuine stripe tables.

<sup>Written for commit 064e0d2b8914ec5ae634abd5ef1a9b99c089902b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

