### PR TITLE
perf(tables): evaluate one bar-family anchor per distinct breadth

### DIFF
--- a/src/tables/detect_rects.rs
+++ b/src/tables/detect_rects.rs
@@ -2572,9 +2572,21 @@ fn has_chart_bar_signature(
                       breadth: fn(&(f32, f32, f32, f32)) -> f32,
                       length: fn(&(f32, f32, f32, f32)) -> f32,
                       along: fn(&(f32, f32, f32, f32)) -> f32| {
+        // Everything below is a pure function of `bw`: the family is selected by
+        // breadth alone, and every later test reads only the family. Rect-dense pages
+        // repeat the same widths hundreds of times, and each repeat re-ran an O(n)
+        // family build plus an O(family^2) pairing scan — the cubic cost that makes
+        // this function 91% of conversion time on such a page. Evaluating one anchor
+        // per distinct breadth is the same answer: a repeat can only reproduce the
+        // earlier result, and that result was false, or `any` would already have
+        // stopped. Bit equality keeps it exact rather than merging near-equal widths.
+        let mut evaluated_breadths: HashSet<u32> = HashSet::new();
         group_rects.iter().any(|anchor| {
             let bw = breadth(anchor);
             if bw <= 0.0 {
+                return false;
+            }
+            if !evaluated_breadths.insert(bw.to_bits()) {
                 return false;
             }
             let family: Vec<&(f32, f32, f32, f32)> = group_rects


### PR DESCRIPTION
Fixes #469.

`bar_family` selects its family by breadth alone, and every later test reads only that family — so the closure's result is a pure function of the anchor's breadth. Rect-dense pages repeat the same widths hundreds of times, each recomputing an identical answer.

Evaluating one anchor per distinct breadth returns the same result: a repeat can only reproduce the earlier one, and that one was `false` or the `any` would already have stopped. Breadths compare by bit pattern, so near-equal widths are still evaluated separately.

On `tests/fixtures/bits_pilani_feedback.pdf` via `pdf2md`: **26.8s → 2.1s**, markdown byte-identical (1,315,546 bytes). 1199 existing tests pass unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes `bar_family` evaluation by distinct breadth, fixing #469. Rect-dense page conversion drops from 26.8s to 2.1s with byte-identical output (1,315,546 bytes).

Repeats can only reproduce an earlier result since the closure reads only the breadth-selected family. Breadths compare by bit pattern, so near-equal widths are still evaluated separately. 1199 existing tests pass unchanged.

<sup>Written for commit 95a7b6d8dc989ff30070eb441c05252590ae7bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

