### PR TITLE
feat(vision): selectable pinned OCR model sets with a PP-OCRv5 Korean set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ version and date. Earlier releases are described in their
 
 ### Added
 
+- `OcrModelSet`: selects which pinned, checksum-verified model set the OCR
+  engine loads. `PpOcrV6Small` is the default and unchanged; the new
+  `PpOcrV5Korean` set pairs the script-agnostic PP-OCRv5 mobile detector with
+  the Korean PP-OCRv5 mobile recogniser and its dictionary (all 11,172 Hangul
+  syllables plus Latin letters and digits, ~18 MB in total). Exposed as
+  `OcrOptions::model_set(...)`, the `PP_OCR_V5_KOREAN` manifest, and
+  `pdf2md --ocr-model-set pp-ocrv5-korean`. Each set resolves, downloads, and
+  caches under its own manifest id and revision, and the in-process engine
+  cache is keyed by the selected set, so switching sets never mixes artifacts.
+
 - `TextItem::baseline_shift`: signed offset, in points, of a superscript or
   subscript glyph run from the baseline of the body text it is attached to
   (positive = raised, negative = lowered, `0` for normal text). Exposed as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@ version and date. Earlier releases are described in their
 
 ### Changed
 
+- `OcrOptions` gained the public `model_set` field. Construct it through
+  `OcrOptions::new()`/`Default` and the builder methods, as the docs show;
+  a struct literal that spells out every field needs the new field. This
+  follows the crate's existing practice for public structs (`TextItem`
+  gained `rotation`, `advance_known`, and `baseline_shift` in this cycle).
 - **Coordinate frame of positioned output — consumer action may be required.**
   `extract_text_with_positions*` (Rust), `extractTextWithPositions` (Node),
   `extract_text_with_positions[_bytes]` (Python) and `pdf2md --items-json` now

--- a/docs/ocr-runtime.md
+++ b/docs/ocr-runtime.md
@@ -17,6 +17,37 @@ The reproducible runtime path uses these builds:
 Use these versions for the reproducible path. Other compatible shared-library
 builds may work, but are not part of the release smoke test.
 
+## Model sets
+
+The recogniser and its character dictionary decide which scripts OCR can
+read; detection is script-agnostic. `OcrModelSet` selects one pinned,
+checksum-verified set. The default is unchanged.
+
+| `OcrModelSet` | Identifier | Files (revision) | Scripts | Download size |
+|---|---|---|---|---|
+| `PpOcrV6Small` (default) | `pp-ocrv6-small` | `pp-ocrv6_small_det.onnx`, `pp-ocrv6_small_rec.onnx`, `ppocrv6_dict.txt` (`oar-ocr-v0.7.0`) | Latin scripts, Simplified and Traditional Chinese, Japanese | about 31 MB |
+| `PpOcrV5Korean` | `pp-ocrv5-korean` | `pp-ocrv5_mobile_det.onnx`, `korean_pp-ocrv5_mobile_rec.onnx`, `ppocrv5_korean_dict.txt` (`oar-ocr-v0.3.0`) | Korean (all 11,172 Hangul syllables), Latin letters, digits | about 18 MB |
+
+```bash
+pdf2md scan-ko.pdf --ocr auto --ocr-model-set pp-ocrv5-korean --json
+```
+
+```rust
+use pdf_inspector::vision::{OcrMode, OcrModelSet, OcrOptions, OcrPdfOptions};
+
+let ocr = OcrOptions::new()
+    .mode(OcrMode::Auto)
+    .model_set(OcrModelSet::PpOcrV5Korean);
+let options = OcrPdfOptions::new().ocr(ocr);
+```
+
+Each set is cached under its own `<id>/<revision>` directory, and the
+in-process engine cache is keyed by the selected set, so switching sets in a
+long-lived worker replaces the loaded sessions instead of mixing artifacts.
+For offline packaging, populate the model directory with the three files of
+the chosen set (`--ocr-offline --ocr-model-dir`); the directory is verified
+against that set's manifest.
+
 ## Install the shared libraries
 
 Download and extract the matching archives:

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -125,7 +125,9 @@ separate `model-cache` feature adds pinned artifact management:
 
 - `PageRenderer` and `OcrEngine` traits;
 - renderer-neutral owned page buffers and affine pixel↔PDF transforms;
-- `OcrOptions` and opt-in `Off`/`Auto`/`Force` routing modes;
+- `OcrOptions` and opt-in `Off`/`Auto`/`Force` routing modes, plus
+  `OcrModelSet` to choose the pinned model set (default PP-OCRv6 Small, or
+  PP-OCRv5 Korean);
 - positioned OCR results and per-page provenance types; and
 - a versioned PP-OCRv6 Small manifest with checksum-verified, locked, atomic
   model-cache installation and explicit offline-directory overrides.
@@ -431,8 +433,12 @@ pdf2md document.pdf --ocr auto --ocr-offline --ocr-model-dir /opt/models/pp-ocrv
 ```
 
 CLI controls include `--ocr-dpi`, `--ocr-min-confidence`,
-`--ocr-hosted-threshold`, `--select-pages`, and the existing encrypted-PDF
-`--password` option. JSON output has `schema_version: 1` and includes per-page Markdown, source/model
+`--ocr-hosted-threshold`, `--ocr-model-set`, `--select-pages`, and the
+existing encrypted-PDF `--password` option. `--ocr-model-set` (Rust:
+`OcrOptions::model_set`, see `OcrModelSet`) picks the pinned model set;
+`pp-ocrv6-small` is the default and `pp-ocrv5-korean` adds Korean. The
+[OCR runtime setup guide](https://github.com/firecrawl/pdf-inspector/blob/main/docs/ocr-runtime.md#model-sets)
+lists the files and scripts of every set. JSON output has `schema_version: 1` and includes per-page Markdown, source/model
 provenance, confidence, timings, warnings, routed pages, and hosted-fallback
 recommendations. Page numbers in `OcrPdfResult` and its per-page provenance
 are 1-indexed, matching the PDF page numbers accepted by

--- a/src/bin/pdf2md.rs
+++ b/src/bin/pdf2md.rs
@@ -3,8 +3,8 @@
 use pdf_inspector::extractor::ItemType;
 #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
 use pdf_inspector::vision::{
-    process_pdf_with_ocr, ModelDownloadPolicy, OcrMode, OcrOptions, OcrPdfOptions, OcrPdfResult,
-    PageContentSource, RenderOptions,
+    process_pdf_with_ocr, ModelDownloadPolicy, OcrMode, OcrModelSet, OcrOptions, OcrPdfOptions,
+    OcrPdfResult, PageContentSource, RenderOptions,
 };
 use pdf_inspector::{
     extract_text_with_positions_pages_with_password, process_pdf_with_options, LayoutComplexity,
@@ -426,6 +426,9 @@ fn main() {
         eprintln!("  --ocr-min-confidence N  Drop OCR spans below N (default: 0)");
         eprintln!("  --ocr-hosted-threshold N  Recommend hosted parsing below N (default: 0.5)");
         eprintln!("  --ocr-model-dir DIR Use a package-managed local model directory");
+        eprintln!(
+            "  --ocr-model-set ID  Pinned model set: pp-ocrv6-small (default) or pp-ocrv5-korean"
+        );
         eprintln!("  --ocr-offline       Never download missing OCR models");
         process::exit(1);
     }
@@ -482,6 +485,7 @@ fn main() {
         "--ocr-min-confidence",
         "--ocr-hosted-threshold",
         "--ocr-model-dir",
+        "--ocr-model-set",
         "--ocr-offline",
     ]
     .iter()
@@ -539,11 +543,32 @@ fn main() {
                     exit_ocr_error(&error, json_output);
                 });
 
+            let model_set = argument_value(&args, "--ocr-model-set")
+                .unwrap_or_else(|error| {
+                    exit_ocr_error(&error, json_output);
+                })
+                .map(|value| {
+                    OcrModelSet::parse(value).unwrap_or_else(|| {
+                        let expected: Vec<&str> =
+                            OcrModelSet::ALL.iter().map(|set| set.id()).collect();
+                        exit_ocr_error(
+                            &format!(
+                                "invalid --ocr-model-set {value:?}; expected one of: {}",
+                                expected.join(", ")
+                            ),
+                            json_output,
+                        );
+                    })
+                });
+
             let mut ocr = OcrOptions::new()
                 .mode(mode)
                 .minimum_confidence(minimum_confidence);
             if let Some(directory) = model_directory {
                 ocr = ocr.model_directory(directory);
+            }
+            if let Some(model_set) = model_set {
+                ocr = ocr.model_set(model_set);
             }
             if args.iter().any(|argument| argument == "--ocr-offline") {
                 ocr = ocr.model_downloads(ModelDownloadPolicy::Offline);

--- a/src/vision/contracts.rs
+++ b/src/vision/contracts.rs
@@ -29,6 +29,57 @@ pub enum ModelDownloadPolicy {
     Offline,
 }
 
+/// Selects the pinned model set an OCR engine loads.
+///
+/// Every variant maps to exactly one checksum-verified model manifest, so
+/// downloads, offline directories, and the in-process engine cache stay
+/// deterministic per set. Detection models are script-agnostic; the variants
+/// differ in the recognition model and its character dictionary.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OcrModelSet {
+    /// PP-OCRv6 Small: Latin scripts, Simplified and Traditional Chinese, and
+    /// Japanese. This is the default and preserves existing behavior.
+    #[default]
+    PpOcrV6Small,
+    /// PP-OCRv5 Korean: all 11,172 Hangul syllables plus Latin letters and
+    /// digits, paired with the PP-OCRv5 mobile detector.
+    PpOcrV5Korean,
+}
+
+impl OcrModelSet {
+    /// Every supported model set, in identifier order.
+    pub const ALL: &'static [OcrModelSet] =
+        &[OcrModelSet::PpOcrV6Small, OcrModelSet::PpOcrV5Korean];
+
+    /// Stable identifier, equal to the `id` of the manifest the set resolves to.
+    pub fn id(self) -> &'static str {
+        match self {
+            OcrModelSet::PpOcrV6Small => "pp-ocrv6-small",
+            OcrModelSet::PpOcrV5Korean => "pp-ocrv5-korean",
+        }
+    }
+
+    /// Parses an identifier as printed by [`OcrModelSet::id`].
+    ///
+    /// Matching ignores case and surrounding whitespace and accepts `_` in
+    /// place of `-`, so `PP_OCRv5_Korean` resolves to
+    /// [`OcrModelSet::PpOcrV5Korean`].
+    pub fn parse(value: &str) -> Option<Self> {
+        let normalized = value.trim().to_ascii_lowercase().replace('_', "-");
+        OcrModelSet::ALL
+            .iter()
+            .copied()
+            .find(|set| set.id() == normalized)
+    }
+}
+
+impl std::fmt::Display for OcrModelSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.id())
+    }
+}
+
 /// OCR engine configuration independent of a particular runtime.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OcrOptions {
@@ -40,6 +91,8 @@ pub struct OcrOptions {
     pub model_directory: Option<PathBuf>,
     /// Whether a missing pinned artifact may be downloaded.
     pub model_downloads: ModelDownloadPolicy,
+    /// Which pinned model set the engine loads.
+    pub model_set: OcrModelSet,
 }
 
 impl Default for OcrOptions {
@@ -49,6 +102,7 @@ impl Default for OcrOptions {
             minimum_confidence: 0.0,
             model_directory: None,
             model_downloads: ModelDownloadPolicy::IfMissing,
+            model_set: OcrModelSet::PpOcrV6Small,
         }
     }
 }
@@ -80,6 +134,12 @@ impl OcrOptions {
     /// Sets the missing-model download policy.
     pub fn model_downloads(mut self, policy: ModelDownloadPolicy) -> Self {
         self.model_downloads = policy;
+        self
+    }
+
+    /// Selects the pinned model set the OCR engine loads.
+    pub fn model_set(mut self, model_set: OcrModelSet) -> Self {
+        self.model_set = model_set;
         self
     }
 }
@@ -268,5 +328,31 @@ mod tests {
             options.model_directory,
             Some(PathBuf::from("/models/pp-ocr"))
         );
+    }
+
+    #[test]
+    fn model_set_defaults_to_pp_ocr_v6_small() {
+        assert_eq!(OcrOptions::default().model_set, OcrModelSet::PpOcrV6Small);
+        assert_eq!(OcrModelSet::default(), OcrModelSet::PpOcrV6Small);
+        let options = OcrOptions::new().model_set(OcrModelSet::PpOcrV5Korean);
+        assert_eq!(options.model_set, OcrModelSet::PpOcrV5Korean);
+    }
+
+    #[test]
+    fn model_set_identifiers_round_trip() {
+        for set in OcrModelSet::ALL {
+            assert_eq!(OcrModelSet::parse(set.id()), Some(*set));
+            assert_eq!(set.to_string(), set.id());
+        }
+        assert_eq!(
+            OcrModelSet::parse(" PP_OCRv5_Korean "),
+            Some(OcrModelSet::PpOcrV5Korean)
+        );
+        assert_eq!(
+            OcrModelSet::parse("pp-ocrv6-small"),
+            Some(OcrModelSet::PpOcrV6Small)
+        );
+        assert_eq!(OcrModelSet::parse("korean"), None);
+        assert_eq!(OcrModelSet::parse(""), None);
     }
 }

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -32,8 +32,8 @@ mod pdfium;
 
 #[cfg(all(feature = "vision", not(target_arch = "wasm32")))]
 pub use contracts::{
-    ImagePoint, ImageQuad, ModelDownloadPolicy, ModelIdentity, OcrEngine, OcrMode, OcrOptions,
-    OcrPage, OcrSpan, PageContentSource, PageProvenance, PageRenderer, VisionTimings,
+    ImagePoint, ImageQuad, ModelDownloadPolicy, ModelIdentity, OcrEngine, OcrMode, OcrModelSet,
+    OcrOptions, OcrPage, OcrSpan, PageContentSource, PageProvenance, PageRenderer, VisionTimings,
 };
 #[cfg(all(feature = "model-download", not(target_arch = "wasm32")))]
 pub use download::{HttpModelDownloadError, HttpModelDownloader, DEFAULT_MODEL_DOWNLOAD_TIMEOUT};
@@ -45,7 +45,7 @@ pub use fusion::{
 #[cfg(all(feature = "model-cache", not(target_arch = "wasm32")))]
 pub use models::{
     ModelAcquireError, ModelArtifact, ModelArtifactKind, ModelDownloader, ModelManifest,
-    ModelPaths, ModelStore, ModelStoreError, PP_OCR_V6_SMALL,
+    ModelPaths, ModelStore, ModelStoreError, PP_OCR_V5_KOREAN, PP_OCR_V6_SMALL,
 };
 #[cfg(all(feature = "ocr-oar", not(target_arch = "wasm32")))]
 pub use oar::{OarOcrEngine, OarOcrError, ONNX_RUNTIME_LIBRARY_ENV};

--- a/src/vision/models.rs
+++ b/src/vision/models.rs
@@ -12,7 +12,7 @@ use fs2::FileExt;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use super::{ModelDownloadPolicy, OcrOptions};
+use super::{ModelDownloadPolicy, OcrModelSet, OcrOptions};
 
 /// Environment variable overriding the default local model cache.
 pub const MODEL_CACHE_ENV: &str = "PDF_INSPECTOR_MODEL_CACHE";
@@ -93,6 +93,54 @@ pub const PP_OCR_V6_SMALL: ModelManifest = ModelManifest {
     revision: "oar-ocr-v0.7.0",
     artifacts: PP_OCR_V6_SMALL_ARTIFACTS,
 };
+
+const PP_OCR_V5_KOREAN_ARTIFACTS: &[ModelArtifact] = &[
+    ModelArtifact {
+        kind: ModelArtifactKind::TextDetection,
+        filename: "pp-ocrv5_mobile_det.onnx",
+        url: "https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_mobile_det.onnx",
+        sha256: "1eb7b4f7ab657ebd1c66d5f79bca7497f29768a2e3c15e52daecbba1a8e4a039",
+        size: 4_826_518,
+    },
+    ModelArtifact {
+        kind: ModelArtifactKind::TextRecognition,
+        filename: "korean_pp-ocrv5_mobile_rec.onnx",
+        url: "https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/korean_pp-ocrv5_mobile_rec.onnx",
+        sha256: "2d7ed96308065a86103325d22af07a88c4d06afc009f21602a4882342c0cc054",
+        size: 13_446_374,
+    },
+    ModelArtifact {
+        kind: ModelArtifactKind::CharacterDictionary,
+        filename: "ppocrv5_korean_dict.txt",
+        url: "https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocrv5_korean_dict.txt",
+        sha256: "a88071c68c01707489baa79ebe0405b7beb5cca229f4fc94cc3ef992328802d7",
+        size: 47_451,
+    },
+];
+
+/// Pinned PP-OCRv5 Korean model set.
+///
+/// Pairs the script-agnostic PP-OCRv5 mobile detector with the Korean
+/// PP-OCRv5 mobile recogniser and its dictionary (all 11,172 Hangul
+/// syllables plus Latin letters and digits). The artifacts are the files
+/// published with the `oar-ocr` v0.3.0 release; the revision identifies that
+/// release.
+pub const PP_OCR_V5_KOREAN: ModelManifest = ModelManifest {
+    schema_version: 1,
+    id: "pp-ocrv5-korean",
+    revision: "oar-ocr-v0.3.0",
+    artifacts: PP_OCR_V5_KOREAN_ARTIFACTS,
+};
+
+impl OcrModelSet {
+    /// The pinned manifest this model set resolves to.
+    pub fn manifest(self) -> &'static ModelManifest {
+        match self {
+            OcrModelSet::PpOcrV6Small => &PP_OCR_V6_SMALL,
+            OcrModelSet::PpOcrV5Korean => &PP_OCR_V5_KOREAN,
+        }
+    }
+}
 
 /// Resolved, verified filesystem paths for one model manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -754,6 +802,50 @@ mod tests {
     fn pinned_pp_ocr_manifest_is_well_formed() {
         validate_manifest(&PP_OCR_V6_SMALL).unwrap();
         assert_eq!(PP_OCR_V6_SMALL.artifacts.len(), 3);
+    }
+
+    #[test]
+    fn pinned_korean_manifest_is_well_formed() {
+        validate_manifest(&PP_OCR_V5_KOREAN).unwrap();
+        assert_eq!(PP_OCR_V5_KOREAN.id, "pp-ocrv5-korean");
+        assert_ne!(PP_OCR_V5_KOREAN.id, PP_OCR_V6_SMALL.id);
+        let kinds: Vec<_> = PP_OCR_V5_KOREAN
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.kind)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                ModelArtifactKind::TextDetection,
+                ModelArtifactKind::TextRecognition,
+                ModelArtifactKind::CharacterDictionary,
+            ]
+        );
+    }
+
+    #[test]
+    fn model_sets_resolve_to_manifests_with_matching_ids() {
+        for set in OcrModelSet::ALL {
+            let manifest = set.manifest();
+            validate_manifest(manifest).unwrap();
+            assert_eq!(manifest.id, set.id());
+        }
+        assert_eq!(OcrModelSet::default().manifest().id, PP_OCR_V6_SMALL.id);
+        assert_eq!(
+            OcrModelSet::PpOcrV5Korean.manifest().id,
+            PP_OCR_V5_KOREAN.id
+        );
+    }
+
+    #[test]
+    fn model_sets_use_distinct_cache_roots() {
+        let cache = tempfile::tempdir().unwrap();
+        let store = ModelStore::new(cache.path());
+        let default_root = store.model_root(OcrModelSet::PpOcrV6Small.manifest());
+        let korean_root = store.model_root(OcrModelSet::PpOcrV5Korean.manifest());
+        assert_ne!(default_root, korean_root);
+        assert!(korean_root.starts_with(cache.path()));
     }
 
     #[test]

--- a/src/vision/pipeline.rs
+++ b/src/vision/pipeline.rs
@@ -26,7 +26,7 @@ use super::{
     route_ocr_pages, run_ocr_pages, FusedPageMarkdown, FusedPages, HttpModelDownloadError,
     HttpModelDownloader, ModelAcquireError, ModelStore, ModelStoreError, OarOcrEngine, OarOcrError,
     OcrEngine, OcrFusionError, OcrFusionOptions, OcrMode, OcrOptions, OcrRoutingError, OcrRun,
-    OcrRunError, PageRenderer, PdfiumRenderer, RenderError, RenderOptions, PP_OCR_V6_SMALL,
+    OcrRunError, PageRenderer, PdfiumRenderer, RenderError, RenderOptions,
 };
 
 /// Bounds live rendered-page memory while preserving small OCR batches.
@@ -648,13 +648,14 @@ fn clone_native_page(page: &PageMarkdown) -> PageMarkdown {
 
 fn cached_ocr_engine(options: &OcrOptions) -> Result<Arc<OarOcrEngine>, OcrPipelineError> {
     let store = ModelStore::from_options(options)?;
+    let manifest = options.model_set.manifest();
     let key = OcrEngineCacheKey {
-        model_root: normalized_cache_path(store.model_root(&PP_OCR_V6_SMALL)),
+        model_root: normalized_cache_path(store.model_root(manifest)),
         runtime_library: normalized_cache_path(onnx_runtime_library_path()),
-        manifest_schema: PP_OCR_V6_SMALL.schema_version,
-        manifest_id: PP_OCR_V6_SMALL.id,
-        manifest_revision: PP_OCR_V6_SMALL.revision,
-        artifact_digests: PP_OCR_V6_SMALL
+        manifest_schema: manifest.schema_version,
+        manifest_id: manifest.id,
+        manifest_revision: manifest.revision,
+        artifact_digests: manifest
             .artifacts
             .iter()
             .map(|artifact| artifact.sha256)
@@ -674,7 +675,7 @@ fn cached_ocr_engine(options: &OcrOptions) -> Result<Arc<OarOcrEngine>, OcrPipel
     // OCR requests can continue using a warm engine. Concurrent cold misses may
     // build redundantly; the second cache check keeps only one shared session.
     let models = store.resolve_or_download(
-        &PP_OCR_V6_SMALL,
+        manifest,
         options.model_downloads,
         &HttpModelDownloader::default(),
     )?;


### PR DESCRIPTION
## Summary

Adds `OcrModelSet` so the selective-OCR path can load a different pinned, checksum-verified model set without changing anything else in the pipeline. The default set (`PpOcrV6Small`) and all existing behavior are unchanged; the new `PpOcrV5Korean` set makes Hangul readable.

Motivation: the PP-OCRv6 Small dictionary contains no Hangul at all (18,709 entries, 0 in U+AC00–U+D7A3), so every Korean scanned page currently comes back empty even though the routing, rendering, fusion and Markdown assembly all work. The PP-OCRv5 Korean recogniser published with `oar-ocr` (already the crate's OCR backend) covers all 11,172 Hangul syllables plus Latin letters and digits, and pairs with the script-agnostic PP-OCRv5 mobile detector. Together the set is ~18 MB, smaller than the default.

## What changed

- `vision::OcrModelSet` (`PpOcrV6Small` default, `PpOcrV5Korean`) with stable identifiers, a lenient `parse`, and `Display`. `#[non_exhaustive]` so more sets can follow.
- `OcrOptions::model_set(...)` / `OcrOptions.model_set`. `Default` still selects PP-OCRv6 Small.
- `vision::PP_OCR_V5_KOREAN` manifest pinned to the `oar-ocr` v0.3.0 release files (SHA-256 and exact sizes), and `OcrModelSet::manifest()`.
- `cached_ocr_engine` now resolves, downloads, and caches by the selected manifest. The engine cache key already carried manifest id/revision/digests, so switching sets replaces the loaded sessions instead of mixing artifacts; each set also lives under its own `<id>/<revision>` cache directory.
- CLI: `pdf2md --ocr-model-set pp-ocrv5-korean` (listed with the other OCR-only options; invalid values print the accepted identifiers).
- Docs: `docs/ocr-runtime.md` "Model sets" table and examples, `docs/rust-api.md`, CHANGELOG.

Python and Node bindings are untouched in this PR (they keep the default set); happy to add a `model_set` option to both in a follow-up if you want parity in the same release.

## Verification

- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo clippy --features ocr -- -D warnings`, `cargo test`, `cargo test --features ocr --lib vision::` on the pinned 1.98.0 toolchain.
- New unit tests: Korean manifest validates and has the three expected artifact kinds; every `OcrModelSet` resolves to a manifest whose `id` matches; sets use distinct cache roots; identifier parsing round-trips and rejects unknown values; `OcrOptions` default is unchanged.
- End-to-end (Linux x64, PDFium `native-v7988`, ONNX Runtime 1.27.0, CPU): a Korean government PDF rasterised to a 150 dpi image-only PDF (3 pages, classified `scanned`) processed with `--ocr auto --ocr-model-set pp-ocrv5-korean --ocr-offline --ocr-model-dir …`. Results are in the comment below.

## Notes for reviewers

- Artifact digests were computed from the files downloaded from the `oar-ocr` v0.3.0 GitHub release (`pp-ocrv5_mobile_det.onnx` 4,826,518 B, `korean_pp-ocrv5_mobile_rec.onnx` 13,446,374 B, `ppocrv5_korean_dict.txt` 47,451 B).
- No new dependencies. No change to the default feature set or to the text-only path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `OcrModelSet` so the selective-OCR path can load a different pinned, checksum-verified model set. The default `PpOcrV6Small` set is unchanged, and the new `PpOcrV5Korean` set makes Hangul readable — Korean scanned pages previously came back empty because the default dictionary has no Hangul.

- `PpOcrV5Korean` pairs the script-agnostic PP-OCRv5 mobile detector with the Korean recogniser and dictionary (~18 MB total).
- `OcrOptions::model_set(...)` and `pdf2md --ocr-model-set pp-ocrv5-korean` select the set; the engine cache is keyed by the selected set, so switching sets never mixes artifacts.
- `OcrOptions` gained a public `model_set` field, so struct literals that spell out every field need the new field.
- Python and Node bindings are untouched and keep the default set.

<sup>Written for commit 76cdc11230394cdbd04eb1a8c1774e7310730775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

