### PR TITLE
fix(markdown): adaptive edge zone for sparse documents (#483)

### DIFF
--- a/src/markdown/furniture.rs
+++ b/src/markdown/furniture.rs
@@ -359,16 +359,25 @@ fn strip_repeated_lines(lines: Vec<TextLine>, page_count: u32) -> Vec<TextLine> 
             Some(ys) => ys,
             None => return false,
         };
-        if ys.len() <= n * 2 {
+        // Adaptive edge count for sparse pages: don't let first/last zones
+        // overlap and swallow the entire page (e.g. 9 lines with n=5 covers all).
+        let adaptive_n = if ys.len() <= 6 {
+            1
+        } else if ys.len() <= 12 {
+            2
+        } else {
+            n
+        };
+        if ys.len() <= adaptive_n * 2 {
             // Page has very few lines — everything is near the edge
             return true;
         }
-        // Check if this Y is among the first or last N
+        // Check if this Y is among the first or last adaptive N
         let pos = match ys.iter().position(|&py| (py - y).abs() < 0.1) {
             Some(p) => p,
             None => return false,
         };
-        pos < n || pos >= ys.len() - n
+        pos < adaptive_n || pos >= ys.len() - adaptive_n
     }
 
     // Average page span for normalizing Y variance


### PR DESCRIPTION
Fix of #483 

The repetition classifier (strip_repeated_lines) used a fixed first/last-N (Y=5) zone to detect page-edge furniture. On sparse two-column pages with very few distinct Y positions (e.g. the 6-page ab_threshold_20 benchmark), the fixed zone covered almost the entire page, causing near-duplicate body text (L01-L09 shared across pages 1, 2, 5) to be stripped as repeated headers/footers.

Fix: introduce an adaptive edge count based on page line density:
- <= 6 distinct Y positions -> edge zone = 1
- <= 12 distinct Y positions -> edge zone = 2
- otherwise keep the original N=5

Also guards the sparse-page overlap (ys.len() <= adaptive_n * 2) so pages with minimal content are not incorrectly swallowed.

Verified against desktop benchmark PDF (6 pages, near-duplicate L01-L09 body text): page 2 previously collapsed to a single remaining line; with adaptive_n the full page content is preserved in batch processing.