### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "pdf-inspector",
+  "install": "./scripts/cloud-agent-install.sh",
+  "repositoryDependencies": ["github.com/firecrawl/pdf-evals"]
+}

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Cloud Agent install script for pdf-inspector.
+#
+# Idempotent, non-interactive setup that prepares the full local development
+# experience: the Rust release binaries (pdf2md, detect-pdf) plus the sibling
+# pdf-evals regression suite that drives them. Safe to run repeatedly and
+# against cached state.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> Installing system packages (python venv + qpdf)"
+# python3-venv: create the pdf-evals virtualenv. qpdf: used when trimming
+# fixture PDFs for the corpus (see pdf-evals CLAUDE.md). Both are cheap and
+# absent from the default image.
+if command -v sudo >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq python3.12-venv qpdf
+else
+  apt-get update -qq
+  apt-get install -y -qq python3.12-venv qpdf
+fi
+
+echo "==> Building release binaries with the pinned toolchain"
+# rust-toolchain.toml pins the channel (1.98.0); cargo auto-installs it on the
+# first invocation. This produces target/release/{pdf2md,detect-pdf}.
+cargo build --release
+
+# --- pdf-evals regression suite (sibling repository dependency) -------------
+EVALS_DIR="$(dirname "$REPO_ROOT")/pdf-evals"
+if [ -d "$EVALS_DIR" ]; then
+  echo "==> Setting up pdf-evals at $EVALS_DIR"
+  cd "$EVALS_DIR"
+
+  if [ ! -d .venv ]; then
+    python3 -m venv .venv
+  fi
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+  python -m pip install --quiet --upgrade pip
+
+  # Install only the core benchmark/scoring dependencies (everything above the
+  # "optional provider dependencies" marker in requirements.txt). The optional
+  # cloud-OCR providers (docling/torch, pymupdf4llm, markitdown, llama-cloud)
+  # are heavy and unnecessary for the local pdf-inspector dev + regression flow.
+  CORE_REQS="$(sed '/optional provider dependencies/q' requirements.txt \
+    | grep -vE '^[[:space:]]*#' | grep -vE '^[[:space:]]*$')"
+  # shellcheck disable=SC2086
+  pip install --quiet $CORE_REQS
+
+  # Point the local provider at the freshly built binary. config.yaml is
+  # git-ignored, so writing it here is safe and keeps future shells working
+  # without needing PDF_INSPECTOR_BINARY. detect-pdf is auto-resolved from the
+  # same directory as pdf2md.
+  cat > config.yaml <<EOF
+# Written by pdf-inspector/scripts/cloud-agent-install.sh
+providers:
+  local:
+    binary: $REPO_ROOT/target/release/pdf2md
+EOF
+  deactivate
+  echo "==> pdf-evals ready"
+else
+  echo "==> pdf-evals not found next to pdf-inspector; skipping eval setup"
+fi
+
+echo "==> Install complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cloud Agent environment for `pdf-inspector` (primary) with `pdf-evals` as a repository dependency, so a fresh Cloud Agent boots ready to build the binaries and run the regression/scoring suite end to end.

- `.cursor/environment.json` — default base image + `install` script, with `github.com/firecrawl/pdf-evals` declared under `repositoryDependencies`.
- `scripts/cloud-agent-install.sh` — idempotent, non-interactive setup:
  - installs the small missing system packages (`python3.12-venv`, `qpdf`);
  - builds the release binaries (`pdf2md`, `detect-pdf`) using the pinned `rust-toolchain.toml` channel (1.98.0), which cargo auto-installs;
  - creates the `pdf-evals` `.venv` and installs only the **core** benchmark/scoring deps (the section of `requirements.txt` above `# optional provider dependencies`), skipping the heavy cloud-OCR providers (docling/torch, pymupdf4llm, markitdown, llama-cloud) that the local dev flow does not need;
  - writes `pdf-evals/config.yaml` pointing the `local` provider at the freshly built `pdf2md` (git-ignored), so `bench.py` works without any extra env var.

No `start`/`terminals`: `pdf-inspector` is a CLI/library with no long-running service.

## Validation (on the VM, from a clean state)

| Check | Result |
| --- | --- |
| Pinned toolchain | `rustc 1.98.0` auto-installed from `rust-toolchain.toml` |
| `cargo fmt --check` | OK |
| `cargo clippy -- -D warnings` | OK (zero warnings) |
| `cargo test` | 1083 + 172 + 3 unit/integration + 2 doctests passed, 0 failed |
| Release binaries | `pdf2md` / `detect-pdf` build and extract a sample PDF |
| `bench.py doctor` | 194 PDFs, 0 errors |
| `bench.py test -q` | 20/20 PASS at 100% vs committed snapshots (binary resolved via generated `config.yaml`) |
| `bench.py score -q` | 20/20 scored, composite mean 0.58 (TEDS/MHS via `apted`+`lxml`) |
| Install idempotence | Clean run + two reruns all succeed |

## Note on build-test tooling

This setup was validated by running the exact install script from a clean state on the VM (fresh `.venv`/`config.yaml`, re-run for idempotence). The prebuilt-image build-and-verify path was not exercised because this agent run is anchored to the `pdf-evals` repo, so the build tooling cannot check out `pdf-inspector` as the primary repo to test its committed `.cursor/environment.json`. Once merged, the committed file is the highest-precedence source for Cloud Agents started on `pdf-inspector`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33bd8b37-ced6-4881-b829-881c60fa3c7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33bd8b37-ced6-4881-b829-881c60fa3c7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-managed Cloud Agent environment for `pdf-inspector` so a fresh agent boots ready to build the release binaries and run the `pdf-evals` regression suite.

- The install script is idempotent and non-interactive, installing only the core benchmark dependencies (skipping heavy OCR providers).
- It writes a git-ignored `config.yaml` in `pdf-evals` to point at the freshly built `pdf2md` binary.

<sup>Written for commit c8533944144aa0687f11ced4213f5f35078c3302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

