### PR TITLE
test(bindings): route encrypted fixture through password-aware Python API

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -16,6 +16,11 @@ def fixture_bytes(name: str) -> bytes:
         return f.read()
 
 
+# Fixtures that need a user password to open. `process_pdf` has no password
+# parameter, so these are exercised through `process_pdf_with_ocr`, which does.
+ENCRYPTED_FIXTURE_PASSWORDS = {"encrypted-secret123.pdf": "secret123"}
+
+
 # ---------------------------------------------------------------------------
 # process_pdf
 # ---------------------------------------------------------------------------
@@ -35,6 +40,10 @@ class TestProcessPdf:
         r = repr(result)
         assert "PdfResult" in r
         assert "text_based" in r
+
+    def test_encrypted_pdf_without_password_raises(self):
+        with pytest.raises(ValueError, match="encrypted"):
+            pdf_inspector.process_pdf(fixture_path("encrypted-secret123.pdf"))
 
     def test_with_pages(self):
         result = pdf_inspector.process_pdf(
@@ -94,6 +103,18 @@ class TestProcessPdfWithOcr:
         assert all(page.provenance.ocr_model is None for page in result.pages)
         assert result.markdown
         assert "OcrPdfResult" in repr(result)
+
+    def test_password_opens_encrypted_fixture(self):
+        result = pdf_inspector.process_pdf_with_ocr(
+            fixture_path("encrypted-secret123.pdf"), mode="off", password="secret123"
+        )
+        assert result.page_count > 0
+        assert "Procurement" in result.markdown
+
+        result = pdf_inspector.process_pdf_with_ocr_bytes(
+            fixture_bytes("encrypted-secret123.pdf"), mode="off", password="secret123"
+        )
+        assert "Procurement" in result.markdown
 
     def test_auto_mode_skips_external_runtimes_for_clean_text(self):
         result = pdf_inspector.process_pdf_with_ocr_bytes(
@@ -509,6 +530,17 @@ class TestMultipleFixtures:
         [f for f in os.listdir(FIXTURES_DIR) if f.endswith(".pdf")],
     )
     def test_process_all_fixtures(self, filename):
+        password = ENCRYPTED_FIXTURE_PASSWORDS.get(filename)
+        if password is not None:
+            # `process_pdf` cannot open encrypted files; use the password-aware
+            # entry point with OCR disabled so no external runtime is needed.
+            result = pdf_inspector.process_pdf_with_ocr(
+                fixture_path(filename), mode="off", password=password
+            )
+            assert result.page_count > 0
+            assert result.markdown
+            return
+
         result = pdf_inspector.process_pdf(fixture_path(filename))
         assert result.pdf_type in (
             "text_based",

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -105,14 +105,16 @@ class TestProcessPdfWithOcr:
         assert "OcrPdfResult" in repr(result)
 
     def test_password_opens_encrypted_fixture(self):
+        filename = "encrypted-secret123.pdf"
+        password = ENCRYPTED_FIXTURE_PASSWORDS[filename]
         result = pdf_inspector.process_pdf_with_ocr(
-            fixture_path("encrypted-secret123.pdf"), mode="off", password="secret123"
+            fixture_path(filename), mode="off", password=password
         )
         assert result.page_count > 0
         assert "Procurement" in result.markdown
 
         result = pdf_inspector.process_pdf_with_ocr_bytes(
-            fixture_bytes("encrypted-secret123.pdf"), mode="off", password="secret123"
+            fixture_bytes(filename), mode="off", password=password
         )
         assert "Procurement" in result.markdown
 


### PR DESCRIPTION
## Summary

`TestMultipleFixtures.test_process_all_fixtures` in `tests/test_python.py` runs every PDF in `tests/fixtures/` through `process_pdf`, which has no password parameter, so the encrypted fixture added with `--password` support failed with `ValueError: PDF is encrypted`. CI does not run pytest, so the failure went unnoticed.

- Encrypted fixtures are now routed through `process_pdf_with_ocr` with `mode="off"` and their known password, looked up from a small `ENCRYPTED_FIXTURE_PASSWORDS` map. OCR stays off, so no external runtime is needed.
- Adds two focused tests: `process_pdf` on the encrypted fixture raises `ValueError` mentioning encryption, and the path and bytes OCR entry points decrypt it with the password and return the fixture's real text, mirroring the existing Rust integration test.

## Verification

Built the wheel with `maturin build --release` into a Python 3.12 venv and ran `pytest tests/test_python.py`: 86 passed. The unmodified test file fails on the encrypted fixture against the same wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Python fixture tests so encrypted PDFs use password-aware `process_pdf_with_ocr` instead of `process_pdf`, which cannot accept passwords. OCR stays off, avoiding external runtime dependencies while allowing the full fixture sweep to pass.

- Adds a filename-to-password map as the single source of truth for encrypted fixtures.
- Covers the missing-password error and password-based path and bytes APIs, checking decrypted fixture text.
- `pytest tests/test_python.py` passes with 86 tests.

<sup>Written for commit befa71fe4f85f8f2f5d40ede7551d25d92033405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

