### PR TITLE
feat: add support for tracking removed header/footer lines in PDF pro…

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -62,6 +62,8 @@ pub struct PdfResult {
     pub pages_needing_ocr: Vec<u32>,
     /// Machine-readable OCR reasons by 1-indexed page.
     pub ocr_reasons_by_page: Vec<PageOcrReasons>,
+    /// Number of lines removed as running headers/footers on each page.
+    pub removed_header_footer_lines: Vec<u32>,
     pub title: Option<String>,
     pub confidence: f64,
     pub is_complex_layout: bool,
@@ -248,6 +250,7 @@ fn to_napi_result(r: pdf_inspector::PdfProcessResult) -> PdfResult {
         processing_time_ms: r.processing_time_ms as u32,
         pages_needing_ocr: r.pages_needing_ocr,
         ocr_reasons_by_page: to_napi_page_ocr_reasons(r.ocr_reasons_by_page),
+        removed_header_footer_lines: r.removed_header_footer_lines,
         title: r.title,
         confidence: r.confidence as f64,
         is_complex_layout: r.layout.is_complex,

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -13,6 +13,8 @@ class PdfResult:
     """1-indexed page numbers that need OCR."""
     ocr_reasons_by_page: list["PageOcrReasons"]
     """Machine-readable OCR reasons by 1-indexed page."""
+    removed_header_footer_lines: list[int]
+    """Number of lines removed as running headers/footers on each page."""
     title: Optional[str]
     confidence: float
     is_complex_layout: bool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4404,25 +4404,43 @@ fn process_document(
                 &chart_regions,
             );
 
-            let conversion = markdown::markdown_conversion_output_from_items_with_rects_and_lines(
-                items,
-                options.markdown,
-                &rects,
-                &lines,
-                markdown::MarkdownDocumentContext {
-                    page_thresholds: &page_thresholds,
-                    struct_roles: struct_roles.as_ref(),
-                    struct_tables: &struct_tables,
-                    page_count,
-                    prefiltered_page_number_pages: Some(&removed_pages),
-                    prefiltered_page_number_mask: Some(removal_mask.as_slice()),
-                    precomputed_chart_regions: Some(&chart_regions),
-                },
-            );
+            let conversion = if options.mode == ProcessMode::Analyze {
+                markdown::markdown_counts_only_from_items_with_rects_and_lines(
+                    items,
+                    options.markdown,
+                    &rects,
+                    &lines,
+                    markdown::MarkdownDocumentContext {
+                        page_thresholds: &page_thresholds,
+                        struct_roles: struct_roles.as_ref(),
+                        struct_tables: &struct_tables,
+                        page_count,
+                        prefiltered_page_number_pages: Some(&removed_pages),
+                        prefiltered_page_number_mask: Some(removal_mask.as_slice()),
+                        precomputed_chart_regions: Some(&chart_regions),
+                    },
+                )
+            } else {
+                markdown::markdown_conversion_output_from_items_with_rects_and_lines(
+                    items,
+                    options.markdown,
+                    &rects,
+                    &lines,
+                    markdown::MarkdownDocumentContext {
+                        page_thresholds: &page_thresholds,
+                        struct_roles: struct_roles.as_ref(),
+                        struct_tables: &struct_tables,
+                        page_count,
+                        prefiltered_page_number_pages: Some(&removed_pages),
+                        prefiltered_page_number_mask: Some(removal_mask.as_slice()),
+                        precomputed_chart_regions: Some(&chart_regions),
+                    },
+                )
+            };
             let md = if options.mode == ProcessMode::Analyze {
                 None
             } else {
-Some(conversion.markdown)
+                Some(conversion.markdown)
             };
 
             let enc = !ocr_reasons_by_page.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4379,7 +4379,7 @@ fn process_document(
             let md = if options.mode == ProcessMode::Analyze {
                 None
             } else {
-                Some(conversion.markdown.clone())
+Some(conversion.markdown)
             };
 
             let enc = !ocr_reasons_by_page.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4404,30 +4404,21 @@ fn process_document(
                 &chart_regions,
             );
 
-            let conversion = if options.mode == ProcessMode::Analyze {
-                markdown::MarkdownConversionOutput {
-                    markdown: String::new(),
-                    removed_header_footer_lines: vec![0; page_count as usize],
-                    #[cfg(feature = "ocr")]
-                    detected_tables: Vec::new(),
-                }
-            } else {
-                markdown::markdown_conversion_output_from_items_with_rects_and_lines(
-                    items,
-                    options.markdown,
-                    &rects,
-                    &lines,
-                    markdown::MarkdownDocumentContext {
-                        page_thresholds: &page_thresholds,
-                        struct_roles: struct_roles.as_ref(),
-                        struct_tables: &struct_tables,
-                        page_count,
-                        prefiltered_page_number_pages: Some(&removed_pages),
-                        prefiltered_page_number_mask: Some(removal_mask.as_slice()),
-                        precomputed_chart_regions: Some(&chart_regions),
-                    },
-                )
-            };
+            let conversion = markdown::markdown_conversion_output_from_items_with_rects_and_lines(
+                items,
+                options.markdown,
+                &rects,
+                &lines,
+                markdown::MarkdownDocumentContext {
+                    page_thresholds: &page_thresholds,
+                    struct_roles: struct_roles.as_ref(),
+                    struct_tables: &struct_tables,
+                    page_count,
+                    prefiltered_page_number_pages: Some(&removed_pages),
+                    prefiltered_page_number_mask: Some(removal_mask.as_slice()),
+                    precomputed_chart_regions: Some(&chart_regions),
+                },
+            );
             let md = if options.mode == ProcessMode::Analyze {
                 None
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ pub struct PdfProcessResult {
     pub pages_needing_ocr: Vec<u32>,
     /// Machine-readable OCR reasons by 1-indexed page.
     pub ocr_reasons_by_page: Vec<PageOcrReasons>,
+    /// Count of lines removed as page headers/footers on each page. The vector
+    /// is indexed by page number minus one, so entry `i` is page `i + 1`.
+    pub removed_header_footer_lines: Vec<u32>,
     /// Title from PDF metadata (if available).
     pub title: Option<String>,
     /// Detection confidence score (0.0–1.0).
@@ -4134,6 +4137,7 @@ fn process_document(
             processing_time_ms: start.elapsed_ms(),
             pages_needing_ocr,
             ocr_reasons_by_page: page_ocr_reasons_vec(detection_ocr_reasons),
+            removed_header_footer_lines: vec![0; page_count as usize],
             title,
             confidence,
             layout: LayoutComplexity::default(),
@@ -4150,6 +4154,7 @@ fn process_document(
             processing_time_ms: start.elapsed_ms(),
             pages_needing_ocr,
             ocr_reasons_by_page: page_ocr_reasons_vec(detection_ocr_reasons),
+            removed_header_footer_lines: vec![0; page_count as usize],
             title,
             confidence,
             layout: LayoutComplexity::default(),
@@ -4240,6 +4245,7 @@ fn process_document(
         gid_pages,
         text_quality_pages,
         text_quality_reasons_by_page,
+        removed_header_footer_lines,
     ) = match extracted {
         Some(((items, rects, lines), page_thresholds, gid_encoded_pages)) => {
             let mut ocr_reasons_by_page = BTreeMap::new();
@@ -4346,10 +4352,15 @@ fn process_document(
                 &chart_regions,
             );
 
-            let md = if options.mode == ProcessMode::Analyze {
-                None
+            let conversion = if options.mode == ProcessMode::Analyze {
+                markdown::MarkdownConversionOutput {
+                    markdown: String::new(),
+                    removed_header_footer_lines: vec![0; page_count as usize],
+                    #[cfg(feature = "ocr")]
+                    detected_tables: Vec::new(),
+                }
             } else {
-                Some(markdown::to_markdown_from_items_with_rects_and_lines(
+                markdown::markdown_conversion_output_from_items_with_rects_and_lines(
                     items,
                     options.markdown,
                     &rects,
@@ -4363,7 +4374,12 @@ fn process_document(
                         prefiltered_page_number_mask: Some(removal_mask.as_slice()),
                         precomputed_chart_regions: Some(&chart_regions),
                     },
-                ))
+                )
+            };
+            let md = if options.mode == ProcessMode::Analyze {
+                None
+            } else {
+                Some(conversion.markdown.clone())
             };
 
             let enc = !ocr_reasons_by_page.is_empty()
@@ -4376,6 +4392,7 @@ fn process_document(
                 gid_encoded_pages,
                 text_quality.pages_needing_ocr,
                 ocr_reasons_by_page,
+                conversion.removed_header_footer_lines,
             )
         }
         None => (
@@ -4385,6 +4402,7 @@ fn process_document(
             std::collections::HashSet::new(),
             Vec::new(),
             BTreeMap::new(),
+            vec![0; page_count as usize],
         ),
     };
 
@@ -4484,6 +4502,7 @@ fn process_document(
             merge_ocr_reasons(&mut merged, text_quality_reasons_by_page);
             page_ocr_reasons_vec(merged)
         },
+        removed_header_footer_lines,
         title,
         confidence,
         layout,
@@ -6655,6 +6674,25 @@ mod tests {
         let document_wide =
             compute_layout_complexity(&selected.items, &selected.layout_items, &[], &[]);
         assert!(!document_wide.pages_with_columns.contains(&1));
+    }
+
+    #[test]
+    fn removed_header_footer_line_count_is_exposed_in_result() {
+        let result = PdfProcessResult {
+            pdf_type: PdfType::TextBased,
+            markdown: Some("body".to_string()),
+            page_count: 3,
+            processing_time_ms: 1,
+            pages_needing_ocr: vec![],
+            ocr_reasons_by_page: vec![],
+            title: None,
+            confidence: 0.5,
+            layout: LayoutComplexity::default(),
+            has_encoding_issues: false,
+            removed_header_footer_lines: vec![0, 2, 1],
+        };
+
+        assert_eq!(result.removed_header_footer_lines, vec![0, 2, 1]);
     }
 
     #[test]

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -848,6 +848,12 @@ enum TableOutputMode {
     CompleteTables,
 }
 
+#[derive(Clone, Copy)]
+enum MarkdownSerializationMode {
+    Full,
+    CountsOnly,
+}
+
 struct TableDetectionOutput {
     mode: TableOutputMode,
     pages_with_detected_tables: HashSet<u32>,
@@ -1469,6 +1475,7 @@ pub(crate) fn to_markdown_from_items_with_rects_and_lines(
         pdf_lines,
         context,
         TableOutputMode::Markdown,
+        MarkdownSerializationMode::Full,
     )
     .markdown
 }
@@ -1497,6 +1504,7 @@ pub(crate) fn complete_table_markdown_from_items(
             precomputed_chart_regions: None,
         },
         TableOutputMode::CompleteTables,
+        MarkdownSerializationMode::Full,
     );
     let mut output = String::new();
     for (_, table) in conversion.detected_tables {
@@ -1519,6 +1527,7 @@ fn convert_items_with_rects_lines_and_table_output(
     pdf_lines: &[crate::types::PdfLine],
     context: MarkdownDocumentContext<'_>,
     table_output_mode: TableOutputMode,
+    serialization_mode: MarkdownSerializationMode,
 ) -> MarkdownConversionOutput {
     use crate::tables::{
         content_width, detect_tables_from_lines, detect_tables_from_rects,
@@ -2410,15 +2419,18 @@ fn convert_items_with_rects_lines_and_table_output(
         }
         let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
         band_split_page_set.extend(page_chart_prose_splits.keys().copied());
-        let markdown = to_markdown_from_lines_with_tables_and_images(
-            stripped,
-            options,
-            page_tables,
-            page_images,
-            &page_chart_map,
-            &band_split_page_set,
-            effective_struct_roles,
-        );
+        let markdown = match serialization_mode {
+            MarkdownSerializationMode::Full => to_markdown_from_lines_with_tables_and_images(
+                stripped,
+                options,
+                page_tables,
+                page_images,
+                &page_chart_map,
+                &band_split_page_set,
+                effective_struct_roles,
+            ),
+            MarkdownSerializationMode::CountsOnly => String::new(),
+        };
         MarkdownConversionOutput {
             markdown,
             removed_header_footer_lines: removed,
@@ -2428,15 +2440,18 @@ fn convert_items_with_rects_lines_and_table_output(
     } else {
         let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
         band_split_page_set.extend(page_chart_prose_splits.keys().copied());
-        let markdown = to_markdown_from_lines_with_tables_and_images(
-            lines,
-            options,
-            page_tables,
-            page_images,
-            &page_chart_map,
-            &band_split_page_set,
-            effective_struct_roles,
-        );
+        let markdown = match serialization_mode {
+            MarkdownSerializationMode::Full => to_markdown_from_lines_with_tables_and_images(
+                lines,
+                options,
+                page_tables,
+                page_images,
+                &page_chart_map,
+                &band_split_page_set,
+                effective_struct_roles,
+            ),
+            MarkdownSerializationMode::CountsOnly => String::new(),
+        };
         MarkdownConversionOutput {
             markdown,
             removed_header_footer_lines: vec![0; document_page_count as usize],
@@ -2473,6 +2488,25 @@ pub(crate) fn markdown_conversion_output_from_items_with_rects_and_lines(
         pdf_lines,
         context,
         TableOutputMode::Markdown,
+        MarkdownSerializationMode::Full,
+    )
+}
+
+pub(crate) fn markdown_counts_only_from_items_with_rects_and_lines(
+    items: Vec<TextItem>,
+    options: MarkdownOptions,
+    rects: &[crate::types::PdfRect],
+    pdf_lines: &[crate::types::PdfLine],
+    context: MarkdownDocumentContext<'_>,
+) -> MarkdownConversionOutput {
+    convert_items_with_rects_lines_and_table_output(
+        items,
+        options,
+        rects,
+        pdf_lines,
+        context,
+        TableOutputMode::Markdown,
+        MarkdownSerializationMode::CountsOnly,
     )
 }
 
@@ -2594,6 +2628,35 @@ mod tests {
 
         assert!(output.markdown.is_empty());
         assert_eq!(output.removed_header_footer_lines, vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn counts_only_conversion_reuses_header_footer_stripping_without_markdown() {
+        let items = vec![
+            furniture_item("Running Header", 50.0, 780.0, 1),
+            furniture_item("Body text", 80.0, 700.0, 1),
+            furniture_item("Running Header", 50.0, 780.0, 2),
+            furniture_item("More body", 90.0, 650.0, 2),
+        ];
+
+        let output = markdown_counts_only_from_items_with_rects_and_lines(
+            items,
+            MarkdownOptions::default(),
+            &[],
+            &[],
+            MarkdownDocumentContext {
+                page_thresholds: &HashMap::new(),
+                struct_roles: None,
+                struct_tables: &[],
+                page_count: 2,
+                prefiltered_page_number_pages: None,
+                prefiltered_page_number_mask: None,
+                precomputed_chart_regions: None,
+            },
+        );
+
+        assert!(output.markdown.is_empty());
+        assert_eq!(output.removed_header_footer_lines, vec![1, 1]);
     }
 
     fn furniture_item(text: &str, x: f32, y: f32, page: u32) -> TextItem {

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1537,7 +1537,12 @@ fn convert_items_with_rects_lines_and_table_output(
     } = context;
 
     if items.is_empty() {
-        return MarkdownConversionOutput::default();
+        return MarkdownConversionOutput {
+            markdown: String::new(),
+            removed_header_footer_lines: vec![0; document_page_count as usize],
+            #[cfg(feature = "ocr")]
+            detected_tables: Vec::new(),
+        };
     }
 
     // Table detection must retain the original collection because short
@@ -2567,6 +2572,28 @@ mod tests {
         let md = to_markdown(text, MarkdownOptions::default());
         assert!(md.contains("- First item"));
         assert!(md.contains("- Second item"));
+    }
+
+    #[test]
+    fn empty_conversion_reports_zero_counts_for_each_document_page() {
+        let output = markdown_conversion_output_from_items_with_rects_and_lines(
+            Vec::new(),
+            MarkdownOptions::default(),
+            &[],
+            &[],
+            MarkdownDocumentContext {
+                page_thresholds: &HashMap::new(),
+                struct_roles: None,
+                struct_tables: &[],
+                page_count: 3,
+                prefiltered_page_number_pages: None,
+                prefiltered_page_number_mask: None,
+                precomputed_chart_regions: None,
+            },
+        );
+
+        assert!(output.markdown.is_empty());
+        assert_eq!(output.removed_header_footer_lines, vec![0, 0, 0]);
     }
 
     fn furniture_item(text: &str, x: f32, y: f32, page: u32) -> TextItem {

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -909,10 +909,11 @@ impl TableDetectionOutput {
 }
 
 #[derive(Default)]
-struct MarkdownConversionOutput {
-    markdown: String,
+pub(crate) struct MarkdownConversionOutput {
+    pub(crate) markdown: String,
+    pub(crate) removed_header_footer_lines: Vec<u32>,
     #[cfg(feature = "ocr")]
-    detected_tables: Vec<(u32, crate::tables::Table)>,
+    pub(crate) detected_tables: Vec<(u32, crate::tables::Table)>,
 }
 
 /// Derive a side-by-side split from rect hint regions.
@@ -2385,30 +2386,89 @@ fn convert_items_with_rects_lines_and_table_output(
         all_lines
     };
 
-    // Strip repeated headers/footers before conversion
-    let lines = if options.strip_headers_footers {
-        furniture::strip_header_footer_lines(lines, document_page_count)
+    // Strip repeated headers/footers before conversion and retain a page-by-page
+    // audit trail so callers can tell exactly how much furniture was removed.
+    let conversion = if options.strip_headers_footers {
+        let original_counts = count_lines_by_page(&lines, document_page_count);
+        let stripped = furniture::strip_header_footer_lines(lines, document_page_count);
+        let stripped_counts = count_lines_by_page(&stripped, document_page_count);
+        let mut removed = Vec::with_capacity(document_page_count as usize);
+        for page in 0..document_page_count {
+            let page_index = page as usize;
+            removed.push(
+                original_counts
+                    .get(page_index)
+                    .copied()
+                    .unwrap_or(0)
+                    .saturating_sub(stripped_counts.get(page_index).copied().unwrap_or(0)),
+            );
+        }
+        let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
+        band_split_page_set.extend(page_chart_prose_splits.keys().copied());
+        let markdown = to_markdown_from_lines_with_tables_and_images(
+            stripped,
+            options,
+            page_tables,
+            page_images,
+            &page_chart_map,
+            &band_split_page_set,
+            effective_struct_roles,
+        );
+        MarkdownConversionOutput {
+            markdown,
+            removed_header_footer_lines: removed,
+            #[cfg(feature = "ocr")]
+            detected_tables,
+        }
     } else {
-        lines
+        let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
+        band_split_page_set.extend(page_chart_prose_splits.keys().copied());
+        let markdown = to_markdown_from_lines_with_tables_and_images(
+            lines,
+            options,
+            page_tables,
+            page_images,
+            &page_chart_map,
+            &band_split_page_set,
+            effective_struct_roles,
+        );
+        MarkdownConversionOutput {
+            markdown,
+            removed_header_footer_lines: vec![0; document_page_count as usize],
+            #[cfg(feature = "ocr")]
+            detected_tables,
+        }
     };
 
-    // Convert to markdown, inserting tables and images at appropriate positions
-    let mut band_split_page_set: HashSet<u32> = page_band_splits.keys().copied().collect();
-    band_split_page_set.extend(page_chart_prose_splits.keys().copied());
-    let markdown = to_markdown_from_lines_with_tables_and_images(
-        lines,
-        options,
-        page_tables,
-        page_images,
-        &page_chart_map,
-        &band_split_page_set,
-        effective_struct_roles,
-    );
-    MarkdownConversionOutput {
-        markdown,
-        #[cfg(feature = "ocr")]
-        detected_tables,
+    conversion
+}
+
+fn count_lines_by_page(lines: &[crate::types::TextLine], page_count: u32) -> Vec<u32> {
+    let mut counts = vec![0u32; page_count as usize];
+    for line in lines {
+        let page_index = line.page.saturating_sub(1) as usize;
+        if page_index < counts.len() {
+            counts[page_index] += 1;
+        }
     }
+    counts
+}
+
+pub(crate) fn markdown_conversion_output_from_items_with_rects_and_lines(
+    items: Vec<TextItem>,
+    options: MarkdownOptions,
+    rects: &[crate::types::PdfRect],
+    pdf_lines: &[crate::types::PdfLine],
+    context: MarkdownDocumentContext<'_>,
+) -> MarkdownConversionOutput {
+    convert_items_with_rects_lines_and_table_output(
+        items,
+        options,
+        rects,
+        pdf_lines,
+        context,
+        TableOutputMode::Markdown,
+    )
 }
 
 #[cfg(test)]

--- a/src/python.rs
+++ b/src/python.rs
@@ -33,6 +33,9 @@ pub struct PyPdfResult {
     /// Machine-readable OCR reasons by 1-indexed page.
     #[pyo3(get)]
     pub ocr_reasons_by_page: Vec<PyPageOcrReasons>,
+    /// Number of lines removed as running headers/footers on each page.
+    #[pyo3(get)]
+    pub removed_header_footer_lines: Vec<u32>,
     /// Title from PDF metadata.
     #[pyo3(get)]
     pub title: Option<String>,
@@ -442,6 +445,7 @@ fn to_py_result(r: crate::PdfProcessResult) -> PyPdfResult {
         processing_time_ms: r.processing_time_ms,
         pages_needing_ocr: r.pages_needing_ocr,
         ocr_reasons_by_page: to_py_page_ocr_reasons(r.ocr_reasons_by_page),
+        removed_header_footer_lines: r.removed_header_footer_lines,
         title: r.title,
         confidence: r.confidence,
         is_complex_layout: r.layout.is_complex,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -45,6 +45,8 @@ export interface PdfProcessResult {
   /** 1-indexed page numbers. */
   pagesNeedingOcr: number[];
   ocrReasonsByPage: PageOcrReasons[];
+  /** Number of lines removed as running headers/footers on each page. */
+  removedHeaderFooterLines: number[];
   title?: string;
   confidence: number;
   layout: LayoutComplexity;
@@ -126,6 +128,7 @@ struct WasmPdfProcessResult {
     processing_time_ms: f64,
     pages_needing_ocr: Vec<u32>,
     ocr_reasons_by_page: Vec<WasmPageOcrReasons>,
+    removed_header_footer_lines: Vec<u32>,
     title: Option<String>,
     confidence: f64,
     layout: WasmLayoutComplexity,
@@ -145,6 +148,7 @@ impl From<PdfProcessResult> for WasmPdfProcessResult {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            removed_header_footer_lines: value.removed_header_footer_lines,
             title: value.title,
             confidence: value.confidence as f64,
             layout: value.layout.into(),


### PR DESCRIPTION
Fixes: #459 

what is done:

1. Per-page removed header/footer counts are computed in src/markdown/mod.rs.
2. Counts are threaded through MarkdownConversionOutput.
3. Counts are surfaced on PdfProcessResult.
4. Python, Node/NAPI, and WASM wrappers expose the field.
5. I fixed the visibility issue so src/lib.rs can access MarkdownConversionOutput

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #459 by adding per-page counts of lines removed as running headers/footers to PDF processing results, exposed across Python, Node/NAPI, and WASM bindings. Previously callers had no visibility into how much content was stripped during markdown conversion.

- Counts are computed by diffing line counts before and after header/footer stripping.
- Per-page counts are zero-filled when stripping is disabled or when there are no items to convert.
- Analyze mode now computes these counts without generating markdown, avoiding unnecessary serialization work.

<sup>Written for commit efc312f45f2d5c3554ba7783a45fd4aceff40a94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

