### PR TITLE
fix: repair classic xref tables whose entries end with a bare LF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3935,6 +3935,7 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
 
     add_repair_candidate(&mut candidates, append_missing_eof_marker(buf), buf);
     add_repair_candidate(&mut candidates, recover_startxref_pointer(buf), buf);
+    add_repair_candidate(&mut candidates, normalize_xref_entry_stride(buf), buf);
 
     let stripped = strip_leading_pdf_container_bytes(buf);
     if let Some(stripped_buf) = stripped.as_deref() {
@@ -3949,9 +3950,107 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
             recover_startxref_pointer(stripped_buf),
             buf,
         );
+        add_repair_candidate(
+            &mut candidates,
+            normalize_xref_entry_stride(stripped_buf),
+            buf,
+        );
     }
 
     candidates
+}
+
+/// Repairs classic xref entries that end with a single EOL byte (19-byte
+/// stride) instead of the spec's exactly 20: lopdf rejects the file, while
+/// pypdf/pdfium/pdfjs read it. Rebuilds the table in place with `SP LF`
+/// entries; offsets and `startxref` stay valid because nothing else moves.
+/// Same scope as `recover_startxref_pointer` (last classic table only);
+/// `None` when the stride is already correct or the table is ambiguous.
+fn normalize_xref_entry_stride(buf: &[u8]) -> Option<Vec<u8>> {
+    let table_pos = find_last_valid_xref_table_start(buf)?;
+    let mut pos = table_pos + b"xref".len();
+
+    let mut rebuilt: Vec<u8> = b"xref\n".to_vec();
+    let mut saw_malformed = false;
+
+    fn skip_ws(buf: &[u8], mut pos: usize) -> usize {
+        while buf.get(pos).is_some_and(u8::is_ascii_whitespace) {
+            pos += 1;
+        }
+        pos
+    }
+    fn read_number(buf: &[u8], mut pos: usize) -> Option<(u64, usize)> {
+        let start = pos;
+        while buf.get(pos).is_some_and(u8::is_ascii_digit) {
+            pos += 1;
+        }
+        if pos == start {
+            return None;
+        }
+        std::str::from_utf8(&buf[start..pos])
+            .ok()?
+            .parse()
+            .ok()
+            .map(|n| (n, pos))
+    }
+
+    loop {
+        let header_start = skip_ws(buf, pos);
+        if buf[header_start..].starts_with(b"trailer") {
+            pos = header_start;
+            break;
+        }
+        let (start_id, after_id) = read_number(buf, header_start)?;
+        let sep = skip_ws(buf, after_id);
+        if sep == after_id {
+            return None;
+        }
+        let (count, after_count) = read_number(buf, sep)?;
+        rebuilt.extend_from_slice(format!("{start_id} {count}\n").as_bytes());
+
+        let mut entry_pos = skip_ws(buf, after_count);
+        for _ in 0..count {
+            // 18 content bytes, then a 2-byte EOL (spec) or 1 (malformed).
+            let entry = buf.get(entry_pos..entry_pos + 18)?;
+            let (offset, after_offset) = read_number(entry, 0)?;
+            if after_offset != 10 || entry.get(10) != Some(&b' ') {
+                return None;
+            }
+            let (generation, after_generation) = read_number(entry, 11)?;
+            if after_generation != 16 || entry.get(16) != Some(&b' ') {
+                return None;
+            }
+            let kind = *entry.get(17)?;
+            if kind != b'n' && kind != b'f' {
+                return None;
+            }
+            entry_pos += 18;
+            let eol_len = match (buf.get(entry_pos), buf.get(entry_pos + 1)) {
+                (Some(b'\r'), Some(b'\n')) => 2,
+                (Some(b' '), Some(b'\r' | b'\n')) => 2,
+                (Some(b'\r' | b'\n'), _) => 1,
+                _ => return None,
+            };
+            if eol_len == 1 {
+                saw_malformed = true;
+            }
+            entry_pos += eol_len;
+            rebuilt.extend_from_slice(
+                format!("{offset:010} {generation:05} {} \n", kind as char).as_bytes(),
+            );
+        }
+        pos = entry_pos;
+    }
+
+    if !saw_malformed {
+        return None;
+    }
+
+    let mut repaired = Vec::with_capacity(buf.len() + rebuilt.len());
+    repaired.extend_from_slice(&buf[..table_pos]);
+    repaired.extend_from_slice(&rebuilt);
+    repaired.extend_from_slice(&buf[pos..]);
+    Some(repaired)
 }
 
 /// Some PDF writers emit a `startxref` pointer that doesn't actually point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3960,9 +3960,9 @@ fn repair_pdf_container_candidates(buf: &[u8]) -> Vec<Vec<u8>> {
     candidates
 }
 
-/// Repairs classic xref entries that end with a single EOL byte (19-byte
-/// stride) instead of the spec's exactly 20: lopdf rejects the file, while
-/// pypdf/pdfium/pdfjs read it. Rebuilds the table in place with `SP LF`
+/// Repairs classic xref entries whose EOL is not the spec's exactly two
+/// bytes — a bare `LF` (19-byte stride) or a `SP CR LF` (21) — including a
+/// table that mixes both: lopdf rejects the file, pypdf/pdfium/pdfjs read it. Rebuilds the table in place with `SP LF`
 /// entries; offsets and `startxref` stay valid because nothing else moves.
 /// Same scope as `recover_startxref_pointer` (last classic table only);
 /// `None` when the stride is already correct or the table is ambiguous.
@@ -4025,13 +4025,20 @@ fn normalize_xref_entry_stride(buf: &[u8]) -> Option<Vec<u8>> {
                 return None;
             }
             entry_pos += 18;
-            let eol_len = match (buf.get(entry_pos), buf.get(entry_pos + 1)) {
-                (Some(b'\r'), Some(b'\n')) => 2,
-                (Some(b' '), Some(b'\r' | b'\n')) => 2,
-                (Some(b'\r' | b'\n'), _) => 1,
+            let eol_len = match (
+                buf.get(entry_pos),
+                buf.get(entry_pos + 1),
+                buf.get(entry_pos + 2),
+            ) {
+                // Longest first: `SP CR LF` must not be read as `SP CR`, which
+                // would leave the next entry starting on the stray `LF`.
+                (Some(b' '), Some(b'\r'), Some(b'\n')) => 3,
+                (Some(b'\r'), Some(b'\n'), _) => 2,
+                (Some(b' '), Some(b'\r' | b'\n'), _) => 2,
+                (Some(b'\r' | b'\n'), _, _) => 1,
                 _ => return None,
             };
-            if eol_len == 1 {
+            if eol_len != 2 {
                 saw_malformed = true;
             }
             entry_pos += eol_len;

--- a/tests/fixtures/bare_lf_xref_entries.pdf
+++ b/tests/fixtures/bare_lf_xref_entries.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 57 >>
+stream
+BT /F1 14 Tf 50 780 Td (Synthetic xref stride test) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000241 00000 n
+0000000348 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+418
+%%EOF

--- a/tests/fixtures/mixed_eol_xref_entries.pdf
+++ b/tests/fixtures/mixed_eol_xref_entries.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 52 >>
+stream
+BT /F1 14 Tf 50 780 Td (Mixed EOL stride test) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n 
+0000000058 00000 n
+0000000115 00000 n 
+0000000241 00000 n
+0000000343 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+413
+%%EOF

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4400,6 +4400,22 @@ fn pdf_options_debug_redacts_password() {
 /// point raised "Invalid PDF structure" on a file whose object data was
 /// otherwise completely intact.
 #[test]
+fn test_process_pdf_recovers_corrupted_startxref_pointer() {
+    let result = process_pdf_with_options(
+        "tests/fixtures/broken_startxref_pointer.pdf",
+        PdfOptions::new(),
+    )
+    .expect("a corrupted startxref pointer should be recoverable, like pypdf/pdfium");
+
+    assert_eq!(result.page_count, 1);
+    let md = result.markdown.unwrap_or_default();
+    assert!(
+        md.contains("Order Detail Report by Account") && md.contains("WIDGET ASSEMBLY"),
+        "recovered document should extract its real text, got: {md:?}"
+    );
+}
+
+#[test]
 fn test_process_pdf_recovers_bare_lf_xref_entries() {
     // Bare-LF xref entries (19-byte stride, offsets correct); pypdf, pdfium
     // and pdfjs all read such files.
@@ -4416,17 +4432,19 @@ fn test_process_pdf_recovers_bare_lf_xref_entries() {
 }
 
 #[test]
-fn test_process_pdf_recovers_corrupted_startxref_pointer() {
+fn test_process_pdf_recovers_mixed_eol_xref_entries() {
+    // A table mixing bare-LF (19-byte) and `SP CR LF` (21-byte) entries: the
+    // longest EOL must be consumed first or the next entry starts on a stray LF.
     let result = process_pdf_with_options(
-        "tests/fixtures/broken_startxref_pointer.pdf",
+        "tests/fixtures/mixed_eol_xref_entries.pdf",
         PdfOptions::new(),
     )
-    .expect("a corrupted startxref pointer should be recoverable, like pypdf/pdfium");
+    .expect("mixed-EOL xref entries should be recoverable, like pypdf/pdfium");
 
     assert_eq!(result.page_count, 1);
     let md = result.markdown.unwrap_or_default();
     assert!(
-        md.contains("Order Detail Report by Account") && md.contains("WIDGET ASSEMBLY"),
+        md.contains("Mixed EOL stride test"),
         "recovered document should extract its real text, got: {md:?}"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4400,6 +4400,22 @@ fn pdf_options_debug_redacts_password() {
 /// point raised "Invalid PDF structure" on a file whose object data was
 /// otherwise completely intact.
 #[test]
+fn test_process_pdf_recovers_bare_lf_xref_entries() {
+    // Bare-LF xref entries (19-byte stride, offsets correct); pypdf, pdfium
+    // and pdfjs all read such files.
+    let result =
+        process_pdf_with_options("tests/fixtures/bare_lf_xref_entries.pdf", PdfOptions::new())
+            .expect("bare-LF xref entries should be recoverable, like pypdf/pdfium");
+
+    assert_eq!(result.page_count, 1);
+    let md = result.markdown.unwrap_or_default();
+    assert!(
+        md.contains("Synthetic xref stride test"),
+        "recovered document should extract its real text, got: {md:?}"
+    );
+}
+
+#[test]
 fn test_process_pdf_recovers_corrupted_startxref_pointer() {
     let result = process_pdf_with_options(
         "tests/fixtures/broken_startxref_pointer.pdf",


### PR DESCRIPTION
Fixes #473.

Adds a repair candidate alongside #230's startxref-pointer recovery: when the last classic xref table's entries end with a single EOL byte (19-byte stride) instead of the spec's two (exactly 20), rebuild the table at its original position with spec `SP LF` entries and leave every other byte untouched. The `startxref` pointer still lands on the table start, and object offsets point backwards at content that has not moved.

Returns `None` when every entry already has the spec stride, so well-formed files never produce a useless repair candidate — and any parse ambiguity inside the table (non-digit offsets, unknown entry kind, missing EOL) also bails to `None` rather than guessing, since this crate processes untrusted input.

The fixture is fully synthetic (generated, one page, one text line). The bare-LF variant reproduced the failure verbatim before this change; on a real 65MB / 29-page production document with this malformation, extraction goes from `invalid file trailer` to full text in 0.13s. 1199 existing tests pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #473. Classic xref entries whose EOL isn't the spec's two bytes — a bare `LF` (19-byte stride) or `SP CR LF` (21), including tables mixing both — previously failed with `invalid file trailer`; they now parse because the last classic xref table is rebuilt in place with spec 20-byte `SP LF` entries. Well-formed files are unaffected, and ambiguous tables are left alone rather than guessed at.

- Adds a repair candidate alongside #230's startxref-pointer recovery: rebuild the table at its original position and leave every other byte untouched; three-byte EOLs are matched first so mixed tables don't leave the next entry on a stray `LF`.
- Returns `None` when every entry already has the spec stride, so well-formed files never produce a useless repair candidate; parse ambiguity inside the table also bails to `None`.
- Fixtures are synthetic; the bare-LF and mixed-EOL variants reproduced the failure before this change, and a real 65MB / 29-page production document with this malformation now extracts fully.
- 1199 existing tests pass unchanged.

<sup>Written for commit 69827c8ab595a03805bec2d1d59664451c3dd639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

