### PR TITLE
fix(extractor): recover embedded bold font metadata

### DIFF
--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -1110,9 +1110,19 @@ fn embedded_style_flags(doc: &Document, ff_ref: ObjectId) -> (bool, bool) {
         return (false, false);
     };
     if let Ok(face) = ttf_parser::Face::parse(&data, 0) {
+        // PDF subsetters can remove OS/2 while retaining the bold bit in
+        // head.macStyle. Face::is_bold only reads OS/2; use the legacy flag
+        // when that table is unavailable, without overriding an explicit
+        // regular OS/2 face. The parsed face has already validated head.
+        let mac_bold = face.tables().os2.is_none()
+            && face
+                .raw_face()
+                .table(ttf_parser::Tag::from_bytes(b"head"))
+                .and_then(|head| head.get(44..46))
+                .is_some_and(|bytes| u16::from_be_bytes([bytes[0], bytes[1]]) & 1 != 0);
         (
             face.is_italic() || face.italic_angle().abs() >= 4.0,
-            face.is_bold(),
+            face.is_bold() || mac_bold,
         )
     } else if let Some(name) = cff_font_name(&data) {
         // FontFile3 is bare CFF (no sfnt container) — ttf_parser
@@ -1936,6 +1946,77 @@ mod tests {
             descriptor_style_flags(&doc, &font_dict, &mut FontStyleCache::new()),
             (false, false)
         );
+    }
+
+    /// Synthetic sfnt containing just the tables needed to parse a face.
+    /// No source-document font bytes are needed for these style tests.
+    fn sfnt_with_style(mac_style: u16, os2_selection: Option<u16>) -> Vec<u8> {
+        let mut head = vec![0u8; 54];
+        head[18..20].copy_from_slice(&1000u16.to_be_bytes()); // unitsPerEm
+        head[44..46].copy_from_slice(&mac_style.to_be_bytes());
+        let hhea = vec![0u8; 36];
+        let mut maxp = vec![0u8; 6];
+        maxp[..4].copy_from_slice(&0x00005000u32.to_be_bytes());
+        maxp[4..6].copy_from_slice(&1u16.to_be_bytes()); // numGlyphs
+        let mut tables = vec![(*b"head", head), (*b"hhea", hhea), (*b"maxp", maxp)];
+        if let Some(selection) = os2_selection {
+            let mut os2 = vec![0u8; 78]; // version 0
+            os2[62..64].copy_from_slice(&selection.to_be_bytes());
+            tables.push((*b"OS/2", os2));
+        }
+        tables.sort_by_key(|(tag, _)| *tag);
+        let count = tables.len();
+        let mut data = vec![0u8; 12 + count * 16];
+        data[..4].copy_from_slice(&0x00010000u32.to_be_bytes());
+        data[4..6].copy_from_slice(&(count as u16).to_be_bytes());
+        for (i, (tag, table)) in tables.into_iter().enumerate() {
+            let offset = data.len() as u32;
+            let record = 12 + i * 16;
+            data[record..record + 4].copy_from_slice(&tag);
+            data[record + 8..record + 12].copy_from_slice(&offset.to_be_bytes());
+            data[record + 12..record + 16].copy_from_slice(&(table.len() as u32).to_be_bytes());
+            data.extend_from_slice(&table);
+            while !data.len().is_multiple_of(4) {
+                data.push(0);
+            }
+        }
+        data
+    }
+
+    fn descriptor_flags_from_sfnt(mac_style: u16, os2_selection: Option<u16>) -> (bool, bool) {
+        let mut doc = Document::with_version("1.4");
+        let font_file = doc.add_object(lopdf::Stream::new(
+            dictionary! {},
+            sfnt_with_style(mac_style, os2_selection),
+        ));
+        let descriptor = doc.add_object(dictionary! {
+            "Type" => "FontDescriptor",
+            "FontName" => "ABCDEF+OpaqueFace",
+            "Flags" => 4,
+            "ItalicAngle" => 0,
+            "FontFile2" => font_file,
+        });
+        let font_dict = dictionary! {
+            "Type" => "Font",
+            "Subtype" => "TrueType",
+            "BaseFont" => "ABCDEF+OpaqueFace",
+            "FontDescriptor" => descriptor,
+        };
+        descriptor_style_flags(&doc, &font_dict, &mut FontStyleCache::new())
+    }
+
+    #[test]
+    fn embedded_mac_bold_without_os2_survives_opaque_subset_names() {
+        assert_eq!(descriptor_flags_from_sfnt(1, None), (false, true));
+        assert_eq!(descriptor_flags_from_sfnt(0, None), (false, false));
+        // Italic and other macStyle bits must not imply bold.
+        assert_eq!(descriptor_flags_from_sfnt(2, None), (false, false));
+    }
+
+    #[test]
+    fn embedded_os2_bold_remains_authoritative() {
+        assert_eq!(descriptor_flags_from_sfnt(0, Some(1 << 5)), (false, true));
+        assert_eq!(descriptor_flags_from_sfnt(1, Some(1 << 6)), (false, false));
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1285,14 +1285,9 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                 {
                     break;
                 }
-                // Never merge across style boundaries: the merged item
-                // carries `first`'s flags, so absorbing a styled run into a
-                // plain neighbor (or vice versa) silently erases the styling
-                // that markdown emission and downstream inline-styling need —
-                // and OR-ing underline instead would stretch `<u>` spans over
-                // neighboring plain text.
-                if next.is_bold != first.is_bold
-                    || next.is_italic != first.is_italic
+                // Preserve the existing join behavior at non-bold style
+                // boundaries, including italic fragments within formulas.
+                if next.is_italic != first.is_italic
                     || next.is_underline != first.is_underline
                     || next.is_strikeout != first.is_strikeout
                 {
@@ -1365,8 +1360,40 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                     Some((run_end, floor)) if j <= run_end => floor,
                     _ => threshold,
                 };
-                if !small_caps_join && (needs_bullet_space || gap > effective_threshold) {
+                let bold_boundary = next.is_bold != first.is_bold;
+                let explicit_bold_space = bold_boundary
+                    && (text.ends_with(char::is_whitespace)
+                        || next.text.starts_with(char::is_whitespace));
+                // Numeric fragments have their own joining thresholds in
+                // line assembly. Injecting a word space here would split a
+                // number whose decimal point or digits use a bold font.
+                let numeric_boundary = bold_boundary
+                    && match (text.chars().last(), next.text.chars().next()) {
+                        (Some(p), Some(c)) if p.is_ascii_digit() => {
+                            c.is_ascii_digit() || matches!(c, '.' | ',' | '%')
+                        }
+                        (Some('.' | ','), Some(c)) if c.is_ascii_digit() => {
+                            let prefix = &text[..text.len() - 1];
+                            // A separate decimal glyph can start a fractional
+                            // number even without a preceding integer run.
+                            prefix.trim().is_empty()
+                                || prefix.chars().last().is_some_and(|c| c.is_ascii_digit())
+                        }
+                        (Some('+' | '-'), Some(c)) => c.is_ascii_digit(),
+                        _ => false,
+                    };
+                if !small_caps_join
+                    && (needs_bullet_space || (gap > effective_threshold && !numeric_boundary))
+                    && !explicit_bold_space
+                {
                     text.push(' ');
+                }
+                // Keep bold runs separate, but preserve the same word-space
+                // decision as an unstyled merge. Otherwise the later line
+                // assembler's wider joining threshold can glue words when
+                // newly recovered font flags split a previously merged run.
+                if bold_boundary {
+                    break;
                 }
                 text.push_str(&next.text);
                 box_right = box_right.max(next.x + next.width);
@@ -1603,6 +1630,146 @@ mod tests {
         assert!(merged[1].is_italic && !merged[1].is_underline);
         assert!(merged[2].is_underline && !merged[2].is_italic);
         assert!(!merged[3].is_underline && !merged[3].is_italic);
+    }
+
+    #[test]
+    fn recovered_bold_preserves_word_spacing_at_style_boundary() {
+        // A 0.1-em gap is a word boundary in merging, but the later line
+        // assembler joins gaps below 0.15 em. Recovering bold must not lose
+        // the space that the original all-plain merge would have emitted.
+        let plain = vec![
+            make_merge_item("KEY", 100.0, 24.0),
+            make_merge_item("Body", 125.2, 24.0),
+        ];
+        let original = merge_text_items(plain.clone());
+        let mut styled = plain;
+        styled[0].is_bold = true;
+        let recovered = merge_text_items(styled);
+        assert_eq!(original[0].text, "KEY Body");
+        assert_eq!(recovered.len(), 2);
+        assert!(recovered[0].is_bold && !recovered[1].is_bold);
+        assert_eq!(recovered[0].text, "KEY ");
+        assert_eq!(recovered[1].text, "Body");
+        assert_eq!(
+            recovered
+                .iter()
+                .map(|item| item.text.as_str())
+                .collect::<String>(),
+            original[0].text
+        );
+        let line = TextLine {
+            items: recovered,
+            y: 100.0,
+            page: 1,
+            adaptive_threshold: 0.1,
+        };
+        assert_eq!(line.text(), "KEY Body");
+        assert_eq!(
+            line.text_with_formatting(true, false, false),
+            "**KEY** Body"
+        );
+    }
+
+    #[test]
+    fn recovered_bold_keeps_zero_gap_word_fragments_joined() {
+        let plain = vec![
+            make_merge_item("un", 100.0, 12.0),
+            make_merge_item("known", 112.0, 30.0),
+        ];
+        let original = merge_text_items(plain.clone());
+        let mut styled = plain;
+        styled[0].is_bold = true;
+        let recovered = merge_text_items(styled);
+        assert_eq!(original[0].text, "unknown");
+        assert_eq!(recovered.len(), 2);
+        assert!(recovered[0].is_bold && !recovered[1].is_bold);
+        assert_eq!(
+            recovered
+                .iter()
+                .map(|item| item.text.as_str())
+                .collect::<String>(),
+            original[0].text
+        );
+        let line = TextLine {
+            items: recovered,
+            y: 100.0,
+            page: 1,
+            adaptive_threshold: 0.1,
+        };
+        assert_eq!(line.text(), "unknown");
+        assert_eq!(line.text_with_formatting(true, false, false), "**un**known");
+    }
+
+    #[test]
+    fn bold_numeric_fragments_keep_line_assembly_spacing() {
+        for (parts, gap, expected) in [
+            (
+                vec![("0", false), (".", true), ("86", false)],
+                1.2,
+                "0**.**86",
+            ),
+            (vec![("0.", true), ("86", false)], 1.2, "**0.**86"),
+            (vec![(".", true), ("42", false)], 1.2, "**.**42"),
+            (
+                vec![("12 ", false), (".", true), ("55", false)],
+                1.2,
+                "12 **.**55",
+            ),
+            (
+                vec![("12", false), (" .", true), ("55", false)],
+                1.2,
+                "12 **.**55",
+            ),
+            (vec![("1", false), ("23", true)], 1.2, "1**23**"),
+            (vec![("12", true), ("%", false)], 1.2, "**12**%"),
+            (vec![("+", true), ("12", false)], 1.2, "**+**12"),
+            (
+                vec![("1", false), (",", true), ("25", false)],
+                1.2,
+                "1**,**25",
+            ),
+            (vec![("Done.", true), ("2", false)], 1.2, "**Done.** 2"),
+            (vec![("0. ", true), ("86", false)], 1.2, "**0.** 86"),
+            (vec![("0.", true), ("86", false)], 4.8, "**0.** 86"),
+            (vec![("KEY ", true), ("Body", false)], 1.2, "**KEY** Body"),
+            (vec![("KEY", true), (" Body", false)], 1.2, "**KEY** Body"),
+        ] {
+            let mut x = 100.0;
+            let items = parts
+                .into_iter()
+                .map(|(text, bold)| {
+                    let width = text.len() as f32 * 6.0;
+                    let mut item = make_merge_item(text, x, width);
+                    item.is_bold = bold;
+                    x += width + gap;
+                    item
+                })
+                .collect();
+            let line = TextLine {
+                items: merge_text_items(items),
+                y: 100.0,
+                page: 1,
+                adaptive_threshold: 0.1,
+            };
+            assert_eq!(line.text_with_formatting(true, false, false), expected);
+            assert_eq!(line.text(), expected.replace("**", ""));
+        }
+    }
+
+    #[test]
+    fn non_bold_style_boundaries_keep_existing_spacing() {
+        for style in 0..3 {
+            let mut first = make_merge_item("KEY", 100.0, 24.0);
+            match style {
+                0 => first.is_italic = true,
+                1 => first.is_underline = true,
+                _ => first.is_strikeout = true,
+            }
+            let merged = merge_text_items(vec![first, make_merge_item("Body", 125.2, 24.0)]);
+            assert_eq!(merged.len(), 2);
+            assert_eq!(merged[0].text, "KEY");
+            assert_eq!(merged[1].text, "Body");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Recover bold styling from the TrueType `head.macStyle` flag when the OS/2 table is unavailable, while keeping explicit OS/2 styling authoritative. Preserve word spacing and numeric continuity when bold and regular text runs are separated, so bold markup does not join adjacent words or split numbers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover bold styling from the TrueType `head.macStyle` flag when the OS/2 table is unavailable, while keeping explicit OS/2 styling authoritative. Preserve word spacing and numeric continuity when bold and regular text runs are separated, so bold markup does not join adjacent words or split numbers.

<sup>Written for commit 577cc54235ffd52cebaa84e8f22d0e5945e7c6b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

