### PR TITLE
fix(markdown): recognize extractor bullet glyphs (▪ ‣ ◆) as list items

### DIFF
--- a/src/extractor/layout.rs
+++ b/src/extractor/layout.rs
@@ -790,25 +790,18 @@ fn find_relative_valleys(
 }
 
 /// Detect whether a side of a gutter consists predominantly of list-marker
-/// glyphs (•, ●, ○, ◦, ▪, ▫, ◆, ◇). A column of bullets on the left margin
-/// creates a spurious histogram valley between the bullet and the content.
-/// Treating it as a real column splits each list item's text across two
-/// "columns," so we reject these candidates.
+/// glyphs from [`crate::markdown::classify::BULLET_GLYPHS`]. A column of bullets
+/// on the left margin creates a spurious histogram valley between the bullet
+/// and the content. Treating it as a real column splits each list item's text
+/// across two "columns," so we reject these candidates.
 fn is_list_marker_column(items: &[&&TextItem]) -> bool {
-    const LIST_MARKERS: &[char] = &['•', '●', '○', '◦', '▪', '▫', '◆', '◇', '■', '□'];
+    use crate::markdown::classify::is_standalone_bullet_glyph;
     if items.is_empty() {
         return false;
     }
     let marker_count = items
         .iter()
-        .filter(|i| {
-            let t = i.text.trim();
-            let mut chars = t.chars();
-            match (chars.next(), chars.next()) {
-                (Some(c), None) => LIST_MARKERS.contains(&c),
-                _ => false,
-            }
-        })
+        .filter(|i| is_standalone_bullet_glyph(&i.text))
         .count();
     // Require ≥80% of items on this side to be standalone markers. A handful
     // of non-marker items (stray page numbers, footnote refs) shouldn't

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -634,12 +634,7 @@ fn effective_merge_width(item: &TextItem) -> f32 {
 }
 
 fn is_standalone_bullet_text(text: &str) -> bool {
-    let trimmed = text.trim();
-    let mut chars = trimmed.chars();
-    matches!(
-        (chars.next(), chars.next()),
-        (Some(c), None) if crate::markdown::classify::BULLET_GLYPHS.contains(&c)
-    )
+    crate::markdown::classify::is_standalone_bullet_glyph(text)
 }
 
 fn first_text_char(text: &str) -> Option<char> {

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -634,7 +634,12 @@ fn effective_merge_width(item: &TextItem) -> f32 {
 }
 
 fn is_standalone_bullet_text(text: &str) -> bool {
-    matches!(text.trim(), "•" | "○" | "●" | "◦")
+    let trimmed = text.trim();
+    let mut chars = trimmed.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(c), None) if crate::markdown::classify::BULLET_GLYPHS.contains(&c)
+    )
 }
 
 fn first_text_char(text: &str) -> Option<char> {

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1613,6 +1613,20 @@ mod tests {
     }
 
     #[test]
+    fn merge_items_preserves_square_bullet_stream_order_with_backtracking() {
+        let items = vec![
+            with_mcid(make_merge_item("▪", 79.4, 5.0)),
+            with_mcid(make_merge_item("The MS", 91.0, 32.6)),
+            with_mcid(make_merge_item("A LoS project", 84.4, 70.0)),
+        ];
+
+        let merged = merge_text_items(items);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "▪ The MSA LoS project");
+    }
+
+    #[test]
     fn merge_items_keeps_normal_bullet_gap_limit_without_stream_order() {
         let items = vec![
             make_merge_item("•", 79.4, 5.0),

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -1,15 +1,11 @@
 //! Line classification: captions, lists, code detection.
 
-/// Unicode bullet glyphs used in PDF list markers.
-///
-/// Matches the set recognized by `extractor/layout.rs` and
-/// `extractor/underline.rs`, minus U+00B7 (·) middle dot which also
-/// appears in normal prose.
-const BULLET_MARKERS: &[char] = &['•', '●', '○', '◦', '▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'];
+pub(crate) const BULLET_GLYPHS: &[char] =
+    &['•', '●', '○', '◦', '▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'];
 
-fn starts_with_unicode_bullet_and_space(text: &str) -> bool {
-    BULLET_MARKERS.iter().any(|marker| {
-        text.strip_prefix(*marker)
+fn starts_with_bullet_glyph_and_space(text: &str) -> bool {
+    BULLET_GLYPHS.iter().any(|glyph| {
+        text.strip_prefix(*glyph)
             .is_some_and(|rest| rest.starts_with(' '))
     })
 }
@@ -86,7 +82,7 @@ pub(crate) fn is_caption_line(text: &str) -> bool {
 /// also demoting numbered headings.
 pub(crate) fn starts_with_bullet_marker(text: &str) -> bool {
     let trimmed = text.trim_start();
-    starts_with_unicode_bullet_and_space(trimmed)
+    starts_with_bullet_glyph_and_space(trimmed)
         || trimmed.starts_with("- ")
         || trimmed.starts_with("* ")
 }
@@ -96,7 +92,7 @@ pub(crate) fn is_list_item(text: &str) -> bool {
     let trimmed = text.trim_start();
 
     // Bullet patterns
-    if starts_with_unicode_bullet_and_space(trimmed)
+    if starts_with_bullet_glyph_and_space(trimmed)
         || trimmed.starts_with("- ")
         || trimmed.starts_with("* ")
     {
@@ -135,7 +131,7 @@ pub(crate) fn format_list_item(text: &str) -> String {
 
     // Convert various bullet styles to markdown
     // Note: bullet characters like • are multi-byte in UTF-8, use char indices
-    for bullet in BULLET_MARKERS {
+    for bullet in BULLET_GLYPHS {
         if let Some(rest) = trimmed.strip_prefix(*bullet) {
             return format!("- {}", rest.trim_start());
         }
@@ -309,6 +305,7 @@ mod tests {
             "- **Label:** rest of line"
         );
         assert_eq!(format_list_item("*● Italic:* rest"), "- *Italic:* rest");
+        assert_eq!(format_list_item("**▪ Label:** rest"), "- **Label:** rest");
     }
 
     #[test]
@@ -317,32 +314,44 @@ mod tests {
     }
 
     #[test]
-    fn is_list_item_with_bullet_space() {
+    fn is_list_item_original_bullet_styles() {
         assert!(is_list_item("● Item"));
         assert!(is_list_item("• Item"));
+        assert!(is_list_item("○ Item"));
+        assert!(is_list_item("◦ Item"));
         assert!(is_list_item("- Item"));
+        assert!(is_list_item("* Item"));
+        assert!(is_list_item("1. First"));
+        assert!(is_list_item("a. Letter"));
+        assert!(is_list_item("a) Letter"));
     }
 
     #[test]
     fn is_list_item_extended_bullet_glyphs() {
-        assert!(is_list_item("▪ Item"));
-        assert!(is_list_item("‣ Item"));
-        assert!(is_list_item("◆ Item"));
-        // Middle dot appears in prose; do not treat as a list marker.
+        for glyph in ['▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'] {
+            assert!(is_list_item(&format!("{glyph} Item")), "glyph {glyph}");
+            assert!(
+                starts_with_bullet_marker(&format!("{glyph} Item")),
+                "glyph {glyph}"
+            );
+            assert_eq!(
+                format_list_item(&format!("{glyph} Item")),
+                "- Item",
+                "glyph {glyph}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_list_item_rejects_non_bullets() {
+        assert!(!is_list_item("▪Item"));
+        assert!(!is_list_item("Item ▪"));
         assert!(!is_list_item("· Item"));
-    }
-
-    #[test]
-    fn starts_with_bullet_marker_extended_glyphs() {
-        assert!(starts_with_bullet_marker("▪ Item"));
-        assert!(starts_with_bullet_marker("‣ Item"));
-        assert!(starts_with_bullet_marker("◆ Item"));
-    }
-
-    #[test]
-    fn format_list_item_extended_glyphs() {
-        assert_eq!(format_list_item("▪ Item"), "- Item");
-        assert_eq!(format_list_item("‣ Item"), "- Item");
-        assert_eq!(format_list_item("◆ Item"), "- Item");
+        assert!(!is_list_item("– Item"));
+        assert!(!is_list_item("— Item"));
+        assert!(!is_list_item("Regular text"));
+        assert!(!starts_with_bullet_marker("· Item"));
+        assert!(!starts_with_bullet_marker("– Item"));
+        assert!(!starts_with_bullet_marker("— Item"));
     }
 }

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -322,10 +322,20 @@ mod tests {
         assert!(is_list_item("- Item"));
         assert!(is_list_item("* Item"));
         assert!(is_list_item("1. First"));
+        assert!(is_list_item("1. Item"));
         assert!(is_list_item("a. Letter"));
         assert!(is_list_item("a) Letter"));
+        assert!(is_list_item("a) Item"));
     }
 
+    #[test]
+    fn is_list_item_primary_extended_glyphs() {
+        for text in ["▪ Item", "‣ Item", "◆ Item"] {
+            assert!(is_list_item(text), "{text}");
+            assert!(starts_with_bullet_marker(text), "{text}");
+            assert_eq!(format_list_item(text), "- Item", "{text}");
+        }
+    }
     #[test]
     fn is_list_item_extended_bullet_glyphs() {
         for glyph in ['▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'] {
@@ -340,6 +350,12 @@ mod tests {
                 "glyph {glyph}"
             );
         }
+    }
+
+    #[test]
+    fn middle_dot_is_not_formatted_as_list_item() {
+        assert!(!is_list_item("· Item"));
+        assert_eq!(format_list_item("· Item"), "· Item");
     }
 
     #[test]

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -1,5 +1,19 @@
 //! Line classification: captions, lists, code detection.
 
+/// Unicode bullet glyphs used in PDF list markers.
+///
+/// Matches the set recognized by `extractor/layout.rs` and
+/// `extractor/underline.rs`, minus U+00B7 (·) middle dot which also
+/// appears in normal prose.
+const BULLET_MARKERS: &[char] = &['•', '●', '○', '◦', '▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'];
+
+fn starts_with_unicode_bullet_and_space(text: &str) -> bool {
+    BULLET_MARKERS.iter().any(|marker| {
+        text.strip_prefix(*marker)
+            .is_some_and(|rest| rest.starts_with(' '))
+    })
+}
+
 /// Check if text is a figure/table caption or source citation
 pub(crate) fn is_caption_line(text: &str) -> bool {
     let trimmed = text.trim();
@@ -64,7 +78,7 @@ pub(crate) fn is_caption_line(text: &str) -> bool {
     false
 }
 
-/// Check if text starts with an unambiguous bullet marker (●, •, ○, ◦).
+/// Check if text starts with an unambiguous bullet marker (●, •, ○, ◦, ▪, …).
 ///
 /// Narrower than [`is_list_item`]: it excludes numbered/lettered patterns
 /// like `1.` or `a)`, which legitimately appear as section headings in many
@@ -72,10 +86,7 @@ pub(crate) fn is_caption_line(text: &str) -> bool {
 /// also demoting numbered headings.
 pub(crate) fn starts_with_bullet_marker(text: &str) -> bool {
     let trimmed = text.trim_start();
-    trimmed.starts_with("• ")
-        || trimmed.starts_with("● ")
-        || trimmed.starts_with("○ ")
-        || trimmed.starts_with("◦ ")
+    starts_with_unicode_bullet_and_space(trimmed)
         || trimmed.starts_with("- ")
         || trimmed.starts_with("* ")
 }
@@ -85,12 +96,9 @@ pub(crate) fn is_list_item(text: &str) -> bool {
     let trimmed = text.trim_start();
 
     // Bullet patterns
-    if trimmed.starts_with("• ")
+    if starts_with_unicode_bullet_and_space(trimmed)
         || trimmed.starts_with("- ")
         || trimmed.starts_with("* ")
-        || trimmed.starts_with("○ ")
-        || trimmed.starts_with("● ")
-        || trimmed.starts_with("◦ ")
     {
         return true;
     }
@@ -127,7 +135,7 @@ pub(crate) fn format_list_item(text: &str) -> String {
 
     // Convert various bullet styles to markdown
     // Note: bullet characters like • are multi-byte in UTF-8, use char indices
-    for bullet in &['•', '○', '●', '◦'] {
+    for bullet in BULLET_MARKERS {
         if let Some(rest) = trimmed.strip_prefix(*bullet) {
             return format!("- {}", rest.trim_start());
         }
@@ -313,5 +321,28 @@ mod tests {
         assert!(is_list_item("● Item"));
         assert!(is_list_item("• Item"));
         assert!(is_list_item("- Item"));
+    }
+
+    #[test]
+    fn is_list_item_extended_bullet_glyphs() {
+        assert!(is_list_item("▪ Item"));
+        assert!(is_list_item("‣ Item"));
+        assert!(is_list_item("◆ Item"));
+        // Middle dot appears in prose; do not treat as a list marker.
+        assert!(!is_list_item("· Item"));
+    }
+
+    #[test]
+    fn starts_with_bullet_marker_extended_glyphs() {
+        assert!(starts_with_bullet_marker("▪ Item"));
+        assert!(starts_with_bullet_marker("‣ Item"));
+        assert!(starts_with_bullet_marker("◆ Item"));
+    }
+
+    #[test]
+    fn format_list_item_extended_glyphs() {
+        assert_eq!(format_list_item("▪ Item"), "- Item");
+        assert_eq!(format_list_item("‣ Item"), "- Item");
+        assert_eq!(format_list_item("◆ Item"), "- Item");
     }
 }

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -3,6 +3,16 @@
 pub(crate) const BULLET_GLYPHS: &[char] =
     &['•', '●', '○', '◦', '▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'];
 
+/// True when `text` is exactly one `BULLET_GLYPHS` entry (standalone marker).
+pub(crate) fn is_standalone_bullet_glyph(text: &str) -> bool {
+    let trimmed = text.trim();
+    let mut chars = trimmed.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(c), None) if BULLET_GLYPHS.contains(&c)
+    )
+}
+
 fn starts_with_bullet_glyph_and_space(text: &str) -> bool {
     BULLET_GLYPHS.iter().any(|glyph| {
         text.strip_prefix(*glyph)
@@ -315,12 +325,11 @@ mod tests {
 
     #[test]
     fn is_list_item_extended_bullet_glyphs() {
-        for text in [
-            "▪ Item", "▫ Item", "◆ Item", "◇ Item", "■ Item", "□ Item", "‣ Item", "⁃ Item",
-        ] {
-            assert!(is_list_item(text), "{text}");
-            assert!(starts_with_bullet_marker(text), "{text}");
-            assert_eq!(format_list_item(text), "- Item", "{text}");
+        for &glyph in BULLET_GLYPHS {
+            let text = format!("{glyph} Item");
+            assert!(is_list_item(&text), "{text}");
+            assert!(starts_with_bullet_marker(&text), "{text}");
+            assert_eq!(format_list_item(&text), "- Item", "{text}");
         }
     }
 

--- a/src/markdown/classify.rs
+++ b/src/markdown/classify.rs
@@ -314,48 +314,24 @@ mod tests {
     }
 
     #[test]
-    fn is_list_item_original_bullet_styles() {
-        assert!(is_list_item("● Item"));
-        assert!(is_list_item("• Item"));
-        assert!(is_list_item("○ Item"));
-        assert!(is_list_item("◦ Item"));
-        assert!(is_list_item("- Item"));
-        assert!(is_list_item("* Item"));
-        assert!(is_list_item("1. First"));
-        assert!(is_list_item("1. Item"));
-        assert!(is_list_item("a. Letter"));
-        assert!(is_list_item("a) Letter"));
-        assert!(is_list_item("a) Item"));
-    }
-
-    #[test]
-    fn is_list_item_primary_extended_glyphs() {
-        for text in ["▪ Item", "‣ Item", "◆ Item"] {
+    fn is_list_item_extended_bullet_glyphs() {
+        for text in [
+            "▪ Item", "▫ Item", "◆ Item", "◇ Item", "■ Item", "□ Item", "‣ Item", "⁃ Item",
+        ] {
             assert!(is_list_item(text), "{text}");
             assert!(starts_with_bullet_marker(text), "{text}");
             assert_eq!(format_list_item(text), "- Item", "{text}");
         }
     }
-    #[test]
-    fn is_list_item_extended_bullet_glyphs() {
-        for glyph in ['▪', '▫', '◆', '◇', '■', '□', '‣', '⁃'] {
-            assert!(is_list_item(&format!("{glyph} Item")), "glyph {glyph}");
-            assert!(
-                starts_with_bullet_marker(&format!("{glyph} Item")),
-                "glyph {glyph}"
-            );
-            assert_eq!(
-                format_list_item(&format!("{glyph} Item")),
-                "- Item",
-                "glyph {glyph}"
-            );
-        }
-    }
 
     #[test]
-    fn middle_dot_is_not_formatted_as_list_item() {
-        assert!(!is_list_item("· Item"));
-        assert_eq!(format_list_item("· Item"), "· Item");
+    fn is_list_item_preserves_original_styles() {
+        assert!(is_list_item("● Item"));
+        assert!(is_list_item("• Item"));
+        assert!(is_list_item("- Item"));
+        assert!(is_list_item("* Item"));
+        assert!(is_list_item("1. Item"));
+        assert!(is_list_item("a) Item"));
     }
 
     #[test]
@@ -363,9 +339,11 @@ mod tests {
         assert!(!is_list_item("▪Item"));
         assert!(!is_list_item("Item ▪"));
         assert!(!is_list_item("· Item"));
+        assert_eq!(format_list_item("· Item"), "· Item");
         assert!(!is_list_item("– Item"));
         assert!(!is_list_item("— Item"));
-        assert!(!is_list_item("Regular text"));
+        assert!(!is_list_item("not a list"));
+        assert!(!is_list_item("**bold** not a list"));
         assert!(!starts_with_bullet_marker("· Item"));
         assert!(!starts_with_bullet_marker("– Item"));
         assert!(!starts_with_bullet_marker("— Item"));

--- a/src/markdown/heading.rs
+++ b/src/markdown/heading.rs
@@ -602,6 +602,29 @@ mod tests {
     }
 
     #[test]
+    fn square_bullet_line_is_not_classified_as_heading() {
+        assert!(!title_like("▪ Short item", false, true));
+
+        let lines = vec![
+            line("▪ Short item", 700.0, 72.0, 14.0, "Bold", true),
+            line(
+                "Body paragraph continues here.",
+                680.0,
+                72.0,
+                12.0,
+                "Body",
+                false,
+            ),
+        ];
+        let decisions =
+            classify_heading_sequences(&lines, 12.0, &[], &HashSet::new(), &HashSet::new());
+        assert!(
+            !decisions.contains_key(&0),
+            "square bullet line must not be promoted to heading"
+        );
+    }
+
+    #[test]
     fn singleton_bold_label_does_not_form_sequence() {
         let lines = vec![
             line(

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -7,7 +7,7 @@
 //! - Paragraphs
 
 pub(crate) mod analysis;
-mod classify;
+pub(crate) mod classify;
 mod convert;
 mod furniture;
 mod heading;


### PR DESCRIPTION
Fixes #475

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes additional bullet glyphs (▪ ‣ ◆ and related) as list items in markdown extraction, so PDF lists using them are no longer emitted as plain paragraphs or misclassified as headings. Fixes #475.

- Shares `BULLET_GLYPHS` across list detection, formatting, standalone bullet merging, and the layout marker guard.
- Keeps `-` and `*` as separate checks and excludes middle dot, en dash, and em dash.
- Expands tests covering extended glyphs, negative cases, heading rejection, and a square-bullet merge stream-order regression.

<sup>Written for commit 87d8478863c37b9a3c83ca2143b5438d5e6dc916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

