### PR TITLE
build: keep tinyvec below 1.13 until it compiles on the pinned toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ name = "pdf_inspector"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-# Transitive via unicode-normalization (lopdf → stringprep). 1.13.0 does not
-# compile on the pinned toolchain ("cannot find macro `vec`"); keep the
+# Reached through unicode-normalization — a direct dependency here and
+# lopdf → stringprep's. 1.13.0 does not compile on the pinned toolchain ("cannot find macro `vec`"); keep the
 # resolver below it until a fixed release or a toolchain bump.
 tinyvec = { version = "~1.12", default-features = false }
 # Python bindings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ name = "pdf_inspector"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
+# Transitive via unicode-normalization (lopdf → stringprep). 1.13.0 does not
+# compile on the pinned toolchain ("cannot find macro `vec`"); keep the
+# resolver below it until a fixed release or a toolchain bump.
+tinyvec = { version = "~1.12", default-features = false }
 # Python bindings
 pyo3 = { version = "0.25", features = ["extension-module", "abi3-py38"], optional = true }
 

--- a/napi/Cargo.lock
+++ b/napi/Cargo.lock
@@ -2060,6 +2060,7 @@ dependencies = [
  "regex",
  "sha2",
  "thiserror",
+ "tinyvec",
  "ttf-parser",
  "unicode-normalization",
  "ureq",
@@ -2933,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
## Summary

CI on `main` (the #486 merge run) and on every open PR fails in the dependency build: `tinyvec` 1.13.0, published today, does not compile on the pinned Rust 1.98.0 (`cannot find macro 'vec' in this scope`). It reaches us transitively through `unicode-normalization` (`lopdf` → `stringprep`), and because `Cargo.lock` is not tracked, CI resolves it fresh.

## Change

A direct `tinyvec = { version = "~1.12", default-features = false }` entry in `Cargo.toml`. A requirement inside the 1.x range unifies the resolver on 1.12.x for every path (a bare upper bound would have been satisfied by 0.4.1 while the transitive path kept 1.13.0); no features are added, and the crate's own use of it is unchanged. Remove the entry once a fixed tinyvec release or a toolchain bump lands.

## Verification

- Fresh worktree of `main`: `cargo update -p tinyvec --precise 1.13.0 && cargo check` reproduces the error; with the pin, the resolver picks 1.12.x and `cargo check` passes with and without `--features ocr`.
- No source change; the corpus output is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `tinyvec` below 1.13 so CI builds pass on the pinned Rust 1.98.0 toolchain. The 1.13.0 release fails to compile (`cannot find macro 'vec'`) and is resolved fresh on every CI run since `Cargo.lock` is not tracked, breaking all build, clippy, test, OCR, and WebAssembly jobs. A direct `tinyvec = { version = "~1.12", default-features = false }` entry in `Cargo.toml` unifies the resolver on 1.12.x; it reaches us through `unicode-normalization`, which is both a direct dependency and `lopdf` → `stringprep`'s. `napi/Cargo.lock` is updated to match so the Node build doesn't rewrite it locally. No source changes, so corpus output is unaffected; remove the pin once a fixed release or toolchain bump lands.

<sup>Written for commit 96994be31ab468b75fda19556654c75253be6580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

