### PR TITLE
ci: run the Python binding tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,15 @@ jobs:
           assert result.pages[0].markdown.strip()
           PY
 
+      # The wheel installed above is the release build of the Python bindings,
+      # so the binding test suite runs here instead of paying for a second
+      # release build in its own job.
+      - name: Run Python binding tests
+        shell: bash
+        run: |
+          python -m pip install 'pytest>=8,<10'
+          python -m pytest tests/test_python.py -q
+
   wasm:
     name: WebAssembly
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary

`tests/test_python.py` was never executed in CI, so a failing Python binding test could sit unnoticed. The encrypted-fixture failure fixed in #489 had been failing locally without anything flagging it.

- The `OCR runtime smoke` job already builds and installs the release wheel of the Python bindings, so this adds a final step there that installs pytest and runs `tests/test_python.py`. No second release build, and one job to look at for Python binding health.

## Verification

- `actionlint` passes on the workflow, apart from the pre-existing notices about the custom runner labels.
- The same two commands pass locally against a freshly built wheel: 86 tests.
- The `OCR runtime smoke` job on this PR ran the new step: [86 passed in 44.29s](https://github.com/firecrawl/pdf-inspector/actions/runs/33679119382/job/100411112566), adding about a minute to the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
