### PR TITLE
Publish a darwin-x64 (Intel macOS) Node binding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,10 @@ jobs:
             build-flags: -x
           - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
+          # macos-13 was retired by GitHub; macos-15-intel is the remaining
+          # Intel runner label (available through 2027).
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
           - runner: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
@@ -169,6 +173,8 @@ jobs:
             target: aarch64-unknown-linux-musl
           - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
           - runner: blacksmith-2vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
@@ -243,6 +249,7 @@ jobs:
                 "linux-arm64-gnu":  { os: ["linux"],  cpu: ["arm64"], libc: ["glibc"] },
                 "linux-arm64-musl": { os: ["linux"],  cpu: ["arm64"], libc: ["musl"] },
                 "darwin-arm64":     { os: ["darwin"], cpu: ["arm64"] },
+                "darwin-x64":       { os: ["darwin"], cpu: ["x64"] },
                 "win32-x64-msvc":   { os: ["win32"],  cpu: ["x64"] },
               }[suffix]
               if (!meta) {

--- a/napi/README.md
+++ b/napi/README.md
@@ -35,7 +35,7 @@ npm install @firecrawl/pdf-inspector
 bun add @firecrawl/pdf-inspector
 ```
 
-Prebuilt binaries for **Linux x64/ARM64** (glibc and musl/Alpine), **macOS ARM64**, and **Windows x64** — npm installs only the one matching your platform. No Rust toolchain needed.
+Prebuilt binaries for **Linux x64/ARM64** (glibc and musl/Alpine), **macOS ARM64/x64**, and **Windows x64** — npm installs only the one matching your platform. No Rust toolchain needed.
 
 OCR calls that route work require compatible PDFium and ONNX Runtime shared
 libraries. Set `PDFIUM_LIB_PATH` and `ORT_DYLIB_PATH` when they are not on the
@@ -188,6 +188,7 @@ Prebuilt binaries ship as platform-specific packages installed automatically via
 | Linux    | ARM64 (glibc)       | `@firecrawl/pdf-inspector-linux-arm64-gnu` |
 | Linux    | ARM64 (musl/Alpine) | `@firecrawl/pdf-inspector-linux-arm64-musl` |
 | macOS    | ARM64               | `@firecrawl/pdf-inspector-darwin-arm64` |
+| macOS    | x64 (Intel)         | `@firecrawl/pdf-inspector-darwin-x64` |
 | Windows  | x64                 | `@firecrawl/pdf-inspector-win32-x64-msvc` |
 
 ## License

--- a/napi/README.md
+++ b/napi/README.md
@@ -35,7 +35,7 @@ npm install @firecrawl/pdf-inspector
 bun add @firecrawl/pdf-inspector
 ```
 
-Prebuilt binaries for **Linux x64/ARM64** (glibc and musl/Alpine), **macOS ARM64**, and **Windows x64** — npm installs only the one matching your platform. No Rust toolchain needed.
+Prebuilt binaries for **Linux x64/ARM64** (glibc and musl/Alpine), **macOS ARM64/x64**, and **Windows x64** — npm installs only the one matching your platform. No Rust toolchain needed.
 
 OCR calls that route work require compatible PDFium and ONNX Runtime shared
 libraries. Set `PDFIUM_LIB_PATH` and `ORT_DYLIB_PATH` when they are not on the
@@ -217,6 +217,7 @@ Prebuilt binaries ship as platform-specific packages installed automatically via
 | Linux    | ARM64 (glibc)       | `@firecrawl/pdf-inspector-linux-arm64-gnu` |
 | Linux    | ARM64 (musl/Alpine) | `@firecrawl/pdf-inspector-linux-arm64-musl` |
 | macOS    | ARM64               | `@firecrawl/pdf-inspector-darwin-arm64` |
+| macOS    | x64 (Intel)         | `@firecrawl/pdf-inspector-darwin-x64` |
 | Windows  | x64                 | `@firecrawl/pdf-inspector-win32-x64-msvc` |
 
 ## License

--- a/napi/package.json
+++ b/napi/package.json
@@ -41,6 +41,7 @@
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
       "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc"
     ]
   },
@@ -57,6 +58,7 @@
     "@firecrawl/pdf-inspector-linux-arm64-gnu": "1.17.0",
     "@firecrawl/pdf-inspector-linux-arm64-musl": "1.17.0",
     "@firecrawl/pdf-inspector-darwin-arm64": "1.17.0",
+    "@firecrawl/pdf-inspector-darwin-x64": "1.17.0",
     "@firecrawl/pdf-inspector-win32-x64-msvc": "1.17.0"
   }
 }

--- a/napi/package.json
+++ b/napi/package.json
@@ -41,6 +41,7 @@
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
       "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc"
     ]
   },
@@ -57,6 +58,7 @@
     "@firecrawl/pdf-inspector-linux-arm64-gnu": "1.19.0",
     "@firecrawl/pdf-inspector-linux-arm64-musl": "1.19.0",
     "@firecrawl/pdf-inspector-darwin-arm64": "1.19.0",
+    "@firecrawl/pdf-inspector-darwin-x64": "1.19.0",
     "@firecrawl/pdf-inspector-win32-x64-msvc": "1.19.0"
   }
 }


### PR DESCRIPTION
## Why

`@firecrawl/pdf-inspector` has no `darwin-x64` platform package, so on an Intel Mac `require("@firecrawl/pdf-inspector")` fails even though the generated `index.js` already has a `darwin` + `x64` branch. We ship pdf-inspector inside Miyo, an Electron app, and this is the one dependency keeping us from an Intel macOS build.

## What

- Add `x86_64-apple-darwin` to the build and smoke-test matrices in `publish.yml`, on GitHub's `macos-15-intel` runner. `publish-pypi.yml` already uses that runner for the Intel wheel.
- Add the `darwin-x64` entry to the platform-package metadata map, `napi.targets`, and `optionalDependencies`.
- List the package in the napi README.

PDFium and ONNX Runtime are loaded at runtime, so the build needs nothing beyond the Rust target. As `docs/ocr-runtime.md` already notes for the Python wheel, ONNX Runtime 1.27.0 has no Intel macOS archive, so local OCR on that target still needs a custom build. Text extraction is unaffected.

## Verification

I ran the new matrix leg on my fork, on `macos-15-intel`: the build produces `pdf-inspector.darwin-x64.node` (`Mach-O 64-bit dynamically linked shared library x86_64`) and `napi/test.mjs` passes against it. Run: https://github.com/wenzhengjiang/pdf-inspector/actions/runs/33236213976

The publish step itself only runs on a `napi/package.json` version change from `main`, so the next release exercises it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Intel macOS (`darwin-x64`) binary for `@firecrawl/pdf-inspector` so the package loads on Intel Macs instead of failing at `require()`.

- Builds and smoke-tests `x86_64-apple-darwin` on the `macos-15-intel` runner in the publish workflow.
- Registers the `darwin-x64` platform package in `napi/package.json` and documents it in the README.

Local OCR still needs a custom ONNX Runtime build on Intel macOS; text extraction is unaffected.

<sup>Written for commit b866eb21d8899cb3b0da72f09f02c85a9b833ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

