### PR TITLE
fix(extraction): recover an invisible OCR layer on TextBased documents

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -136,9 +136,8 @@ pub(crate) fn extract_text_with_positions_and_rects_with_password<P: AsRef<Path>
     crate::validate_pdf_file(&path)?;
     let (doc, _) = crate::load_document_from_path_with_password(&path, password)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
-    let (extraction, _thresholds, _gid_pages, _page_rotations) =
-        extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, page_filter)?;
-    Ok(extraction)
+    let extracted = extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, page_filter)?;
+    Ok(extracted.extraction)
 }
 
 /// Extract text with positions from a memory buffer. Coordinates: see
@@ -172,9 +171,9 @@ pub fn extract_text_with_positions_and_rotations_mem(
     crate::validate_pdf_bytes(buffer)?;
     let (doc, _) = crate::load_document_from_mem(buffer)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
-    let ((items, _rects, _lines), _thresholds, _gid_pages, page_rotations) =
-        extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, None)?;
-    Ok((items, page_rotations))
+    let extracted = extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, None)?;
+    let (items, _rects, _lines) = extracted.extraction;
+    Ok((items, extracted.page_rotations))
 }
 
 /// Extract text with positions and rectangles from memory buffer.
@@ -185,9 +184,8 @@ pub(crate) fn extract_text_with_positions_mem_and_rects(
     crate::validate_pdf_bytes(buffer)?;
     let (doc, _) = crate::load_document_from_mem(buffer)?;
     let font_cmaps = FontCMaps::from_doc(&doc);
-    let (extraction, _thresholds, _gid_pages, _page_rotations) =
-        extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, page_filter)?;
-    Ok(extraction)
+    let extracted = extract_positioned_text_from_doc_in_page_box(&doc, &font_cmaps, page_filter)?;
+    Ok(extracted.extraction)
 }
 
 /// One page's geometry in the visible-page-box frame, from
@@ -258,6 +256,22 @@ pub(crate) type PageThresholds = HashMap<u32, f32>;
 /// are upright.
 pub(crate) type PageRotations = HashMap<u32, geometry::PageRotation>;
 
+/// What a document-level positioned-text extraction reports — the same shape
+/// [`PageBoxExtraction`] gives one page, so `skipped_invisible` survives the
+/// document walk instead of being dropped per page.
+pub(crate) struct PositionedExtraction {
+    pub(crate) extraction: PageExtraction,
+    pub(crate) thresholds: PageThresholds,
+    pub(crate) gid_encoded_pages: HashSet<u32>,
+    pub(crate) page_rotations: PageRotations,
+    /// Some extracted page carried invisible (Tr 3) text that this pass
+    /// suppressed, so an `include_invisible` retry has something to recover.
+    /// False when the pass already included invisible text — nothing was
+    /// skipped — and false for a blank or image-only page, which is what
+    /// makes it a usable gate on that retry.
+    pub(crate) skipped_invisible: bool,
+}
+
 /// Extract positioned text, rectangles, and line segments from a pre-loaded document.
 ///
 /// Also returns per-page adaptive join thresholds for Canva-style pages.
@@ -265,7 +279,7 @@ pub(crate) fn extract_positioned_text_from_doc(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     extract_positioned_text_impl(
         doc,
         font_cmaps,
@@ -285,7 +299,7 @@ pub(crate) fn extract_positioned_text_from_doc_in_page_box(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     extract_positioned_text_impl(
         doc,
         font_cmaps,
@@ -315,7 +329,7 @@ pub(crate) fn extract_positioned_text_with_folio_context(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     extract_positioned_text_with_folio_context_impl(doc, font_cmaps, page_filter, false)
 }
 
@@ -324,7 +338,7 @@ pub(crate) fn extract_positioned_text_include_invisible_with_folio_context(
     doc: &Document,
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     extract_positioned_text_with_folio_context_impl(doc, font_cmaps, page_filter, true)
 }
 
@@ -333,7 +347,7 @@ fn extract_positioned_text_with_folio_context_impl(
     font_cmaps: &FontCMaps,
     page_filter: Option<&HashSet<u32>>,
     include_invisible: bool,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     let Some(required_pages) = page_filter else {
         return extract_positioned_text_impl(
             doc,
@@ -345,12 +359,17 @@ fn extract_positioned_text_with_folio_context_impl(
         );
     };
 
-    let (
-        (mut selected_items, mut selected_rects, mut selected_lines),
-        mut page_thresholds,
+    let PositionedExtraction {
+        extraction: (mut selected_items, mut selected_rects, mut selected_lines),
+        thresholds: mut page_thresholds,
         mut gid_encoded_pages,
         mut page_rotations,
-    ) = extract_positioned_text_impl(
+        // Only the SELECTED pages' verdict travels on: context pages are
+        // folio evidence, not extraction targets, so an invisible layer on
+        // one of them says nothing about the pages the caller asked for.
+        // Same scoping as the caller's own visible-text test.
+        skipped_invisible,
+    } = extract_positioned_text_impl(
         doc,
         font_cmaps,
         Some(required_pages),
@@ -359,12 +378,13 @@ fn extract_positioned_text_with_folio_context_impl(
         CoordinateFrame::UserSpace,
     )?;
     if !layout::needs_document_page_number_context(&selected_items, doc.get_pages().len()) {
-        return Ok((
-            (selected_items, selected_rects, selected_lines),
-            page_thresholds,
+        return Ok(PositionedExtraction {
+            extraction: (selected_items, selected_rects, selected_lines),
+            thresholds: page_thresholds,
             gid_encoded_pages,
             page_rotations,
-        ));
+            skipped_invisible,
+        });
     }
 
     let context_pages: HashSet<u32> = doc
@@ -373,12 +393,13 @@ fn extract_positioned_text_with_folio_context_impl(
         .copied()
         .filter(|page| !required_pages.contains(page))
         .collect();
-    let (
-        (context_items, context_rects, context_lines),
-        context_thresholds,
-        context_gid_pages,
-        context_rotations,
-    ) = extract_positioned_text_impl(
+    let PositionedExtraction {
+        extraction: (context_items, context_rects, context_lines),
+        thresholds: context_thresholds,
+        gid_encoded_pages: context_gid_pages,
+        page_rotations: context_rotations,
+        skipped_invisible: _context_skipped_invisible,
+    } = extract_positioned_text_impl(
         doc,
         font_cmaps,
         Some(&context_pages),
@@ -392,12 +413,13 @@ fn extract_positioned_text_with_folio_context_impl(
     page_thresholds.extend(context_thresholds);
     gid_encoded_pages.extend(context_gid_pages);
     page_rotations.extend(context_rotations);
-    Ok((
-        (selected_items, selected_rects, selected_lines),
-        page_thresholds,
+    Ok(PositionedExtraction {
+        extraction: (selected_items, selected_rects, selected_lines),
+        thresholds: page_thresholds,
         gid_encoded_pages,
         page_rotations,
-    ))
+        skipped_invisible,
+    })
 }
 
 /// Extract all pages for document-wide analysis while allowing malformed
@@ -406,7 +428,7 @@ pub(crate) fn extract_positioned_text_for_document_analysis(
     doc: &Document,
     font_cmaps: &FontCMaps,
     required_pages: &HashSet<u32>,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     extract_positioned_text_impl(
         doc,
         font_cmaps,
@@ -424,7 +446,7 @@ fn extract_positioned_text_impl(
     include_invisible: bool,
     required_pages: Option<&HashSet<u32>>,
     frame: CoordinateFrame,
-) -> Result<(PageExtraction, PageThresholds, HashSet<u32>, PageRotations), PdfError> {
+) -> Result<PositionedExtraction, PdfError> {
     let pages = doc.get_pages();
     let mut all_items = Vec::new();
     let mut all_rects = Vec::new();
@@ -439,6 +461,10 @@ fn extract_positioned_text_impl(
     let mut page_rotations: PageRotations = HashMap::new();
     // Visible page box per extracted page, for the form-field shift below.
     let mut page_boxes: HashMap<u32, PageBox> = HashMap::new();
+    // Did ANY extracted page suppress invisible (Tr 3) text? The retry that
+    // consumes this re-extracts the whole selection, so one page with a
+    // recoverable layer is enough to make it worth paying for.
+    let mut skipped_invisible_anywhere = false;
 
     // Build page ObjectId → page number map for form field extraction
     let page_id_to_num: HashMap<ObjectId, u32> =
@@ -459,7 +485,7 @@ fn extract_positioned_text_impl(
             &mut style_cache,
             &mut FormWalkBudget::new(),
         );
-        let ((mut items, mut rects, mut lines), has_gid_fonts, coords_rotated, _skipped_invisible) =
+        let ((mut items, mut rects, mut lines), has_gid_fonts, coords_rotated, skipped_invisible) =
             match page_result {
                 Ok(extraction) => extraction,
                 Err(error)
@@ -473,6 +499,7 @@ fn extract_positioned_text_impl(
                 }
                 Err(error) => return Err(error),
             };
+        skipped_invisible_anywhere |= skipped_invisible;
         if coords_rotated != geometry::PageRotation::Upright {
             page_rotations.insert(*page_num, coords_rotated);
         }
@@ -648,12 +675,13 @@ fn extract_positioned_text_impl(
         .collect();
     all_items.extend(form_items);
 
-    Ok((
-        (all_items, all_rects, all_lines),
-        page_thresholds,
+    Ok(PositionedExtraction {
+        extraction: (all_items, all_rects, all_lines),
+        thresholds: page_thresholds,
         gid_encoded_pages,
         page_rotations,
-    ))
+        skipped_invisible: skipped_invisible_anywhere,
+    })
 }
 
 fn suppress_table_underlines(
@@ -3590,9 +3618,12 @@ BT /F1 12 Tf 0 1 -1 0 240 100 Tm (WORLD) Tj ET"
         doc.trailer.set("Root", Object::Reference(catalog_id));
 
         let font_cmaps = FontCMaps::from_doc(&doc);
-        let ((items, _, _), _, _, page_rotations) =
-            extract_positioned_text_from_doc(&doc, &font_cmaps, None).unwrap();
-        assert_eq!(page_rotations.get(&1), Some(&geometry::PageRotation::Ccw));
+        let extracted = extract_positioned_text_from_doc(&doc, &font_cmaps, None).unwrap();
+        let (items, _, _) = extracted.extraction;
+        assert_eq!(
+            extracted.page_rotations.get(&1),
+            Some(&geometry::PageRotation::Ccw)
+        );
         let field = items
             .iter()
             .find(|i| matches!(i.item_type, ItemType::FormField))
@@ -3613,6 +3644,117 @@ BT /F1 12 Tf 0 1 -1 0 240 100 Tm (WORLD) Tj ET"
             (100.0, -200.0, 40.0, 12.0)
         );
         assert_eq!(link.rotation, 0.0);
+    }
+
+    /// A document of `pages` single-stream pages, each with the same Type1
+    /// font as `/F1`.
+    fn doc_with_page_contents(pages: &[&[u8]]) -> lopdf::Document {
+        use lopdf::{dictionary, Object, Stream};
+
+        let mut doc = lopdf::Document::new();
+        let widths: Vec<Object> = (0..=255).map(|_| 600.into()).collect();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "FirstChar" => 0,
+            "LastChar" => 255,
+            "Widths" => Object::Array(widths),
+        });
+        let page_ids: Vec<Object> = pages
+            .iter()
+            .map(|content| {
+                let content_id = doc.add_object(Object::Stream(Stream::new(
+                    dictionary! {},
+                    content.to_vec(),
+                )));
+                Object::Reference(doc.add_object(dictionary! {
+                    "Type" => "Page",
+                    "Contents" => Object::Reference(content_id),
+                    "Resources" => dictionary! {
+                        "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+                    },
+                    "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                }))
+            })
+            .collect();
+        let pages_id = doc.add_object(dictionary! {
+            "Type" => "Pages",
+            "Count" => Object::Integer(page_ids.len() as i64),
+            "Kids" => Object::Array(page_ids),
+        });
+        for (_, page_id) in doc.get_pages() {
+            let page = doc.get_object_mut(page_id).unwrap().as_dict_mut().unwrap();
+            page.set("Parent", Object::Reference(pages_id));
+        }
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => Object::Reference(pages_id),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        doc
+    }
+
+    #[test]
+    fn document_extraction_reports_an_invisible_layer_from_any_page() {
+        use crate::tounicode::FontCMaps;
+
+        // `process_document` gates its `include_invisible` retry on this
+        // flag, so the document walk must carry a page's verdict out instead
+        // of dropping it: page 2 hides its text behind `3 Tr` the way an
+        // `ocrmypdf` page does, and one such page is enough.
+        let doc = doc_with_page_contents(&[
+            b"BT /F1 12 Tf 72 700 Td (Visible) Tj ET",
+            b"BT 3 Tr /F1 12 Tf 72 700 Td (Hidden) Tj ET",
+        ]);
+        let font_cmaps = FontCMaps::from_doc(&doc);
+        let visible = extract_positioned_text_from_doc(&doc, &font_cmaps, None).unwrap();
+        let texts: Vec<&str> = visible
+            .extraction
+            .0
+            .iter()
+            .map(|i| i.text.as_str())
+            .collect();
+        assert_eq!(texts, ["Visible"]);
+        assert!(visible.skipped_invisible);
+
+        // And the retry that flag unlocks does recover the hidden layer —
+        // having already included it, that pass skipped nothing.
+        let with_invisible = extract_positioned_text_impl(
+            &doc,
+            &font_cmaps,
+            None,
+            true,
+            None,
+            CoordinateFrame::UserSpace,
+        )
+        .unwrap();
+        assert!(
+            with_invisible
+                .extraction
+                .0
+                .iter()
+                .any(|i| i.text == "Hidden"),
+            "{:?}",
+            with_invisible.extraction.0
+        );
+        assert!(!with_invisible.skipped_invisible);
+    }
+
+    #[test]
+    fn document_extraction_reports_nothing_skipped_without_an_invisible_layer() {
+        use crate::tounicode::FontCMaps;
+
+        // The negative half of the gate: a page that simply has no text must
+        // not claim a recoverable layer, or every blank and image-only
+        // document would pay for a second content-stream parse.
+        let doc = doc_with_page_contents(&[
+            b"BT /F1 12 Tf 72 700 Td (Visible) Tj ET",
+            b"q 1 0 0 1 0 0 cm Q",
+        ]);
+        let font_cmaps = FontCMaps::from_doc(&doc);
+        let extracted = extract_positioned_text_from_doc(&doc, &font_cmaps, None).unwrap();
+        assert!(!extracted.skipped_invisible);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4315,7 +4315,18 @@ fn process_document(
         // For Mixed/template PDFs: if normal extraction produces garbage text
         // (mostly non-alphanumeric), retry with invisible (Tr=3) text included.
         // This unlocks OCR text layers behind scanned images.
-        if pdf_type == PdfType::Mixed {
+        //
+        // TextBased documents join that retry on the EMPTY branch only. An
+        // `ocrmypdf` file lands exactly there: every page carries show-text
+        // operators, so the detector calls the document TextBased, yet all of
+        // that text is an invisible (Tr 3) OCR layer which the visible-only
+        // pass drops — markdown came back empty while `has_text` was true.
+        // Requiring an empty visible pass mirrors the region extractor's
+        // `skipped_invisible && !has_visible_text` gate and cannot change
+        // output for documents that already extract text. The garbage branch
+        // stays Mixed-only: on TextBased it would let a noisy-but-real text
+        // layer be replaced by its invisible twin.
+        if pdf_type == PdfType::Mixed || pdf_type == PdfType::TextBased {
             if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _, _)| e) {
                 let sample: String = items
                     .iter()
@@ -4328,7 +4339,26 @@ fn process_document(
                     .take(200)
                     .map(|item| item.text.as_str())
                     .collect();
-                if is_garbage_text(&sample) || sample.trim().is_empty() {
+                // `[Image: ...]` placeholders are synthesized for image
+                // XObjects: they mark that pixels exist, not that text was
+                // read, so a scanned page's visible pass is "empty" despite
+                // carrying them (same rule as `non_placeholder_alnum`).
+                let has_visible_text = items
+                    .iter()
+                    .filter(|item| {
+                        options
+                            .page_filter
+                            .as_ref()
+                            .is_none_or(|filter| filter.contains(&item.page))
+                    })
+                    .any(|item| {
+                        !matches!(item.item_type, types::ItemType::Image)
+                            && !item.text.trim().is_empty()
+                    });
+                let mixed_retry = pdf_type == PdfType::Mixed
+                    && (is_garbage_text(&sample) || sample.trim().is_empty());
+                let text_based_retry = pdf_type == PdfType::TextBased && !has_visible_text;
+                if mixed_retry || text_based_retry {
                     extractor::extract_positioned_text_include_invisible_with_folio_context(
                         &doc,
                         &font_cmaps,
@@ -4337,13 +4367,18 @@ fn process_document(
                 } else {
                     result
                 }
-            } else {
-                // Normal extraction failed — try invisible as fallback
+            } else if pdf_type == PdfType::Mixed {
+                // Normal extraction failed — try invisible as fallback.
+                // TextBased keeps propagating the error (see `extracted?`
+                // below): a failed parse there is a real failure, not a
+                // missing OCR layer.
                 extractor::extract_positioned_text_include_invisible_with_folio_context(
                     &doc,
                     &font_cmaps,
                     options.page_filter.as_ref(),
                 )
+            } else {
+                result
             }
         } else {
             result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,16 +518,14 @@ fn extract_pages_markdown_mem_impl(
             .filter_map(|page| page.checked_add(1))
             .collect()
     });
-    let ((all_items, all_rects, all_lines), page_thresholds, gid_pages, _page_rotations) =
-        if let Some(required_pages) = required_pages.as_ref() {
-            extractor::extract_positioned_text_for_document_analysis(
-                &doc,
-                &font_cmaps,
-                required_pages,
-            )?
-        } else {
-            extractor::extract_positioned_text_from_doc(&doc, &font_cmaps, None)?
-        };
+    let analysis = if let Some(required_pages) = required_pages.as_ref() {
+        extractor::extract_positioned_text_for_document_analysis(&doc, &font_cmaps, required_pages)?
+    } else {
+        extractor::extract_positioned_text_from_doc(&doc, &font_cmaps, None)?
+    };
+    let (all_items, all_rects, all_lines) = analysis.extraction;
+    let page_thresholds = analysis.thresholds;
+    let gid_pages = analysis.gid_encoded_pages;
     let text_quality = analyze_text_quality(&all_items);
 
     // Resolve page numbers with full-document context before partitioning.
@@ -4321,44 +4319,54 @@ fn process_document(
         // operators, so the detector calls the document TextBased, yet all of
         // that text is an invisible (Tr 3) OCR layer which the visible-only
         // pass drops — markdown came back empty while `has_text` was true.
-        // Requiring an empty visible pass mirrors the region extractor's
-        // `skipped_invisible && !has_visible_text` gate and cannot change
+        // That branch takes the region extractor's gate whole, both halves
+        // (`skipped_invisible && !has_visible_text`), so it cannot change
         // output for documents that already extract text. The garbage branch
         // stays Mixed-only: on TextBased it would let a noisy-but-real text
         // layer be replaced by its invisible twin.
         if pdf_type == PdfType::Mixed || pdf_type == PdfType::TextBased {
-            if let Ok((ref items, _, _)) = result.as_ref().map(|(e, _, _, _)| e) {
-                let sample: String = items
-                    .iter()
-                    .filter(|item| {
-                        options
-                            .page_filter
-                            .as_ref()
-                            .is_none_or(|filter| filter.contains(&item.page))
-                    })
-                    .take(200)
-                    .map(|item| item.text.as_str())
-                    .collect();
-                // `[Image: ...]` placeholders are synthesized for image
-                // XObjects: they mark that pixels exist, not that text was
-                // read, so a scanned page's visible pass is "empty" despite
-                // carrying them (same rule as `non_placeholder_alnum`).
-                let has_visible_text = items
-                    .iter()
-                    .filter(|item| {
-                        options
-                            .page_filter
-                            .as_ref()
-                            .is_none_or(|filter| filter.contains(&item.page))
-                    })
-                    .any(|item| {
-                        !matches!(item.item_type, types::ItemType::Image)
-                            && !item.text.trim().is_empty()
-                    });
-                let mixed_retry = pdf_type == PdfType::Mixed
-                    && (is_garbage_text(&sample) || sample.trim().is_empty());
-                let text_based_retry = pdf_type == PdfType::TextBased && !has_visible_text;
-                if mixed_retry || text_based_retry {
+            if let Ok(extracted) = result.as_ref() {
+                let (items, _rects, _lines) = &extracted.extraction;
+                let selected = |item: &types::TextItem| {
+                    options
+                        .page_filter
+                        .as_ref()
+                        .is_none_or(|filter| filter.contains(&item.page))
+                };
+                // Each gate is built only on the branch that consumes it:
+                // `sample` joins up to 200 items into a String and the
+                // visible-text test scans every item, so neither type pays
+                // for the other's evidence (review catch).
+                let retry = match pdf_type {
+                    PdfType::Mixed => {
+                        let sample: String = items
+                            .iter()
+                            .filter(|item| selected(item))
+                            .take(200)
+                            .map(|item| item.text.as_str())
+                            .collect();
+                        is_garbage_text(&sample) || sample.trim().is_empty()
+                    }
+                    // Two conditions, same pair the region extractor uses at
+                    // `skipped_invisible && !has_visible_text` above: some
+                    // page must actually have SUPPRESSED a Tr 3 layer — a
+                    // blank or image-only page has nothing to recover and
+                    // must not pay for a second content-stream parse — and
+                    // the visible pass must have read nothing. `[Image: ...]`
+                    // placeholders are synthesized for image XObjects: they
+                    // mark that pixels exist, not that text was read, so a
+                    // scanned page's visible pass is "empty" despite carrying
+                    // them (same rule as `non_placeholder_alnum`).
+                    PdfType::TextBased => {
+                        extracted.skipped_invisible
+                            && !items.iter().filter(|item| selected(item)).any(|item| {
+                                !matches!(item.item_type, types::ItemType::Image)
+                                    && !item.text.trim().is_empty()
+                            })
+                    }
+                    _ => false,
+                };
+                if retry {
                     extractor::extract_positioned_text_include_invisible_with_folio_context(
                         &doc,
                         &font_cmaps,
@@ -4419,7 +4427,12 @@ fn process_document(
         text_quality_pages,
         text_quality_reasons_by_page,
     ) = match extracted {
-        Some(((items, rects, lines), page_thresholds, gid_encoded_pages, _page_rotations)) => {
+        Some(extractor::PositionedExtraction {
+            extraction: (items, rects, lines),
+            thresholds: page_thresholds,
+            gid_encoded_pages,
+            ..
+        }) => {
             let mut ocr_reasons_by_page = BTreeMap::new();
 
             // For TextBased PDFs with pages flagged for OCR (Identity-H or

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1991,6 +1991,63 @@ fn test_extract_regions_mem_recovers_invisible_ocr_layer() {
     );
 }
 
+/// The markdown path must recover the same invisible (Tr 3) OCR layer the
+/// region extractor already serves. An `ocrmypdf` file classifies as
+/// TextBased — every page carries show-text operators — so the Mixed-only
+/// invisible retry never fired and the markdown came back empty while
+/// `has_text` was true.
+#[test]
+fn test_process_pdf_mem_recovers_invisible_ocr_layer_on_text_based() {
+    let buf = make_pdf_with_custom_text_layer(3, None, Some(&ocr_page_lines()), false);
+    let result = process_pdf_mem(&buf).unwrap();
+    assert_eq!(
+        result.pdf_type,
+        PdfType::TextBased,
+        "a full OCR layer must classify as TextBased — that is the case the \
+         Mixed-only retry missed"
+    );
+    let markdown = result.markdown.unwrap_or_default();
+    assert!(
+        markdown.contains("quick brown fox"),
+        "invisible OCR layer should reach the markdown, got: {markdown:?}"
+    );
+}
+
+/// A page-sized OCR layer: enough show-text operators (>= 10 on a page that
+/// also carries an image) and enough character diversity for the detector to
+/// call the document TextBased, the way a real `ocrmypdf` page does.
+fn ocr_page_lines() -> Vec<&'static str> {
+    vec![
+        "The quick brown fox jumps over the lazy dog",
+        "Pack my box with five dozen liquor jugs",
+        "How vexingly quick daft zebras jump",
+        "Sphinx of black quartz judge my vow",
+        "Jackdaws love my big sphinx of quartz",
+        "The five boxing wizards jump quickly",
+        "Bright vixens jump dozy fowl quack",
+        "Quick zephyrs blow vexing daft Jim",
+        "Two driven jocks help fax my big quiz",
+        "Waltz bad nymph for quick jigs vex",
+        "Glib jocks quiz nymph to vex dwarf",
+        "Sympathizing would fix Quaker objectives",
+    ]
+}
+
+/// The recovery above must not double-serve a page that already extracts
+/// visible text: the invisible pass returns visible items too, so a retry
+/// there would duplicate every visible word.
+#[test]
+fn test_process_pdf_mem_visible_text_keeps_single_copy() {
+    let buf = make_pdf_with_custom_text_layer(0, None, Some(&ocr_page_lines()), false);
+    let result = process_pdf_mem(&buf).unwrap();
+    let markdown = result.markdown.unwrap_or_default();
+    assert_eq!(
+        markdown.matches("quick brown fox").count(),
+        1,
+        "visible text must appear exactly once, got: {markdown:?}"
+    );
+}
+
 /// ANY visible text on the page — even a single short line — must block the
 /// invisible-layer adoption entirely: the invisible pass returns visible
 /// items too, so adopting it alongside visible text would duplicate the


### PR DESCRIPTION
Fixes #500.

## Problem

An `ocrmypdf` file — the output of the most common OCR pipeline in the wild — carries its text as an invisible (`Tr 3`) layer behind the page raster. Every page still has show-text operators, so the detector classifies the document `TextBased`, and the invisible-text retry in `process_document` was gated on `PdfType::Mixed`. It never fired, and `pdf2md` returned an empty markdown string while reporting `has_text: true`:

```json
{"pdf_type":"text_based","has_text":true,"markdown_length":0,"pages_needing_ocr":[1],"markdown":""}
```

`pdftotext` reads the same file fine, and so does this crate's own `extract_text_in_regions_mem` — the two extractors disagreed on one file.

## Change

`TextBased` documents now take the same retry, but only on the empty branch:

- **empty visible pass** → retry with invisible text included (new, `Mixed` and `TextBased`);
- **garbage visible pass** → retry, `Mixed` only (unchanged) — on `TextBased` that could replace a noisy-but-real text layer with its invisible twin;
- **extraction failure** → invisible fallback stays `Mixed`-only; on `TextBased` a failed parse is still a real failure and keeps propagating.

"Empty" ignores `[Image: ...]` placeholders: they mark that pixels exist, not that text was read. That is the same rule `non_placeholder_alnum` already applies for the region extractor, and without it a scanned page never looks empty. The overall condition mirrors the `skipped_invisible && !has_visible_text` gate at `src/lib.rs:1105`, so both extractors now agree.

A document that already extracts visible text cannot reach the new branch, so its output is unchanged.

## Tests

Two new integration tests, built on the existing `make_pdf_with_custom_text_layer` helper (no new fixture):

- `test_process_pdf_mem_recovers_invisible_ocr_layer_on_text_based` — asserts the document really classifies `TextBased` (that is the case the `Mixed` gate missed) and that the layer reaches the markdown. Fails on `main` with `got: ""`.
- `test_process_pdf_mem_visible_text_keeps_single_copy` — a visible page still yields exactly one copy of its text.

The layer needs >= 10 show-text operators and real character diversity for the detector to call the page a text page when an image is present, so the helper is given a page-sized set of lines rather than the default three.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all clean (1162 unit + 178 integration + doctests, 0 failures).
- End to end on a real `ocrmypdf` file (Ukrainian journal page, scored against the page's genuine text layer): `pdf2md` goes from **0 words extracted** to **89.8% word recall / 88.8% sequence similarity** — above `pdftotext` on the same file (88.3% / 41.0%), since paragraph assembly survives here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #500. `TextBased` documents now retry extraction with invisible text when the visible pass finds no text, so `ocrmypdf` files no longer return empty markdown while reporting `has_text: true`.

The invisible-text retry previously ran only for `Mixed` documents. An `ocrmypdf` page carries show-text operators (its OCR layer is invisible, `Tr 3`), so the detector classifies it as `TextBased` and the retry never fired. The `TextBased` retry now uses the region extractor's full gate — `skipped_invisible && !has_visible_text` — so blank and image-only pages don't pay for a second parse, and the document-level extractor carries each page's `skipped_invisible` verdict out of the walk.

- `[Image: ...]` placeholders don't count as text — they mark that pixels exist, matching the region extractor's rule.
- The garbage-text branch stays `Mixed`-only: on `TextBased` it could replace a noisy-but-real text layer with its invisible twin.
- Documents that already extract visible text never reach the new branch, so their output is unchanged.
- Each gate is built only in the branch that consumes it, so neither type pays for the other's evidence.

**Tests**
- Two integration tests cover the `TextBased` recovery and confirm visible text still appears exactly once.
- Two extractor unit tests verify the `skipped_invisible` flag survives the walk and stays false when nothing was skipped.

<sup>Written for commit 64230e9f5d252e683d1b588fe0efe7a65a2b781f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

