### PR TITLE
feat: PDF outline bookmark TOC

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -570,6 +570,49 @@ pub fn extract_structure_elements(
     })
 }
 
+/// One flattened outline (bookmark) entry from the document catalog's
+/// `/Outlines` tree.
+#[napi(object)]
+pub struct OutlineEntryJs {
+    /// 1-based nesting depth (top-level bookmarks are level 1).
+    pub level: u32,
+    /// Bookmark title (decoded from UTF-16BE or PDFDocEncoding).
+    pub title: String,
+    /// 1-indexed target page (matches `TextItem.page`), `None` when the
+    /// destination is missing or cannot be resolved.
+    pub page: Option<u32>,
+    /// Destination kind when known: an explicit destination's fit type
+    /// ("XYZ", "Fit", "FitH", …) or "named" for named destinations.
+    pub dest_kind: Option<String>,
+}
+
+/// Extract the document outline (bookmarks) from a PDF.
+///
+/// Walks the catalog's `/Outlines` tree and returns one entry per bookmark
+/// in document order, matching the shape of PyMuPDF's simple TOC
+/// (`[level, title, page]` plus the destination kind). Returns an empty
+/// array when the PDF has no outline.
+///
+/// Pass 1-indexed page numbers (matching `TextItem.page`) to keep only
+/// entries that resolve to those pages; omit `pages` for the whole outline.
+#[napi]
+pub fn extract_outline(buffer: Buffer, pages: Option<Vec<u32>>) -> Result<Vec<OutlineEntryJs>> {
+    let bytes: Vec<u8> = buffer.to_vec();
+    catch_panic("extract_outline", move || {
+        let entries = pdf_inspector::extract_outline_mem(&bytes, pages.as_deref())
+            .map_err(|e| to_napi_err(e, "extract_outline"))?;
+        Ok(entries
+            .into_iter()
+            .map(|e| OutlineEntryJs {
+                level: e.level,
+                title: e.title,
+                page: e.page,
+                dest_kind: e.dest_kind,
+            })
+            .collect())
+    })
+}
+
 /// Extract text within bounding-box regions from a PDF.
 ///
 /// For hybrid OCR: layout model detects regions in rendered images,

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -114,6 +114,17 @@ class StructureElement:
     role: str
     """Standard structure type name ("H1".."H6", "P", "Table", "TD", ...)."""
 
+class OutlineEntry:
+    """One flattened outline (bookmark) entry from the /Outlines tree."""
+    level: int
+    """1-based nesting depth (top-level bookmarks are level 1)."""
+    title: str
+    """Bookmark title (decoded from UTF-16BE or PDFDocEncoding)."""
+    page: Optional[int]
+    """1-indexed target page (matches TextItem.page), None when unresolved."""
+    dest_kind: Optional[str]
+    """Destination kind: fit type ("XYZ", "Fit", "FitH", ...) or "named"."""
+
 class RegionText:
     """Extracted text for a single region."""
     text: str
@@ -245,6 +256,29 @@ def extract_structure_elements_bytes(data: bytes, pages: Optional[list[int]] = N
     """Extract structure-tree element references from tagged PDF bytes.
 
     See :func:`extract_structure_elements` for details.
+    """
+    ...
+
+def extract_outline(path: str, pages: Optional[list[int]] = None) -> list[OutlineEntry]:
+    """Extract the document outline (bookmarks) from a PDF file.
+
+    Walks the catalog's /Outlines tree and returns one OutlineEntry per
+    bookmark in document order, matching PyMuPDF's simple TOC shape
+    ([level, title, page] plus the destination kind). Returns an empty list
+    when the PDF has no outline.
+
+    Args:
+        path: Path to the PDF file.
+        pages: Optional list of 1-indexed pages (matching ``TextItem.page``).
+            When given, only entries resolving to those pages are returned;
+            when ``None`` (default), the whole outline is returned.
+    """
+    ...
+
+def extract_outline_bytes(data: bytes, pages: Optional[list[int]] = None) -> list[OutlineEntry]:
+    """Extract the document outline (bookmarks) from PDF bytes.
+
+    See :func:`extract_outline` for details.
     """
     ...
 

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -258,9 +258,51 @@ fn extract_items_json(
         .map(|items| format_items_json(&items))
 }
 
+fn format_outline_json(outline: &[pdf_inspector::OutlineEntry]) -> String {
+    let entries_json = outline
+        .iter()
+        .map(|entry| {
+            let page = entry
+                .page
+                .map(|page| page.to_string())
+                .unwrap_or_else(|| "null".to_string());
+            let dest_kind = entry
+                .dest_kind
+                .as_ref()
+                .map(|kind| format!(r#""{}""#, json_escape(kind)))
+                .unwrap_or_else(|| "null".to_string());
+            format!(
+                r#"{{"level":{},"title":"{}","page":{},"dest_kind":{}}}"#,
+                entry.level,
+                json_escape(&entry.title),
+                page,
+                dest_kind,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(r#"{{"schema_version":1,"outline":[{}]}}"#, entries_json)
+}
+
+fn extract_toc_json(
+    pdf_path: &str,
+    page_filter: Option<&HashSet<u32>>,
+) -> Result<String, pdf_inspector::PdfError> {
+    let pages: Option<Vec<u32>> = page_filter.map(|filter| {
+        let mut pages: Vec<u32> = filter.iter().copied().collect();
+        pages.sort_unstable();
+        pages
+    });
+    pdf_inspector::extract_outline(pdf_path, pages.as_deref())
+        .map(|outline| format_outline_json(&outline))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{extract_items_json, format_items_json, format_ocr_error_json};
+    use super::{
+        extract_items_json, extract_toc_json, format_items_json, format_ocr_error_json,
+        format_outline_json,
+    };
     #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
     use super::{format_ocr_json, process_pdf_with_ocr, OcrPdfOptions};
     use pdf_inspector::extractor::ItemType;
@@ -325,6 +367,44 @@ mod tests {
         assert!(json.starts_with(r#"{"schema_version":1,"page_count":3,"#));
         assert!(json.contains(r#""page":1,"source":"native""#));
         assert!(!json.contains("layout_ms"));
+    }
+
+    #[test]
+    fn toc_json_has_a_versioned_stable_envelope() {
+        let outline = vec![pdf_inspector::OutlineEntry {
+            level: 1,
+            title: "Say \"hi\"".to_string(),
+            page: Some(3),
+            dest_kind: Some("XYZ".to_string()),
+        }];
+        assert_eq!(
+            format_outline_json(&outline),
+            r#"{"schema_version":1,"outline":[{"level":1,"title":"Say \"hi\"","page":3,"dest_kind":"XYZ"}]}"#
+        );
+
+        let unresolved = vec![pdf_inspector::OutlineEntry {
+            level: 2,
+            title: "Dangling".to_string(),
+            page: None,
+            dest_kind: None,
+        }];
+        assert_eq!(
+            format_outline_json(&unresolved),
+            r#"{"schema_version":1,"outline":[{"level":2,"title":"Dangling","page":null,"dest_kind":null}]}"#
+        );
+    }
+
+    #[test]
+    fn toc_json_extracts_fixture_bookmarks() {
+        let json = extract_toc_json(
+            "tests/fixtures/accessory_building_permit_prose_frame.pdf",
+            None,
+        )
+        .expect("fixture outline should extract");
+        assert!(json.starts_with(r#"{"schema_version":1,"outline":["#));
+        assert!(json.contains(
+            r#"{"level":1,"title":"Accessory Building Ordinance","page":2,"dest_kind":"FitH"}"#
+        ));
     }
 
     #[test]
@@ -403,6 +483,7 @@ fn main() {
         eprintln!("Options:");
         eprintln!("  --json              Output result as JSON");
         eprintln!("  --items-json        Output positioned TextItem JSON");
+        eprintln!("  --toc-json          Output the outline (bookmark) TOC as JSON");
         eprintln!("  --raw               Output only markdown (no headers)");
         eprintln!(
             "  --compact           Collapse token-heavy source formatting such as dot leaders"
@@ -424,6 +505,7 @@ fn main() {
     let pdf_path = &args[1];
     let json_output = args.iter().any(|a| a == "--json");
     let items_json_output = args.iter().any(|a| a == "--items-json");
+    let toc_json_output = args.iter().any(|a| a == "--toc-json");
     let raw_output = args.iter().any(|a| a == "--raw");
     let compact_output = args.iter().any(|a| a == "--compact");
     let page_numbers = args.iter().any(|a| a == "--pages");
@@ -485,9 +567,9 @@ fn main() {
     }
 
     if let Some(mode) = ocr_mode_argument {
-        if items_json_output || detect_only || analyze {
+        if items_json_output || toc_json_output || detect_only || analyze {
             exit_ocr_error(
-                "--ocr cannot be combined with --items-json, --detect-only, or --analyze",
+                "--ocr cannot be combined with --items-json, --toc-json, --detect-only, or --analyze",
                 json_output,
             );
         }
@@ -597,6 +679,17 @@ fn main() {
 
     if items_json_output {
         match extract_items_json(pdf_path, page_filter.as_ref(), password.as_deref()) {
+            Ok(json) => println!("{}", json),
+            Err(e) => {
+                println!(r#"{{"error":"{}"}}"#, json_escape(&e.to_string()));
+                process::exit(1);
+            }
+        }
+        return;
+    }
+
+    if toc_json_output {
+        match extract_toc_json(pdf_path, page_filter.as_ref()) {
             Ok(json) => println!("{}", json),
             Err(e) => {
                 println!(r#"{{"error":"{}"}}"#, json_escape(&e.to_string()));

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod content_stream;
 mod fonts;
 mod layout;
 mod links;
+pub(crate) mod outline;
 mod reading_order;
 pub(crate) mod underline;
 mod xobjects;
@@ -38,6 +39,7 @@ pub(crate) use layout::group_prefiltered_items_into_lines_with_thresholds_and_re
 pub(crate) use layout::is_newspaper_layout;
 pub(crate) use layout::ColumnRegion;
 pub use layout::{group_into_lines, group_into_lines_preserving_all_text};
+pub use outline::OutlineEntry;
 pub(crate) use xobjects::FormWalkBudget;
 
 // ---------------------------------------------------------------------------

--- a/src/extractor/outline.rs
+++ b/src/extractor/outline.rs
@@ -1,0 +1,910 @@
+//! PDF outline (bookmark) extraction.
+//!
+//! Walks the document catalog's `/Outlines` tree and flattens it into a
+//! PyMuPDF-style simple table of contents: one entry per bookmark with a
+//! 1-based nesting level, decoded title, and resolved 1-indexed target page.
+//!
+//! The walk is bounded the same way as the AcroForm field walk in
+//! [`super::links`]: a visited set catches `/Next`/`/First` reference cycles,
+//! a depth cap bounds child recursion, and a node budget caps total traversal
+//! work so a crafted PDF cannot burn unbounded CPU on invalid or duplicate
+//! entries.
+
+use crate::text_utils::decode_text_string;
+use lopdf::{Document, Object, ObjectId};
+use std::collections::{HashMap, HashSet};
+
+use super::fonts::{resolve_array, resolve_dict};
+
+/// Upper bound on the number of outline nodes visited during a single
+/// `extract_outline_from_doc` pass. Mirrors the AcroForm field walk budget:
+/// a crafted PDF can chain enormous `/Next` lists, so total traversal work is
+/// capped in addition to detecting cycles.
+const MAX_OUTLINE_NODES: usize = 100_000;
+
+/// Upper bound on `/First` (child) recursion depth. Real outlines are only a
+/// handful of levels deep; a crafted PDF can nest thousands of levels to
+/// overflow the stack long before the node budget is reached. Sibling
+/// traversal is iterative, so only child nesting consumes stack.
+const MAX_OUTLINE_DEPTH: usize = 32;
+
+/// Traversal budget for the outline walk (FieldWalkBudget-style, see
+/// [`super::links::FieldWalkBudget`]). Bounds both the number of distinct
+/// nodes visited *and* the total number of node references examined, so
+/// duplicate or invalid entries cannot iterate past the cap either.
+struct OutlineWalkBudget {
+    visited: HashSet<ObjectId>,
+    examined: usize,
+}
+
+impl OutlineWalkBudget {
+    fn new() -> Self {
+        Self {
+            visited: HashSet::new(),
+            examined: 0,
+        }
+    }
+
+    /// True once the budget is spent; callers must stop iterating and recursing.
+    fn exhausted(&self) -> bool {
+        self.visited.len() >= MAX_OUTLINE_NODES || self.examined >= MAX_OUTLINE_NODES
+    }
+}
+
+/// One flattened outline (bookmark) entry.
+///
+/// Matches the shape of PyMuPDF's `Document.get_toc(simple=True)` rows
+/// (`[level, title, page]`) plus the destination kind when known.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutlineEntry {
+    /// 1-based nesting depth (top-level bookmarks are level 1).
+    pub level: u32,
+    /// Bookmark title, decoded from UTF-16BE (BOM `FE FF`) or PDFDocEncoding.
+    pub title: String,
+    /// 1-indexed target page (matches [`crate::TextItem::page`]), or `None`
+    /// when the destination is missing or cannot be resolved.
+    pub page: Option<u32>,
+    /// Destination kind when known: an explicit destination's fit type
+    /// ("XYZ", "Fit", "FitH", …) or "named" for named destinations.
+    pub dest_kind: Option<String>,
+}
+
+/// Walk `trailer /Root -> /Outlines` and flatten the bookmark tree.
+///
+/// `page_map` maps page `ObjectId`s to 1-indexed page numbers (the same map
+/// used by [`super::links::extract_form_fields`]). Returns an empty list when
+/// the document has no `/Outlines`; a missing or malformed outline is never
+/// an error.
+pub(crate) fn extract_outline_from_doc(
+    doc: &Document,
+    page_map: &HashMap<ObjectId, u32>,
+) -> Vec<OutlineEntry> {
+    let mut entries = Vec::new();
+
+    let root = match doc.trailer.get(b"Root") {
+        Ok(root_ref) => match root_ref.as_reference() {
+            Ok(r) => match doc.get_dictionary(r) {
+                Ok(d) => d,
+                Err(_) => return entries,
+            },
+            Err(_) => return entries,
+        },
+        Err(_) => return entries,
+    };
+
+    let outlines = match root.get(b"Outlines") {
+        Ok(obj) => match resolve_dict(doc, obj) {
+            Some(d) => d,
+            None => return entries,
+        },
+        Err(_) => return entries,
+    };
+
+    let first = match outlines.get(b"First") {
+        Ok(obj) => match obj.as_reference() {
+            Ok(r) => r,
+            Err(_) => return entries,
+        },
+        Err(_) => return entries,
+    };
+
+    // Named destinations are resolved lazily: most outlines use explicit
+    // destinations, so the name table is only built when first needed.
+    let mut named_dests = NamedDests::new();
+    let mut budget = OutlineWalkBudget::new();
+    walk_outline_level(
+        doc,
+        first,
+        1,
+        page_map,
+        &mut named_dests,
+        &mut entries,
+        &mut budget,
+        0,
+    );
+    entries
+}
+
+/// Walk one sibling chain (`/Next` links) iteratively, recursing into
+/// `/First` children. Sibling iteration is a loop so only child nesting
+/// consumes stack, which the depth cap bounds.
+#[allow(clippy::too_many_arguments)]
+fn walk_outline_level(
+    doc: &Document,
+    first_id: ObjectId,
+    level: u32,
+    page_map: &HashMap<ObjectId, u32>,
+    named_dests: &mut NamedDests,
+    entries: &mut Vec<OutlineEntry>,
+    budget: &mut OutlineWalkBudget,
+    depth: usize,
+) {
+    if depth > MAX_OUTLINE_DEPTH {
+        return;
+    }
+
+    let mut current = Some(first_id);
+    while let Some(node_id) = current {
+        if budget.exhausted() {
+            return;
+        }
+        budget.examined += 1;
+        // Revisiting an object ID means a `/Next` or `/First` cycle.
+        if !budget.visited.insert(node_id) {
+            return;
+        }
+
+        let node = match doc.get_dictionary(node_id) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+
+        let title = node
+            .get(b"Title")
+            .ok()
+            .and_then(|obj| resolve_string_bytes(doc, obj))
+            .map(decode_text_string)
+            .unwrap_or_default();
+
+        let (page, dest_kind) = resolve_outline_destination(doc, node, page_map, named_dests);
+
+        entries.push(OutlineEntry {
+            level,
+            title,
+            page,
+            dest_kind,
+        });
+
+        if let Some(child_id) = node
+            .get(b"First")
+            .ok()
+            .and_then(|obj| obj.as_reference().ok())
+        {
+            walk_outline_level(
+                doc,
+                child_id,
+                level + 1,
+                page_map,
+                named_dests,
+                entries,
+                budget,
+                depth + 1,
+            );
+        }
+
+        current = node
+            .get(b"Next")
+            .ok()
+            .and_then(|obj| obj.as_reference().ok());
+    }
+}
+
+/// Resolve a possibly-referenced PDF string object to its raw bytes.
+fn resolve_string_bytes<'a>(doc: &'a Document, obj: &'a Object) -> Option<&'a [u8]> {
+    match obj {
+        Object::String(bytes, _) => Some(bytes),
+        Object::Reference(r) => match doc.get_object(*r) {
+            Ok(Object::String(bytes, _)) => Some(bytes),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Resolve an outline node's destination to a 1-indexed page and dest kind.
+///
+/// Tries `/Dest` first (explicit array or named destination), then a `/A`
+/// GoTo action's `/D`. Returns `(None, None)` when the node has no
+/// resolvable in-document destination.
+fn resolve_outline_destination(
+    doc: &Document,
+    node: &lopdf::Dictionary,
+    page_map: &HashMap<ObjectId, u32>,
+    named_dests: &mut NamedDests,
+) -> (Option<u32>, Option<String>) {
+    if let Ok(dest) = node.get(b"Dest") {
+        return resolve_dest_object(doc, dest, page_map, named_dests);
+    }
+
+    if let Some(action) = node.get(b"A").ok().and_then(|obj| resolve_dict(doc, obj)) {
+        let is_goto = action
+            .get(b"S")
+            .ok()
+            .and_then(|s| s.as_name().ok())
+            .is_some_and(|name| name == b"GoTo");
+        if is_goto {
+            if let Ok(dest) = action.get(b"D") {
+                return resolve_dest_object(doc, dest, page_map, named_dests);
+            }
+        }
+    }
+
+    (None, None)
+}
+
+/// Resolve a destination object (explicit array, name, or string) to a
+/// 1-indexed page and dest kind.
+fn resolve_dest_object(
+    doc: &Document,
+    dest: &Object,
+    page_map: &HashMap<ObjectId, u32>,
+    named_dests: &mut NamedDests,
+) -> (Option<u32>, Option<String>) {
+    let dest = match dest {
+        Object::Reference(r) => match doc.get_object(*r) {
+            Ok(obj) => obj,
+            Err(_) => return (None, None),
+        },
+        other => other,
+    };
+
+    match dest {
+        Object::Array(arr) => (
+            dest_array_page(arr, page_map),
+            dest_array_kind(arr).map(str::to_string),
+        ),
+        Object::Name(name) => {
+            let page = named_dests
+                .lookup(doc, name)
+                .and_then(|arr| dest_array_page(&arr, page_map));
+            (page, Some("named".to_string()))
+        }
+        Object::String(bytes, _) => {
+            let page = named_dests
+                .lookup(doc, bytes)
+                .and_then(|arr| dest_array_page(&arr, page_map));
+            (page, Some("named".to_string()))
+        }
+        _ => (None, None),
+    }
+}
+
+/// First element of an explicit destination array resolved to a 1-indexed
+/// page number. The element is normally a page reference; an integer is a
+/// 0-based page index (seen in some generators).
+fn dest_array_page(arr: &[Object], page_map: &HashMap<ObjectId, u32>) -> Option<u32> {
+    match arr.first()? {
+        Object::Reference(r) => page_map.get(r).copied(),
+        Object::Integer(i) => {
+            let index = u32::try_from(*i).ok()?;
+            let page = index + 1;
+            (page as usize <= page_map.len()).then_some(page)
+        }
+        _ => None,
+    }
+}
+
+/// Fit-type name from an explicit destination array's second element
+/// ("XYZ", "Fit", "FitH", …).
+fn dest_array_kind(arr: &[Object]) -> Option<&str> {
+    match arr.get(1)? {
+        Object::Name(name) => std::str::from_utf8(name).ok(),
+        _ => None,
+    }
+}
+
+/// Lazily-built map of named destinations.
+///
+/// Built on first lookup from the catalog's PDF 1.1 `/Dests` dictionary and
+/// the `/Names` `/Dests` name tree, walking the tree with the same
+/// cycle/depth/node bounds as the outline walk. Destination values that are
+/// dictionaries contribute their `/D` array.
+struct NamedDests {
+    map: Option<HashMap<Vec<u8>, Vec<Object>>>,
+}
+
+impl NamedDests {
+    fn new() -> Self {
+        Self { map: None }
+    }
+
+    /// Resolve `name` to its explicit destination array, building the name
+    /// table on first use.
+    fn lookup(&mut self, doc: &Document, name: &[u8]) -> Option<Vec<Object>> {
+        if self.map.is_none() {
+            self.map = Some(build_named_dests(doc));
+        }
+        self.map.as_ref().and_then(|m| m.get(name).cloned())
+    }
+}
+
+fn build_named_dests(doc: &Document) -> HashMap<Vec<u8>, Vec<Object>> {
+    let mut map = HashMap::new();
+
+    let Some(root) = doc
+        .trailer
+        .get(b"Root")
+        .ok()
+        .and_then(|obj| resolve_dict(doc, obj))
+    else {
+        return map;
+    };
+
+    // PDF 1.1 style: /Root /Dests is a dictionary of name -> destination.
+    // A crafted dictionary wider than the node budget is truncated.
+    if let Some(dests) = root.get(b"Dests").ok().and_then(|o| resolve_dict(doc, o)) {
+        for (name, value) in dests.iter().take(MAX_OUTLINE_NODES) {
+            if let Some(arr) = dest_value_array(doc, value) {
+                map.insert(name.to_vec(), arr);
+            }
+        }
+    }
+
+    // PDF 1.2+ style: /Root /Names /Dests is a name tree.
+    if let Some(tree_root) = root
+        .get(b"Names")
+        .ok()
+        .and_then(|o| resolve_dict(doc, o))
+        .and_then(|names| names.get(b"Dests").ok())
+        .and_then(|o| resolve_dict(doc, o))
+    {
+        let mut budget = OutlineWalkBudget::new();
+        collect_name_tree_dests(doc, tree_root, &mut map, &mut budget, 0);
+    }
+
+    map
+}
+
+/// Recursively collect `name -> destination array` pairs from a name tree
+/// node, bounded by the shared cycle set, depth cap, and node budget.
+fn collect_name_tree_dests(
+    doc: &Document,
+    node: &lopdf::Dictionary,
+    map: &mut HashMap<Vec<u8>, Vec<Object>>,
+    budget: &mut OutlineWalkBudget,
+    depth: usize,
+) {
+    if depth > MAX_OUTLINE_DEPTH || budget.exhausted() {
+        return;
+    }
+
+    if let Some(names) = node.get(b"Names").ok().and_then(|o| resolve_array(doc, o)) {
+        for pair in names.chunks(2) {
+            if budget.exhausted() {
+                return;
+            }
+            budget.examined += 1;
+            let [key, value] = pair else { continue };
+            let Some(key_bytes) = resolve_string_bytes(doc, key) else {
+                continue;
+            };
+            if let Some(arr) = dest_value_array(doc, value) {
+                map.insert(key_bytes.to_vec(), arr);
+            }
+        }
+    }
+
+    if let Some(kids) = node.get(b"Kids").ok().and_then(|o| resolve_array(doc, o)) {
+        for kid in kids {
+            if budget.exhausted() {
+                return;
+            }
+            budget.examined += 1;
+            let Ok(kid_ref) = kid.as_reference() else {
+                continue;
+            };
+            // Revisiting a node means a /Kids cycle.
+            if !budget.visited.insert(kid_ref) {
+                continue;
+            }
+            if let Ok(kid_dict) = doc.get_dictionary(kid_ref) {
+                collect_name_tree_dests(doc, kid_dict, map, budget, depth + 1);
+            }
+        }
+    }
+}
+
+/// Normalize a named-destination value to its explicit destination array.
+/// The value is either the array itself or a dictionary whose `/D` holds it.
+fn dest_value_array(doc: &Document, value: &Object) -> Option<Vec<Object>> {
+    let value = match value {
+        Object::Reference(r) => doc.get_object(*r).ok()?,
+        other => other,
+    };
+    match value {
+        Object::Array(arr) => Some(arr.clone()),
+        Object::Dictionary(dict) => {
+            let d = dict.get(b"D").ok()?;
+            resolve_array(doc, d).cloned()
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::{dictionary, Object};
+
+    /// Build a doc with `page_count` pages, returning (doc, page ids).
+    /// The pages are standalone objects; tests build the page map directly,
+    /// matching how `extract_positioned_text_impl` derives it from
+    /// `doc.get_pages()`.
+    fn doc_with_pages(page_count: usize) -> (Document, Vec<ObjectId>) {
+        let mut doc = Document::new();
+        let page_ids: Vec<ObjectId> = (0..page_count)
+            .map(|_| doc.add_object(dictionary! { "Type" => "Page" }))
+            .collect();
+        (doc, page_ids)
+    }
+
+    fn page_map(page_ids: &[ObjectId]) -> HashMap<ObjectId, u32> {
+        page_ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| (id, i as u32 + 1))
+            .collect()
+    }
+
+    fn set_catalog(doc: &mut Document, outlines_id: ObjectId) {
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Outlines" => Object::Reference(outlines_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+    }
+
+    #[test]
+    fn no_outlines_returns_empty() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog" });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn flat_outline_with_explicit_dests() {
+        let (mut doc, page_ids) = doc_with_pages(3);
+        let second = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Chapter 2"),
+            "Dest" => vec![
+                Object::Reference(page_ids[2]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let first = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Chapter 1"),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"XYZ".to_vec()),
+                69.into(),
+                720.into(),
+                0.into(),
+            ],
+            "Next" => Object::Reference(second),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(first),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(
+            entries,
+            vec![
+                OutlineEntry {
+                    level: 1,
+                    title: "Chapter 1".to_string(),
+                    page: Some(1),
+                    dest_kind: Some("XYZ".to_string()),
+                },
+                // Second entry is a sibling, not a child, so it stays level 1.
+                OutlineEntry {
+                    level: 1,
+                    title: "Chapter 2".to_string(),
+                    page: Some(3),
+                    dest_kind: Some("Fit".to_string()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_children_get_deeper_levels() {
+        let (mut doc, page_ids) = doc_with_pages(2);
+        let grandchild = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("1.1.1"),
+            "Dest" => vec![
+                Object::Reference(page_ids[1]),
+                Object::Name(b"FitH".to_vec()),
+                796.into(),
+            ],
+        });
+        let child = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("1.1"),
+            "First" => Object::Reference(grandchild),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let top = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("1"),
+            "First" => Object::Reference(child),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(top),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        let simple: Vec<(u32, &str, Option<u32>)> = entries
+            .iter()
+            .map(|e| (e.level, e.title.as_str(), e.page))
+            .collect();
+        assert_eq!(
+            simple,
+            vec![
+                (1, "1", Some(1)),
+                (2, "1.1", Some(1)),
+                (3, "1.1.1", Some(2)),
+            ]
+        );
+        assert_eq!(entries[2].dest_kind.as_deref(), Some("FitH"));
+    }
+
+    #[test]
+    fn goto_action_dest_resolves() {
+        let (mut doc, page_ids) = doc_with_pages(2);
+        let action = doc.add_object(dictionary! {
+            "S" => "GoTo",
+            "D" => vec![
+                Object::Reference(page_ids[1]),
+                Object::Name(b"FitH".to_vec()),
+                796.into(),
+            ],
+        });
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Via action"),
+            "A" => Object::Reference(action),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(2));
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("FitH"));
+    }
+
+    #[test]
+    fn non_goto_action_yields_no_page() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("External link"),
+            "A" => dictionary! {
+                "S" => "URI",
+                "URI" => Object::string_literal("https://example.com"),
+            },
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, None);
+        assert_eq!(entries[0].dest_kind, None);
+    }
+
+    #[test]
+    fn named_dest_via_names_tree() {
+        let (mut doc, page_ids) = doc_with_pages(2);
+        let leaf = doc.add_object(dictionary! {
+            "Names" => vec![
+                Object::string_literal("section.2"),
+                Object::Array(vec![
+                    Object::Reference(page_ids[1]),
+                    Object::Name(b"XYZ".to_vec()),
+                    Object::Null,
+                    Object::Null,
+                    Object::Null,
+                ]),
+            ],
+        });
+        let tree_root = doc.add_object(dictionary! {
+            "Kids" => vec![Object::Reference(leaf)],
+        });
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Section 2"),
+            "Dest" => Object::string_literal("section.2"),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Outlines" => Object::Reference(outlines_id),
+            "Names" => dictionary! {
+                "Dests" => Object::Reference(tree_root),
+            },
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(2));
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("named"));
+    }
+
+    #[test]
+    fn named_dest_via_dests_dictionary() {
+        // PDF 1.1 style: catalog /Dests dictionary, value is a dictionary
+        // whose /D holds the explicit destination.
+        let (mut doc, page_ids) = doc_with_pages(2);
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Appendix"),
+            "Dest" => Object::Name(b"appendix".to_vec()),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        let dests_id = doc.add_object(dictionary! {
+            "appendix" => dictionary! {
+                "D" => vec![
+                    Object::Reference(page_ids[1]),
+                    Object::Name(b"Fit".to_vec()),
+                ],
+            },
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Outlines" => Object::Reference(outlines_id),
+            "Dests" => Object::Reference(dests_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(2));
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("named"));
+    }
+
+    #[test]
+    fn unresolvable_named_dest_keeps_entry_without_page() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Dangling"),
+            "Dest" => Object::string_literal("missing-name"),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, None);
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("named"));
+    }
+
+    #[test]
+    fn utf16be_title_decodes() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        // "Résumé" as UTF-16BE with BOM.
+        let mut bytes = vec![0xFE, 0xFF];
+        for unit in "Résumé".encode_utf16() {
+            bytes.extend_from_slice(&unit.to_be_bytes());
+        }
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::String(bytes, lopdf::StringFormat::Literal),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Résumé");
+    }
+
+    #[test]
+    fn integer_page_index_resolves_one_indexed() {
+        let (mut doc, page_ids) = doc_with_pages(3);
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("By index"),
+            "Dest" => vec![Object::Integer(2), Object::Name(b"Fit".to_vec())],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries[0].page, Some(3));
+    }
+
+    #[test]
+    fn next_self_cycle_terminates() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let node_id = doc.new_object_id();
+        doc.set_object(
+            node_id,
+            dictionary! {
+                "Title" => Object::string_literal("loop"),
+                "Next" => Object::Reference(node_id),
+            },
+        );
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node_id),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn first_next_mutual_cycle_terminates() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let a = doc.new_object_id();
+        let b = doc.new_object_id();
+        doc.set_object(
+            a,
+            dictionary! {
+                "Title" => Object::string_literal("a"),
+                "First" => Object::Reference(b),
+            },
+        );
+        doc.set_object(
+            b,
+            dictionary! {
+                "Title" => Object::string_literal("b"),
+                "Next" => Object::Reference(a),
+            },
+        );
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(a),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn deep_first_chain_stops_at_depth_cap() {
+        // A chain of distinct children nested deeper than the cap must stop
+        // at the cap rather than recursing to the chain length.
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let n = MAX_OUTLINE_DEPTH * 100;
+        let ids: Vec<ObjectId> = (0..=n).map(|_| doc.new_object_id()).collect();
+        for i in 0..n {
+            doc.set_object(
+                ids[i],
+                dictionary! {
+                    "Title" => Object::string_literal("nested"),
+                    "First" => Object::Reference(ids[i + 1]),
+                },
+            );
+        }
+        doc.set_object(
+            ids[n],
+            dictionary! { "Title" => Object::string_literal("leaf") },
+        );
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(ids[0]),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        // Levels 1..=MAX_OUTLINE_DEPTH+1 are emitted (recursion into depth
+        // MAX_OUTLINE_DEPTH+1 is cut off), far fewer than the chain length.
+        assert_eq!(entries.len(), MAX_OUTLINE_DEPTH + 1);
+        assert_eq!(
+            entries.last().unwrap().level as usize,
+            MAX_OUTLINE_DEPTH + 1
+        );
+    }
+
+    #[test]
+    fn long_sibling_chain_stops_at_node_budget() {
+        // A /Next chain longer than the node budget must stop at the cap.
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let n = MAX_OUTLINE_NODES + 50;
+        let ids: Vec<ObjectId> = (0..n).map(|_| doc.new_object_id()).collect();
+        for i in 0..n {
+            let mut dict = dictionary! {
+                "Title" => Object::string_literal("s"),
+            };
+            if i + 1 < n {
+                dict.set("Next", Object::Reference(ids[i + 1]));
+            }
+            doc.set_object(ids[i], dict);
+        }
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(ids[0]),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert!(entries.len() <= MAX_OUTLINE_NODES);
+        assert!(entries.len() >= MAX_OUTLINE_NODES - 1);
+    }
+
+    #[test]
+    fn name_tree_kids_cycle_terminates() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let kid = doc.new_object_id();
+        doc.set_object(
+            kid,
+            dictionary! {
+                "Kids" => vec![Object::Reference(kid)],
+                "Names" => vec![
+                    Object::string_literal("n1"),
+                    Object::Array(vec![
+                        Object::Reference(page_ids[0]),
+                        Object::Name(b"Fit".to_vec()),
+                    ]),
+                ],
+            },
+        );
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("cyclic tree"),
+            "Dest" => Object::string_literal("n1"),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Outlines" => Object::Reference(outlines_id),
+            "Names" => dictionary! {
+                "Dests" => Object::Reference(kid),
+            },
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(1));
+    }
+}

--- a/src/extractor/outline.rs
+++ b/src/extractor/outline.rs
@@ -10,7 +10,7 @@
 //! work so a crafted PDF cannot burn unbounded CPU on invalid or duplicate
 //! entries.
 
-use crate::text_utils::decode_text_string;
+use crate::text_utils::decode_pdfdoc_text_string;
 use lopdf::{Document, Object, ObjectId};
 use std::collections::{HashMap, HashSet};
 
@@ -163,7 +163,7 @@ fn walk_outline_level(
             .get(b"Title")
             .ok()
             .and_then(|obj| resolve_string_bytes(doc, obj))
-            .map(decode_text_string)
+            .map(decode_pdfdoc_text_string)
             .unwrap_or_default();
 
         let (page, dest_kind) = resolve_outline_destination(doc, node, page_map, named_dests);
@@ -211,6 +211,18 @@ fn resolve_string_bytes<'a>(doc: &'a Document, obj: &'a Object) -> Option<&'a [u
     }
 }
 
+/// Resolve a possibly-referenced PDF name object to its raw bytes.
+fn resolve_name_bytes<'a>(doc: &'a Document, obj: &'a Object) -> Option<&'a [u8]> {
+    match obj {
+        Object::Name(name) => Some(name),
+        Object::Reference(r) => match doc.get_object(*r) {
+            Ok(Object::Name(name)) => Some(name),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Resolve an outline node's destination to a 1-indexed page and dest kind.
 ///
 /// Tries `/Dest` first (explicit array or named destination), then a `/A`
@@ -227,10 +239,11 @@ fn resolve_outline_destination(
     }
 
     if let Some(action) = node.get(b"A").ok().and_then(|obj| resolve_dict(doc, obj)) {
+        // `/S` may itself be an indirect reference to the action-type name.
         let is_goto = action
             .get(b"S")
             .ok()
-            .and_then(|s| s.as_name().ok())
+            .and_then(|s| resolve_name_bytes(doc, s))
             .is_some_and(|name| name == b"GoTo");
         if is_goto {
             if let Ok(dest) = action.get(b"D") {
@@ -261,7 +274,7 @@ fn resolve_dest_object(
     match dest {
         Object::Array(arr) => (
             dest_array_page(arr, page_map),
-            dest_array_kind(arr).map(str::to_string),
+            dest_array_kind(doc, arr).map(str::to_string),
         ),
         Object::Name(name) => {
             let page = named_dests
@@ -287,7 +300,9 @@ fn dest_array_page(arr: &[Object], page_map: &HashMap<ObjectId, u32>) -> Option<
         Object::Reference(r) => page_map.get(r).copied(),
         Object::Integer(i) => {
             let index = u32::try_from(*i).ok()?;
-            let page = index + 1;
+            // Checked: a malformed u32::MAX index must yield None, not
+            // overflow.
+            let page = index.checked_add(1)?;
             (page as usize <= page_map.len()).then_some(page)
         }
         _ => None,
@@ -295,12 +310,10 @@ fn dest_array_page(arr: &[Object], page_map: &HashMap<ObjectId, u32>) -> Option<
 }
 
 /// Fit-type name from an explicit destination array's second element
-/// ("XYZ", "Fit", "FitH", …).
-fn dest_array_kind(arr: &[Object]) -> Option<&str> {
-    match arr.get(1)? {
-        Object::Name(name) => std::str::from_utf8(name).ok(),
-        _ => None,
-    }
+/// ("XYZ", "Fit", "FitH", …), which may be an indirect reference.
+fn dest_array_kind<'a>(doc: &'a Document, arr: &'a [Object]) -> Option<&'a str> {
+    let name = resolve_name_bytes(doc, arr.get(1)?)?;
+    std::str::from_utf8(name).ok()
 }
 
 /// Lazily-built map of named destinations.
@@ -599,6 +612,84 @@ mod tests {
     }
 
     #[test]
+    fn goto_action_with_indirect_s_name_resolves() {
+        // `/S` stored as an indirect reference to the /GoTo name must still
+        // be recognized as a GoTo action.
+        let (mut doc, page_ids) = doc_with_pages(2);
+        let s_name = doc.add_object(Object::Name(b"GoTo".to_vec()));
+        let action = doc.add_object(dictionary! {
+            "S" => Object::Reference(s_name),
+            "D" => vec![
+                Object::Reference(page_ids[1]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Indirect S"),
+            "A" => Object::Reference(action),
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(2));
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("Fit"));
+    }
+
+    #[test]
+    fn indirect_dest_fit_type_name_resolves() {
+        // The fit-type name in an explicit destination array may itself be
+        // an indirect reference.
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let kind_name = doc.add_object(Object::Name(b"FitH".to_vec()));
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Indirect kind"),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Reference(kind_name),
+                796.into(),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, Some(1));
+        assert_eq!(entries[0].dest_kind.as_deref(), Some("FitH"));
+    }
+
+    #[test]
+    fn max_u32_integer_page_index_yields_none_without_overflow() {
+        // A malformed 0-based page index of u32::MAX must return None, not
+        // overflow in `index + 1`.
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Overflow"),
+            "Dest" => vec![
+                Object::Integer(u32::MAX as i64),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].page, None);
+    }
+
+    #[test]
     fn non_goto_action_yields_no_page() {
         let (mut doc, page_ids) = doc_with_pages(1);
         let node = doc.add_object(dictionary! {
@@ -738,6 +829,36 @@ mod tests {
         let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].title, "Résumé");
+    }
+
+    #[test]
+    fn pdfdoc_encoding_title_maps_punctuation_and_ligatures() {
+        // Titles without a UTF-16BE BOM are PDFDocEncoded: bytes 0x80–0x9E
+        // are punctuation/ligatures, not the Latin-1 control characters.
+        let (mut doc, page_ids) = doc_with_pages(1);
+        // "ﬁle — 'quoted'" in PDFDocEncoding.
+        let bytes = vec![
+            0x93, b'l', b'e', b' ', 0x84, b' ', 0x8F, b'q', b'u', b'o', b't', b'e', b'd', 0x90,
+        ];
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::String(bytes, lopdf::StringFormat::Literal),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].title,
+            "\u{FB01}le \u{2014} \u{2018}quoted\u{2019}"
+        );
     }
 
     #[test]

--- a/src/extractor/outline.rs
+++ b/src/extractor/outline.rs
@@ -59,7 +59,7 @@ impl OutlineWalkBudget {
 pub struct OutlineEntry {
     /// 1-based nesting depth (top-level bookmarks are level 1).
     pub level: u32,
-    /// Bookmark title, decoded from UTF-16BE (BOM `FE FF`) or PDFDocEncoding.
+    /// Bookmark title, decoded from BOM-marked UTF-16 or PDFDocEncoding.
     pub title: String,
     /// 1-indexed target page (matches [`crate::TextItem::page`]), or `None`
     /// when the destination is missing or cannot be resolved.
@@ -832,8 +832,33 @@ mod tests {
     }
 
     #[test]
+    fn utf16le_title_decodes() {
+        let (mut doc, page_ids) = doc_with_pages(1);
+        let mut bytes = vec![0xFF, 0xFE];
+        for unit in "Résumé".encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        let node = doc.add_object(dictionary! {
+            "Title" => Object::String(bytes, lopdf::StringFormat::Literal),
+            "Dest" => vec![
+                Object::Reference(page_ids[0]),
+                Object::Name(b"Fit".to_vec()),
+            ],
+        });
+        let outlines_id = doc.add_object(dictionary! {
+            "Type" => "Outlines",
+            "First" => Object::Reference(node),
+        });
+        set_catalog(&mut doc, outlines_id);
+
+        let entries = extract_outline_from_doc(&doc, &page_map(&page_ids));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Résumé");
+    }
+
+    #[test]
     fn pdfdoc_encoding_title_maps_punctuation_and_ligatures() {
-        // Titles without a UTF-16BE BOM are PDFDocEncoded: bytes 0x80–0x9E
+        // Titles without a UTF-16 BOM are PDFDocEncoded: bytes 0x80–0x9E
         // are punctuation/ligatures, not the Latin-1 control characters.
         let (mut doc, page_ids) = doc_with_pages(1);
         // "ﬁle — 'quoted'" in PDFDocEncoding.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub use detector::{
 pub use extractor::{
     extract_text, extract_text_with_positions, extract_text_with_positions_mem,
     extract_text_with_positions_pages, extract_text_with_positions_pages_with_password,
+    OutlineEntry,
 };
 pub use markdown::{
     to_markdown, to_markdown_from_items, to_markdown_from_items_with_rects,
@@ -961,6 +962,49 @@ pub fn extract_structure_elements<P: AsRef<Path>>(
     validate_pdf_file(&path)?;
     let buffer = std::fs::read(path.as_ref())?;
     extract_structure_elements_mem(&buffer, pages)
+}
+
+/// Extract the document outline (bookmarks) from a PDF in memory.
+///
+/// Walks the catalog's `/Outlines` tree and returns one [`OutlineEntry`] per
+/// bookmark in document order, matching the shape of PyMuPDF's simple TOC
+/// (`[level, title, page]` plus the destination kind). Returns an empty list
+/// when the PDF has no outline — a missing outline is never an error.
+///
+/// Pass `Some(&[...])` with 1-indexed page numbers (matching
+/// [`TextItem::page`]) to keep only entries that resolve to those pages;
+/// pass `None` for the whole outline.
+pub fn extract_outline_mem(
+    buffer: &[u8],
+    pages: Option<&[u32]>,
+) -> Result<Vec<OutlineEntry>, PdfError> {
+    validate_pdf_bytes(buffer)?;
+    let (doc, _page_count) = load_document_from_mem(buffer)?;
+    let page_map: HashMap<lopdf::ObjectId, u32> = doc
+        .get_pages()
+        .iter()
+        .map(|(num, &id)| (id, *num))
+        .collect();
+    let mut entries = extractor::outline::extract_outline_from_doc(&doc, &page_map);
+    if let Some(pages) = pages {
+        let filter: HashSet<u32> = pages.iter().copied().collect();
+        entries.retain(|entry| entry.page.is_some_and(|page| filter.contains(&page)));
+    }
+    Ok(entries)
+}
+
+/// Path-based wrapper for [`extract_outline_mem`].
+///
+/// Reads the PDF from disk and extracts its outline (bookmarks). Pass `None`
+/// for `pages` to return the whole outline, or `Some(&[...])` to keep only
+/// entries resolving to specific 1-indexed pages.
+pub fn extract_outline<P: AsRef<Path>>(
+    path: P,
+    pages: Option<&[u32]>,
+) -> Result<Vec<OutlineEntry>, PdfError> {
+    validate_pdf_file(&path)?;
+    let buffer = std::fs::read(path.as_ref())?;
+    extract_outline_mem(&buffer, pages)
 }
 
 // =========================================================================

--- a/src/python.rs
+++ b/src/python.rs
@@ -430,7 +430,7 @@ pub struct PyOutlineEntry {
     /// 1-based nesting depth (top-level bookmarks are level 1).
     #[pyo3(get)]
     pub level: u32,
-    /// Bookmark title (decoded from UTF-16BE or PDFDocEncoding).
+    /// Bookmark title (decoded from BOM-marked UTF-16 or PDFDocEncoding).
     #[pyo3(get)]
     pub title: String,
     /// 1-indexed target page (matches TextItem.page), None when the

--- a/src/python.rs
+++ b/src/python.rs
@@ -446,8 +446,10 @@ pub struct PyOutlineEntry {
 #[pymethods]
 impl PyOutlineEntry {
     fn __repr__(&self) -> String {
+        // `{:?}` escapes quotes and control characters so titles with
+        // apostrophes or embedded newlines cannot break the repr.
         format!(
-            "OutlineEntry(level={}, title='{}', page={:?})",
+            "OutlineEntry(level={}, title={:?}, page={:?})",
             self.level,
             self.title.chars().take(40).collect::<String>(),
             self.page,

--- a/src/python.rs
+++ b/src/python.rs
@@ -421,6 +421,40 @@ impl PyStructureElement {
     }
 }
 
+/// One flattened outline (bookmark) entry from the document catalog's
+/// /Outlines tree. Matches PyMuPDF's simple TOC rows ([level, title, page])
+/// plus the destination kind when known.
+#[pyclass(name = "OutlineEntry")]
+#[derive(Clone)]
+pub struct PyOutlineEntry {
+    /// 1-based nesting depth (top-level bookmarks are level 1).
+    #[pyo3(get)]
+    pub level: u32,
+    /// Bookmark title (decoded from UTF-16BE or PDFDocEncoding).
+    #[pyo3(get)]
+    pub title: String,
+    /// 1-indexed target page (matches TextItem.page), None when the
+    /// destination is missing or cannot be resolved.
+    #[pyo3(get)]
+    pub page: Option<u32>,
+    /// Destination kind when known: an explicit destination's fit type
+    /// ("XYZ", "Fit", "FitH", ...) or "named" for named destinations.
+    #[pyo3(get)]
+    pub dest_kind: Option<String>,
+}
+
+#[pymethods]
+impl PyOutlineEntry {
+    fn __repr__(&self) -> String {
+        format!(
+            "OutlineEntry(level={}, title='{}', page={:?})",
+            self.level,
+            self.title.chars().take(40).collect::<String>(),
+            self.page,
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -991,6 +1025,49 @@ fn extract_structure_elements_bytes(
     Ok(convert_structure_elements(elements))
 }
 
+fn convert_outline_entries(entries: Vec<crate::OutlineEntry>) -> Vec<PyOutlineEntry> {
+    entries
+        .into_iter()
+        .map(|e| PyOutlineEntry {
+            level: e.level,
+            title: e.title,
+            page: e.page,
+            dest_kind: e.dest_kind,
+        })
+        .collect()
+}
+
+/// Extract the document outline (bookmarks) from a PDF file.
+///
+/// Walks the catalog's /Outlines tree and returns one OutlineEntry per
+/// bookmark in document order, matching PyMuPDF's simple TOC shape.
+/// Returns an empty list when the PDF has no outline.
+///
+/// Args:
+///     path: Path to the PDF file.
+///     pages: Optional list of 1-indexed pages (matching TextItem.page).
+///         When given, only entries resolving to those pages are returned;
+///         when None (default), the whole outline is returned.
+///
+/// Returns:
+///     List of OutlineEntry in document order.
+#[pyfunction]
+#[pyo3(signature = (path, pages=None))]
+fn extract_outline(path: &str, pages: Option<Vec<u32>>) -> PyResult<Vec<PyOutlineEntry>> {
+    let entries = crate::extract_outline(path, pages.as_deref()).map_err(to_py_err)?;
+    Ok(convert_outline_entries(entries))
+}
+
+/// Extract the document outline (bookmarks) from PDF bytes.
+///
+/// See [`extract_outline`] for details.
+#[pyfunction]
+#[pyo3(signature = (data, pages=None))]
+fn extract_outline_bytes(data: &[u8], pages: Option<Vec<u32>>) -> PyResult<Vec<PyOutlineEntry>> {
+    let entries = crate::extract_outline_mem(data, pages.as_deref()).map_err(to_py_err)?;
+    Ok(convert_outline_entries(entries))
+}
+
 /// Python module definition.
 #[pymodule]
 fn pdf_inspector(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -1004,6 +1081,7 @@ fn pdf_inspector(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPdfClassification>()?;
     m.add_class::<PyTextItem>()?;
     m.add_class::<PyStructureElement>()?;
+    m.add_class::<PyOutlineEntry>()?;
     m.add_class::<PyRegionText>()?;
     m.add_class::<PyPageRegionTexts>()?;
     m.add_class::<PyPageMarkdown>()?;
@@ -1022,6 +1100,8 @@ fn pdf_inspector(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(extract_text_with_positions_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(extract_structure_elements, m)?)?;
     m.add_function(wrap_pyfunction!(extract_structure_elements_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(extract_outline, m)?)?;
+    m.add_function(wrap_pyfunction!(extract_outline_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(extract_text_in_regions, m)?)?;
     m.add_function(wrap_pyfunction!(extract_text_in_regions_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(extract_pages_markdown, m)?)?;

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -603,7 +603,7 @@ pub(crate) fn decode_text_string(bytes: &[u8]) -> String {
 
 /// PDFDocEncoding bytes that differ from Latin-1 (PDF 32000-1:2008 Annex D):
 /// accents at 0x18–0x1F, punctuation/ligatures at 0x80–0x9E, euro at 0xA0.
-/// Undefined bytes (0x7F, 0x9F, 0xAD) fall back to their Latin-1 value.
+/// Undefined bytes (0x7F, 0x9F, 0xAD) decode to the replacement character.
 fn pdfdoc_encoding_char(byte: u8) -> char {
     match byte {
         0x18 => '\u{02D8}', // breve
@@ -614,6 +614,7 @@ fn pdfdoc_encoding_char(byte: u8) -> char {
         0x1D => '\u{02DB}', // ogonek
         0x1E => '\u{02DA}', // ring
         0x1F => '\u{02DC}', // tilde
+        0x7F | 0x9F | 0xAD => '\u{FFFD}',
         0x80 => '\u{2022}', // bullet
         0x81 => '\u{2020}', // dagger
         0x82 => '\u{2021}', // daggerdbl
@@ -650,12 +651,11 @@ fn pdfdoc_encoding_char(byte: u8) -> char {
     }
 }
 
-/// Decode a PDF text string with the exact PDFDocEncoding table: UTF-16BE
-/// when the BOM (\xFE\xFF) is present, otherwise PDFDocEncoding including
-/// the bytes that differ from Latin-1 (curly quotes, dashes, fi/fl
-/// ligatures, accents, euro). Used for outline (bookmark) titles;
-/// [`decode_text_string`] keeps its Latin-1 approximation for existing
-/// ActualText callers.
+/// Decode a PDF text string with the exact PDFDocEncoding table: UTF-16 when
+/// a byte-order mark is present, otherwise PDFDocEncoding including the bytes
+/// that differ from Latin-1 (curly quotes, dashes, fi/fl ligatures, accents,
+/// euro). Used for outline (bookmark) titles; [`decode_text_string`] keeps its
+/// Latin-1 approximation for existing ActualText callers.
 pub(crate) fn decode_pdfdoc_text_string(bytes: &[u8]) -> String {
     if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
         let utf16: Vec<u16> = bytes[2..]
@@ -663,6 +663,14 @@ pub(crate) fn decode_pdfdoc_text_string(bytes: &[u8]) -> String {
             .0
             .iter()
             .map(|chunk| u16::from_be_bytes(*chunk))
+            .collect();
+        String::from_utf16_lossy(&utf16)
+    } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
+        let utf16: Vec<u16> = bytes[2..]
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect();
         String::from_utf16_lossy(&utf16)
     } else {
@@ -1213,6 +1221,23 @@ mod tests {
             utf16.extend_from_slice(&unit.to_be_bytes());
         }
         assert_eq!(decode_pdfdoc_text_string(&utf16), "Ü");
+    }
+
+    #[test]
+    fn pdfdoc_decoder_replaces_undefined_bytes() {
+        assert_eq!(
+            decode_pdfdoc_text_string(&[0x7F, 0x9F, 0xAD]),
+            "\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn pdfdoc_decoder_decodes_utf16le_with_bom() {
+        let mut utf16 = vec![0xFF, 0xFE];
+        for unit in "Résumé".encode_utf16() {
+            utf16.extend_from_slice(&unit.to_le_bytes());
+        }
+        assert_eq!(decode_pdfdoc_text_string(&utf16), "Résumé");
     }
 
     #[test]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -601,6 +601,75 @@ pub(crate) fn decode_text_string(bytes: &[u8]) -> String {
     }
 }
 
+/// PDFDocEncoding bytes that differ from Latin-1 (PDF 32000-1:2008 Annex D):
+/// accents at 0x18–0x1F, punctuation/ligatures at 0x80–0x9E, euro at 0xA0.
+/// Undefined bytes (0x7F, 0x9F, 0xAD) fall back to their Latin-1 value.
+fn pdfdoc_encoding_char(byte: u8) -> char {
+    match byte {
+        0x18 => '\u{02D8}', // breve
+        0x19 => '\u{02C7}', // caron
+        0x1A => '\u{02C6}', // circumflex
+        0x1B => '\u{02D9}', // dotaccent
+        0x1C => '\u{02DD}', // hungarumlaut
+        0x1D => '\u{02DB}', // ogonek
+        0x1E => '\u{02DA}', // ring
+        0x1F => '\u{02DC}', // tilde
+        0x80 => '\u{2022}', // bullet
+        0x81 => '\u{2020}', // dagger
+        0x82 => '\u{2021}', // daggerdbl
+        0x83 => '\u{2026}', // ellipsis
+        0x84 => '\u{2014}', // emdash
+        0x85 => '\u{2013}', // endash
+        0x86 => '\u{0192}', // florin
+        0x87 => '\u{2044}', // fraction
+        0x88 => '\u{2039}', // guilsinglleft
+        0x89 => '\u{203A}', // guilsinglright
+        0x8A => '\u{2212}', // minus
+        0x8B => '\u{2030}', // perthousand
+        0x8C => '\u{201E}', // quotedblbase
+        0x8D => '\u{201C}', // quotedblleft
+        0x8E => '\u{201D}', // quotedblright
+        0x8F => '\u{2018}', // quoteleft
+        0x90 => '\u{2019}', // quoteright
+        0x91 => '\u{201A}', // quotesinglbase
+        0x92 => '\u{2122}', // trademark
+        0x93 => '\u{FB01}', // fi ligature
+        0x94 => '\u{FB02}', // fl ligature
+        0x95 => '\u{0141}', // Lslash
+        0x96 => '\u{0152}', // OE
+        0x97 => '\u{0160}', // Scaron
+        0x98 => '\u{0178}', // Ydieresis
+        0x99 => '\u{017D}', // Zcaron
+        0x9A => '\u{0131}', // dotlessi
+        0x9B => '\u{0142}', // lslash
+        0x9C => '\u{0153}', // oe
+        0x9D => '\u{0161}', // scaron
+        0x9E => '\u{017E}', // zcaron
+        0xA0 => '\u{20AC}', // Euro
+        other => other as char,
+    }
+}
+
+/// Decode a PDF text string with the exact PDFDocEncoding table: UTF-16BE
+/// when the BOM (\xFE\xFF) is present, otherwise PDFDocEncoding including
+/// the bytes that differ from Latin-1 (curly quotes, dashes, fi/fl
+/// ligatures, accents, euro). Used for outline (bookmark) titles;
+/// [`decode_text_string`] keeps its Latin-1 approximation for existing
+/// ActualText callers.
+pub(crate) fn decode_pdfdoc_text_string(bytes: &[u8]) -> String {
+    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+        let utf16: Vec<u16> = bytes[2..]
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_be_bytes(*chunk))
+            .collect();
+        String::from_utf16_lossy(&utf16)
+    } else {
+        bytes.iter().map(|&b| pdfdoc_encoding_char(b)).collect()
+    }
+}
+
 /// Compute effective font size from base size and text matrix
 /// Text matrix is [a, b, c, d, tx, ty] where a,d are scale factors
 pub(crate) fn effective_font_size(base_size: f32, text_matrix: &[f32; 6]) -> f32 {
@@ -1125,6 +1194,25 @@ mod tests {
     #[test]
     fn strip_soft_hyphen() {
         assert_eq!(expand_ligatures("con\u{00AD}tent"), "content");
+    }
+
+    #[test]
+    fn pdfdoc_decoder_maps_differences_and_keeps_latin1_elsewhere() {
+        // Bytes that differ from Latin-1: accents, punctuation, ligatures, euro.
+        assert_eq!(decode_pdfdoc_text_string(&[0x18]), "\u{02D8}"); // breve
+        assert_eq!(decode_pdfdoc_text_string(&[0x84]), "\u{2014}"); // emdash
+        assert_eq!(decode_pdfdoc_text_string(&[0x93, 0x94]), "\u{FB01}\u{FB02}"); // fi fl
+        assert_eq!(decode_pdfdoc_text_string(&[0x8F, 0x90]), "\u{2018}\u{2019}"); // quotes
+        assert_eq!(decode_pdfdoc_text_string(&[0xA0]), "\u{20AC}"); // euro
+                                                                    // Latin-1-identical ranges pass through unchanged.
+        assert_eq!(decode_pdfdoc_text_string(b"Hello"), "Hello");
+        assert_eq!(decode_pdfdoc_text_string(&[0xE9]), "é");
+        // UTF-16BE with BOM still decodes.
+        let mut utf16 = vec![0xFE, 0xFF];
+        for unit in "Ü".encode_utf16() {
+            utf16.extend_from_slice(&unit.to_be_bytes());
+        }
+        assert_eq!(decode_pdfdoc_text_string(&utf16), "Ü");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1532,6 +1532,96 @@ fn test_extract_structure_elements_untagged_pdf_empty() {
     );
 }
 
+/// Outline extraction must match PyMuPDF's `get_toc(simple=True)` for a
+/// fixture with bookmarks. Expected rows generated with PyMuPDF 1.28:
+/// `[[1, 'Accessory Building Ordinance', 2], [1, 'Accessory Building Permit
+/// Application', 1], [2, 'Accessory Building Permit Application', 1],
+/// [3, 'Accessory Building Permit', 1]]`.
+#[test]
+fn test_extract_outline_matches_pymupdf_simple_toc() {
+    let entries = pdf_inspector::extract_outline(
+        "tests/fixtures/accessory_building_permit_prose_frame.pdf",
+        None,
+    )
+    .unwrap();
+
+    let simple: Vec<(u32, &str, Option<u32>)> = entries
+        .iter()
+        .map(|e| (e.level, e.title.as_str(), e.page))
+        .collect();
+    assert_eq!(
+        simple,
+        vec![
+            (1, "Accessory Building Ordinance", Some(2)),
+            (1, "Accessory Building Permit Application", Some(1)),
+            (2, "Accessory Building Permit Application", Some(1)),
+            (3, "Accessory Building Permit", Some(1)),
+        ]
+    );
+
+    // This fixture's bookmarks use /A GoTo actions with /FitH destinations.
+    assert!(entries
+        .iter()
+        .all(|e| e.dest_kind.as_deref() == Some("FitH")));
+}
+
+/// Multi-level outline (53 entries, 3 levels deep, direct /Dest XYZ arrays).
+/// Expected values cross-checked against PyMuPDF's simple TOC.
+#[test]
+fn test_extract_outline_multilevel_fixture() {
+    let buf = std::fs::read("tests/fixtures/multiline_indent_cell_rect_grid.pdf").unwrap();
+    let entries = pdf_inspector::extract_outline_mem(&buf, None).unwrap();
+
+    assert_eq!(entries.len(), 53);
+    assert_eq!(
+        (entries[0].level, entries[0].title.as_str(), entries[0].page),
+        (1, "Terms of Use", Some(2))
+    );
+    let last = entries.last().unwrap();
+    assert_eq!(
+        (last.level, last.title.as_str(), last.page),
+        (1, "Appendix: Change History", Some(264))
+    );
+
+    // Level distribution matches PyMuPDF: 7 top-level, 21 second, 25 third.
+    let count = |level| entries.iter().filter(|e| e.level == level).count();
+    assert_eq!((count(1), count(2), count(3)), (7, 21, 25));
+
+    assert!(entries
+        .iter()
+        .all(|e| e.dest_kind.as_deref() == Some("XYZ")));
+}
+
+/// The optional page filter is 1-indexed and keeps only entries resolving
+/// to the requested pages.
+#[test]
+fn test_extract_outline_page_filter() {
+    let buf = std::fs::read("tests/fixtures/accessory_building_permit_prose_frame.pdf").unwrap();
+    let page1 = pdf_inspector::extract_outline_mem(&buf, Some(&[1])).unwrap();
+    assert_eq!(page1.len(), 3);
+    assert!(page1.iter().all(|e| e.page == Some(1)));
+
+    let page2 = pdf_inspector::extract_outline_mem(&buf, Some(&[2])).unwrap();
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2[0].title, "Accessory Building Ordinance");
+}
+
+/// A PDF without /Outlines yields an empty list, never an error.
+#[test]
+fn test_extract_outline_absent_is_empty_not_error() {
+    let pdf = make_text_pdf("(Hello world) Tj", "0 0 612 792");
+    let entries = pdf_inspector::extract_outline_mem(&pdf, None).unwrap();
+    assert!(entries.is_empty());
+
+    let buf = std::fs::read("tests/fixtures/thermo-freon12.pdf").unwrap();
+    let entries = pdf_inspector::extract_outline_mem(&buf, None).unwrap();
+    assert!(
+        entries.is_empty(),
+        "fixture without bookmarks should yield an empty outline, got {:?}",
+        entries
+    );
+}
+
 #[test]
 fn test_identity_h_no_tounicode_suppresses_garbage() {
     // shinagawa_identity_h.pdf uses YuGothic with Identity-H encoding and no


### PR DESCRIPTION
## Summary

Adds PDF outline (bookmark) extraction: new `extract_outline` / `extract_outline_mem` public APIs that walk the catalog `/Outlines` tree and return a PyMuPDF-style simple TOC, plus a `pdf2md --toc-json` CLI flag. Default Markdown output is unchanged.

## Behaviour

- Walks `trailer /Root -> /Outlines -> /First`, following `/Next` siblings iteratively and `/First` children recursively.
- Each `OutlineEntry` carries a 1-based `level`, `title` decoded via `text_utils::decode_text_string` (UTF-16BE BOM + PDFDocEncoding), 1-indexed `page: Option<u32>`, and optional `dest_kind` (`XYZ`/`Fit`/`FitH`/… for explicit destinations, `"named"` for named ones).
- Destinations resolve from `/Dest` arrays, `/A` GoTo `/D`, and named destinations via the catalog `/Dests` dictionary or the `/Names` `/Dests` name tree. Pages resolve through the same page `ObjectId -> page number` map used by `extract_form_fields`.
- The walk is bounded FieldWalkBudget-style (copied from the AcroForm field walk): cycle set on visited object ids, depth cap 32, node budget 100,000, with every examined entry charged against the budget. The name-tree walk shares the same bounds.
- A PDF without `/Outlines` (or with a malformed outline) yields an empty list — never an error.

## Surfaces

- **Rust**: `extract_outline(path, pages)` / `extract_outline_mem(buffer, pages)` with an optional 1-indexed page filter.
- **CLI**: `pdf2md file.pdf --toc-json` prints `{"schema_version":1,"outline":[{"level":1,"title":"…","page":2,"dest_kind":"FitH"}, …]}` (honors `--select-pages`; rejected in combination with `--ocr` like the other JSON-only modes).
- **Python**: `extract_outline(path, pages=None)` / `extract_outline_bytes(data, pages=None)` returning `OutlineEntry` objects; `.pyi` stub updated.
- **napi**: `extractOutline(buffer, pages?)` returning `OutlineEntryJs[]`.
- **WASM**: intentionally omitted.

Out of scope (per design): feeding the outline into heading classification, writing outlines, GoTo link annotations, version bump, and visual TOC-line detection (`is_toc_entry_line` is unrelated).

## Testing

- `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` all pass (1044 unit + 169 integration + 5 CLI tests, 0 failures).
- Unit tests use synthetic lopdf outline dictionaries (same shape as the `links.rs` tests): explicit dests, GoTo actions, named dests via both `/Dests` dictionary and `/Names` name tree, UTF-16BE titles, integer page indexes, `/Next` self-cycles, `First`/`Next` mutual cycles, name-tree `/Kids` cycles, depth-cap and node-budget exhaustion.
- Integration tests cross-check two bookmark-bearing fixtures against PyMuPDF 1.28 `get_toc(simple=True)`:
  - `accessory_building_permit_prose_frame.pdf` (4 entries, 3 levels, `/A` GoTo `FitH` dests) — exact match.
  - `multiline_indent_cell_rect_grid.pdf` (53 entries, 3 levels, direct `/Dest` `XYZ` arrays) — exact match, including the 7/21/25 per-level distribution.

End-to-end verification of the release binary against PyMuPDF:

```
tests/fixtures/accessory_building_permit_prose_frame.pdf entries: 4 match PyMuPDF simple TOC: True
  sample: {'level': 1, 'title': 'Accessory Building Ordinance', 'page': 2, 'dest_kind': 'FitH'}
tests/fixtures/multiline_indent_cell_rect_grid.pdf entries: 53 match PyMuPDF simple TOC: True
  sample: {'level': 1, 'title': 'Terms of Use', 'page': 2, 'dest_kind': 'XYZ'}
```

Note: the `pdf-evals` regression suite repo is not available in this environment, so the full `bench.py test` snapshot run was not executed; the extraction pipeline itself is untouched (only new module registration and re-exports), so default Markdown output is byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PDF outline (bookmark) extraction through new `extract_outline` / `extract_outline_mem` APIs and a `pdf2md --toc-json` flag. Default Markdown output is unchanged, and PDFs without an outline return an empty list instead of an error.

**New Features**
- Walks the catalog `/Outlines` tree and returns entries with 1-based level, title decoded via exact PDFDocEncoding or UTF-16 BOM (BE and LE), 1-indexed page, and `dest_kind` (`XYZ`/`Fit`/`FitH`/… or `"named"`).
- Resolves explicit `/Dest` arrays, `/A` GoTo actions, and named destinations from the catalog `/Dests` dictionary or `/Names` `/Dests` name tree, including indirect references.
- Bounds traversal with a visited-object set, depth cap of 32, and 100,000-node budget.
- Both APIs accept an optional 1-indexed page filter.
- Exposes Python `extract_outline` / `extract_outline_bytes` and napi `extractOutline`; WASM is intentionally omitted.
- `--toc-json` prints a versioned JSON envelope, honors `--select-pages`, and is rejected with `--ocr`.

**Testing**
- Unit tests cover explicit, GoTo, and named destinations, indirect references, PDFDocEncoding and UTF-16BE/LE titles, overflow-safe page indexes, plus cycle, depth, and budget limits.
- Integration tests match PyMuPDF 1.28 `get_toc(simple=True)` on two bookmark-bearing fixtures.

<sup>Written for commit c2ab272b67f5f309b36dd24ca261b93082437d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

