### PR TITLE
fix(extractor): honor PDF text horizontal scaling

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -157,23 +157,47 @@ pub(crate) fn estimated_string_advance_ts(
         + spaces as f32 * word_spacing
 }
 
-/// A reflected `Tz` inside ActualText can walk the cursor back over text
-/// already painted. Keep those run bounds so their advances cannot cancel
-/// the replacement item's footprint. Constant-direction spans retain the
-/// existing displacement-based geometry.
+/// Reflections from `Tf` or `Tz` inside ActualText can walk the cursor back
+/// over painted text or flip its glyph-up axis. Keep those run bounds so
+/// cancelled advances cannot hide the replacement item's footprint. Spans
+/// without reflection changes retain the existing displacement geometry.
 #[derive(Default)]
 struct ActualTextBounds {
-    first_scale: Option<f32>,
-    changed_direction: bool,
+    first_advance_reflection: Option<bool>,
+    first_up_reflection: Option<bool>,
+    changed_reflection: bool,
     bounds: Option<[f32; 4]>,
 }
 
 impl ActualTextBounds {
-    fn include(&mut self, geometry: RunGeometry, scale: f32) {
-        if let Some(first) = self.first_scale {
-            self.changed_direction |= first.is_sign_negative() != scale.is_sign_negative();
+    fn reflection_changed(first: &mut Option<bool>, reflection: bool) -> bool {
+        if let Some(first) = first {
+            *first != reflection
         } else {
-            self.first_scale = Some(scale);
+            *first = Some(reflection);
+            false
+        }
+    }
+
+    fn include(&mut self, geometry: RunGeometry, scale: f32, font_size: f32, render_mode: i32) {
+        // Tf reflects both axes; Tz reflects only the advance axis. Track
+        // both: flipping Tf and Tz together still flips glyph-up. A zero
+        // scale has no advance direction. Its collapsed outline has no
+        // fill area, but stroking it can still paint along the glyph-up axis.
+        if scale == 0.0 && !matches!(render_mode, 1 | 2 | 5 | 6) {
+            return;
+        }
+        if font_size != 0.0 {
+            if scale != 0.0 {
+                self.changed_reflection |= Self::reflection_changed(
+                    &mut self.first_advance_reflection,
+                    font_size.is_sign_negative() ^ scale.is_sign_negative(),
+                );
+            }
+            self.changed_reflection |= Self::reflection_changed(
+                &mut self.first_up_reflection,
+                font_size.is_sign_negative(),
+            );
         }
         let run = [
             geometry.x,
@@ -193,7 +217,7 @@ impl ActualTextBounds {
     }
 
     fn apply_to(&self, geometry: &mut RunGeometry) {
-        if self.changed_direction {
+        if self.changed_reflection {
             if let Some([x1, y1, x2, y2]) = self.bounds {
                 geometry.x = x1;
                 geometry.y = y1;
@@ -649,6 +673,8 @@ pub(crate) fn extract_page_text_items(
                                     horizontal_scale,
                                 ),
                                 horizontal_scale,
+                                current_font_size,
+                                text_rendering_mode,
                             );
                         }
                         let cursor_ts = w_ts_opt.unwrap_or(estimate_ts);
@@ -959,6 +985,8 @@ pub(crate) fn extract_page_text_items(
                                             horizontal_scale,
                                         ),
                                         horizontal_scale,
+                                        current_font_size,
+                                        text_rendering_mode,
                                     );
                                 }
                             }
@@ -1186,6 +1214,8 @@ pub(crate) fn extract_page_text_items(
                             horizontal_scale,
                         ),
                         horizontal_scale,
+                        current_font_size,
+                        text_rendering_mode,
                     );
                 }
                 if text_rendering_mode == 3

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -20,7 +20,7 @@ use super::fonts::{
 };
 use super::geometry::{
     estimated_advance_for_glyphs, estimated_advance_ts, normalize_degrees, reading_direction,
-    rise_adjusted, run_geometry, PageRotation,
+    rise_adjusted, scaled_run_geometry, PageRotation, RunGeometry,
 };
 use super::underline::UnderlineLine;
 use super::xobjects::{extract_form_xobject_text, get_page_xobjects, FormWalkBudget, XObjectType};
@@ -155,6 +155,53 @@ pub(crate) fn estimated_string_advance_ts(
     estimated_advance_for_glyphs(glyphs, em_ts)
         + glyphs as f32 * char_spacing
         + spaces as f32 * word_spacing
+}
+
+/// A reflected `Tz` inside ActualText can walk the cursor back over text
+/// already painted. Keep those run bounds so their advances cannot cancel
+/// the replacement item's footprint. Constant-direction spans retain the
+/// existing displacement-based geometry.
+#[derive(Default)]
+struct ActualTextBounds {
+    first_scale: Option<f32>,
+    changed_direction: bool,
+    bounds: Option<[f32; 4]>,
+}
+
+impl ActualTextBounds {
+    fn include(&mut self, geometry: RunGeometry, scale: f32) {
+        if let Some(first) = self.first_scale {
+            self.changed_direction |= first.is_sign_negative() != scale.is_sign_negative();
+        } else {
+            self.first_scale = Some(scale);
+        }
+        let run = [
+            geometry.x,
+            geometry.y,
+            geometry.x + geometry.width,
+            geometry.y + geometry.height,
+        ];
+        self.bounds = Some(match self.bounds {
+            Some(bounds) => [
+                bounds[0].min(run[0]),
+                bounds[1].min(run[1]),
+                bounds[2].max(run[2]),
+                bounds[3].max(run[3]),
+            ],
+            None => run,
+        });
+    }
+
+    fn apply_to(&self, geometry: &mut RunGeometry) {
+        if self.changed_direction {
+            if let Some([x1, y1, x2, y2]) = self.bounds {
+                geometry.x = x1;
+                geometry.y = y1;
+                geometry.width = x2 - x1;
+                geometry.height = y2 - y1;
+            }
+        }
+    }
 }
 
 /// Returns `(page_extraction, has_gid_fonts, page_rotation, skipped_invisible)`
@@ -337,6 +384,7 @@ pub(crate) fn extract_page_text_items(
         line_width: f32,
         char_spacing: f32,
         word_spacing: f32,
+        horizontal_scale: f32,
         text_rise: f32,
         text_leading: f32,
         current_font: String,
@@ -350,6 +398,7 @@ pub(crate) fn extract_page_text_items(
     let mut text_leading: f32 = 0.0; // TL parameter (in text-space units)
     let mut char_spacing: f32 = 0.0; // Tc parameter (extra spacing per character, unscaled)
     let mut word_spacing: f32 = 0.0; // Tw parameter (extra spacing per space char, unscaled)
+    let mut horizontal_scale: f32 = 1.0; // Tz, stored as a ratio
     let mut text_rise: f32 = 0.0; // Ts parameter (baseline shift for super/subscripts, unscaled)
     let mut text_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
     let mut line_matrix = [1.0f32, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -371,6 +420,8 @@ pub(crate) fn extract_page_text_items(
     let mut actual_text_glyph_tm: Option<[f32; 6]> = None; // text matrix at first glyph inside BDC
                                                            // Text rise in effect at each captured matrix — the item must render at
                                                            // the rise of its GLYPHS, not whatever rise is set by EMC time.
+    let mut actual_text_start_scale: f32 = 1.0;
+    let mut actual_text_glyph_scale: Option<f32> = None;
     let mut actual_text_start_rise: f32 = 0.0;
     let mut actual_text_glyph_rise: Option<f32> = None;
     let mut actual_text_glyph_font: Option<String> = None; // font that painted the span's first glyph
@@ -380,6 +431,7 @@ pub(crate) fn extract_page_text_items(
                                                 // Glyphs painted inside the current ActualText span: sizes the span's box
                                                 // when its font has no width metrics.
     let mut actual_text_glyph_count: usize = 0;
+    let mut actual_text_bounds = ActualTextBounds::default();
     /// Get the innermost MCID from the marked content stack.
     fn current_mcid(stack: &[MarkedContentEntry]) -> Option<i64> {
         stack.iter().rev().find_map(|e| e.mcid)
@@ -396,6 +448,7 @@ pub(crate) fn extract_page_text_items(
                     line_width,
                     char_spacing,
                     word_spacing,
+                    horizontal_scale,
                     text_rise,
                     text_leading,
                     current_font: current_font.clone(),
@@ -410,6 +463,7 @@ pub(crate) fn extract_page_text_items(
                     line_width = saved.line_width;
                     char_spacing = saved.char_spacing;
                     word_spacing = saved.word_spacing;
+                    horizontal_scale = saved.horizontal_scale;
                     text_rise = saved.text_rise;
                     text_leading = saved.text_leading;
                     current_font = saved.current_font;
@@ -481,6 +535,13 @@ pub(crate) fn extract_page_text_items(
                 // Set word spacing (extra space added for each space character)
                 if let Some(tw) = op.operands.first().and_then(get_number) {
                     word_spacing = tw;
+                }
+            }
+            "Tz" => {
+                if let Some(scale) = op.operands.first().and_then(get_number) {
+                    if scale.is_finite() {
+                        horizontal_scale = scale / 100.0;
+                    }
                 }
             }
             "Ts" => {
@@ -568,13 +629,31 @@ pub(crate) fn extract_page_text_items(
                             actual_text_glyph_rise = Some(text_rise);
                             actual_text_glyph_font = Some(current_font.clone());
                             actual_text_glyph_font_size = Some(current_font_size);
+                            actual_text_glyph_scale = Some(horizontal_scale);
                         }
                         actual_text_glyph_count += glyph_count;
                         actual_text_glyphs_measured &= w_ts_opt.is_some();
-                        actual_text_estimate_ts += estimate_ts;
+                        actual_text_estimate_ts += estimate_ts * horizontal_scale;
+                        if glyph_count > 0 {
+                            let combined =
+                                multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
+                            let rendered_size = effective_font_size(current_font_size, &combined)
+                                * type3_scales.get(&current_font).copied().unwrap_or(1.0);
+                            actual_text_bounds.include(
+                                scaled_run_geometry(
+                                    &combined,
+                                    w_ts_opt,
+                                    estimate_ts,
+                                    rendered_size.copysign(current_font_size),
+                                    type3_y_flips.contains(&current_font),
+                                    horizontal_scale,
+                                ),
+                                horizontal_scale,
+                            );
+                        }
                         let cursor_ts = w_ts_opt.unwrap_or(estimate_ts);
-                        text_matrix[4] += cursor_ts * text_matrix[0];
-                        text_matrix[5] += cursor_ts * text_matrix[1];
+                        text_matrix[4] += cursor_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += cursor_ts * horizontal_scale * text_matrix[1];
                         continue;
                     }
                     // Skip invisible (Tr=3) text but still advance text matrix.
@@ -590,8 +669,8 @@ pub(crate) fn extract_page_text_items(
                             skipped_invisible = true;
                         }
                         let cursor_ts = w_ts_opt.unwrap_or(estimate_ts);
-                        text_matrix[4] += cursor_ts * text_matrix[0];
-                        text_matrix[5] += cursor_ts * text_matrix[1];
+                        text_matrix[4] += cursor_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += cursor_ts * horizontal_scale * text_matrix[1];
                         continue;
                     }
                     if let Some(text) = extract_text_from_operand(
@@ -610,7 +689,7 @@ pub(crate) fn extract_page_text_items(
                             multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
                         let rendered_size = effective_font_size(current_font_size, &combined)
                             * type3_scales.get(&current_font).copied().unwrap_or(1.0);
-                        let geometry = run_geometry(
+                        let geometry = scaled_run_geometry(
                             &combined,
                             w_ts_opt,
                             if glyph_count > 0 {
@@ -620,15 +699,18 @@ pub(crate) fn extract_page_text_items(
                             },
                             rendered_size.copysign(current_font_size),
                             type3_y_flips.contains(&current_font),
+                            horizontal_scale,
                         );
                         let cursor_ts = w_ts_opt.unwrap_or(estimate_ts);
-                        text_matrix[4] += cursor_ts * text_matrix[0];
-                        text_matrix[5] += cursor_ts * text_matrix[1];
+                        text_matrix[4] += cursor_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += cursor_ts * horizontal_scale * text_matrix[1];
                         // Only create text item for non-whitespace; whitespace
                         // still advances the text matrix above so gap detection works
                         if !text.trim().is_empty() {
-                            rotation_votes
-                                .cast_direction(reading_direction(&combined, current_font_size));
+                            rotation_votes.cast_direction(reading_direction(
+                                &combined,
+                                current_font_size * horizontal_scale,
+                            ));
                             let base_font = font_base_names
                                 .get(&current_font)
                                 .map(|s| s.as_str())
@@ -646,7 +728,7 @@ pub(crate) fn extract_page_text_items(
                                 // horizontal evidence and stay neutral — same
                                 // dominance test as the rotation votes above.
                                 if combined[0].abs() > combined[1].abs() {
-                                    if combined[0] > 0.0 {
+                                    if combined[0] * horizontal_scale > 0.0 {
                                         rtl_visual_candidates.push(items.len());
                                     } else {
                                         rtl_logical_ops += 1;
@@ -716,6 +798,7 @@ pub(crate) fn extract_page_text_items(
                             actual_text_glyph_rise = Some(text_rise);
                             actual_text_glyph_font = Some(current_font.clone());
                             actual_text_glyph_font_size = Some(current_font_size);
+                            actual_text_glyph_scale = Some(horizontal_scale);
                         }
 
                         // Compute space threshold based on font metrics when available
@@ -818,6 +901,7 @@ pub(crate) fn extract_page_text_items(
                             }
                             let element_glyphs =
                                 shown_glyph_count(get_operand_bytes(element), font_info);
+                            let element_start_width_ts = total_width_ts;
                             // The estimate this element would carry without
                             // metrics: its own size, scale, and spacing.
                             let element_estimate_ts = estimated_string_advance_ts(
@@ -847,7 +931,36 @@ pub(crate) fn extract_page_text_items(
                             if suppress_glyph_extraction {
                                 actual_text_glyph_count += element_glyphs;
                                 actual_text_glyphs_measured &= font_info.is_some();
-                                actual_text_estimate_ts += element_estimate_ts;
+                                actual_text_estimate_ts += element_estimate_ts * horizontal_scale;
+                                if element_glyphs > 0 {
+                                    let mut offset_tm = text_matrix;
+                                    offset_tm[4] +=
+                                        element_start_width_ts * horizontal_scale * text_matrix[0];
+                                    offset_tm[5] +=
+                                        element_start_width_ts * horizontal_scale * text_matrix[1];
+                                    let combined = multiply_matrices(
+                                        &rise_adjusted(&offset_tm, text_rise),
+                                        &ctm,
+                                    );
+                                    let rendered_size =
+                                        effective_font_size(current_font_size, &combined)
+                                            * type3_scales
+                                                .get(&current_font)
+                                                .copied()
+                                                .unwrap_or(1.0);
+                                    actual_text_bounds.include(
+                                        scaled_run_geometry(
+                                            &combined,
+                                            font_info
+                                                .map(|_| total_width_ts - element_start_width_ts),
+                                            element_estimate_ts,
+                                            rendered_size.copysign(current_font_size),
+                                            type3_y_flips.contains(&current_font),
+                                            horizontal_scale,
+                                        ),
+                                        horizontal_scale,
+                                    );
+                                }
                             }
                             if !is_invisible {
                                 if let Some(text) = extract_text_from_operand(
@@ -878,8 +991,10 @@ pub(crate) fn extract_page_text_items(
                         // Emit one TextItem per sub-item
                         if !sub_items.is_empty() {
                             let combined = multiply_matrices(&text_matrix, &ctm);
-                            rotation_votes
-                                .cast_direction(reading_direction(&combined, current_font_size));
+                            rotation_votes.cast_direction(reading_direction(
+                                &combined,
+                                current_font_size * horizontal_scale,
+                            ));
                             let rendered_size = effective_font_size(current_font_size, &combined)
                                 * type3_scales.get(&current_font).copied().unwrap_or(1.0);
                             let base_font = font_base_names
@@ -890,10 +1005,12 @@ pub(crate) fn extract_page_text_items(
                                 .get(&current_font)
                                 .copied()
                                 .unwrap_or((false, false));
-                            let scale_x = text_matrix[0] * ctm[0] + text_matrix[1] * ctm[2];
+                            let scale_x = (text_matrix[0] * ctm[0] + text_matrix[1] * ctm[2])
+                                * horizontal_scale;
                             // Rotated matrices carry no horizontal evidence:
                             // stay neutral unless the advance is x-dominant.
-                            let scale_y = text_matrix[0] * ctm[1] + text_matrix[1] * ctm[3];
+                            let scale_y = (text_matrix[0] * ctm[1] + text_matrix[1] * ctm[3])
+                                * horizontal_scale;
                             let horizontal_advance = scale_x.abs() > scale_y.abs();
                             // The op-wide backtrack marker votes once per op —
                             // per-sub-run geometry (mirrored matrices) still
@@ -905,12 +1022,12 @@ pub(crate) fn extract_page_text_items(
                                     text_matrix[1],
                                     text_matrix[2],
                                     text_matrix[3],
-                                    text_matrix[4] + start_w * text_matrix[0],
-                                    text_matrix[5] + start_w * text_matrix[1],
+                                    text_matrix[4] + start_w * horizontal_scale * text_matrix[0],
+                                    text_matrix[5] + start_w * horizontal_scale * text_matrix[1],
                                 ];
                                 let combined =
                                     multiply_matrices(&rise_adjusted(&offset_tm, text_rise), &ctm);
-                                let geometry = run_geometry(
+                                let geometry = scaled_run_geometry(
                                     &combined,
                                     font_info.map(|_| end_w - start_w),
                                     // A measured sub-run's advance is the `Some`
@@ -939,6 +1056,7 @@ pub(crate) fn extract_page_text_items(
                                     },
                                     rendered_size.copysign(current_font_size),
                                     type3_y_flips.contains(&current_font),
+                                    horizontal_scale,
                                 );
                                 if horizontal_advance
                                     && crate::text_utils::is_visual_rtl_candidate(text)
@@ -982,8 +1100,8 @@ pub(crate) fn extract_page_text_items(
                         }
                         // Always advance the text matrix by the total width —
                         // measured, or estimated for a font without metrics.
-                        text_matrix[4] += total_width_ts * text_matrix[0];
-                        text_matrix[5] += total_width_ts * text_matrix[1];
+                        text_matrix[4] += total_width_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += total_width_ts * horizontal_scale * text_matrix[1];
                     }
                 }
             }
@@ -1011,6 +1129,7 @@ pub(crate) fn extract_page_text_items(
                     actual_text_glyph_rise = Some(text_rise);
                     actual_text_glyph_font = Some(current_font.clone());
                     actual_text_glyph_font_size = Some(current_font_size);
+                    actual_text_glyph_scale = Some(horizontal_scale);
                 }
                 if suppress_glyph_extraction {
                     actual_text_glyph_count += shown_glyph_count(
@@ -1024,7 +1143,7 @@ pub(crate) fn extract_page_text_items(
                         current_font_size * type3_scales.get(&current_font).copied().unwrap_or(1.0),
                         char_spacing,
                         word_spacing,
-                    );
+                    ) * horizontal_scale;
                 }
                 // Advance width, as for Tj — without it the item stays
                 // zero-width and geometric underline/strikeout detection
@@ -1053,6 +1172,22 @@ pub(crate) fn extract_page_text_items(
                     char_spacing,
                     word_spacing,
                 );
+                if suppress_glyph_extraction && glyph_count > 0 {
+                    let combined = multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
+                    let rendered_size = effective_font_size(current_font_size, &combined)
+                        * type3_scales.get(&current_font).copied().unwrap_or(1.0);
+                    actual_text_bounds.include(
+                        scaled_run_geometry(
+                            &combined,
+                            w_ts_opt,
+                            estimate_ts,
+                            rendered_size.copysign(current_font_size),
+                            type3_y_flips.contains(&current_font),
+                            horizontal_scale,
+                        ),
+                        horizontal_scale,
+                    );
+                }
                 if text_rendering_mode == 3
                     && !include_invisible
                     && op
@@ -1082,11 +1217,13 @@ pub(crate) fn extract_page_text_items(
                         if !text.trim().is_empty() {
                             let combined =
                                 multiply_matrices(&rise_adjusted(&text_matrix, text_rise), &ctm);
-                            rotation_votes
-                                .cast_direction(reading_direction(&combined, current_font_size));
+                            rotation_votes.cast_direction(reading_direction(
+                                &combined,
+                                current_font_size * horizontal_scale,
+                            ));
                             let rendered_size = effective_font_size(current_font_size, &combined)
                                 * type3_scales.get(&current_font).copied().unwrap_or(1.0);
-                            let geometry = run_geometry(
+                            let geometry = scaled_run_geometry(
                                 &combined,
                                 w_ts_opt,
                                 if glyph_count > 0 {
@@ -1096,6 +1233,7 @@ pub(crate) fn extract_page_text_items(
                                 },
                                 rendered_size.copysign(current_font_size),
                                 type3_y_flips.contains(&current_font),
+                                horizontal_scale,
                             );
                             let base_font = font_base_names
                                 .get(&current_font)
@@ -1108,7 +1246,7 @@ pub(crate) fn extract_page_text_items(
                             if crate::text_utils::is_visual_rtl_candidate(&text)
                                 && combined[0].abs() > combined[1].abs()
                             {
-                                if combined[0] > 0.0 {
+                                if combined[0] * horizontal_scale > 0.0 {
                                     rtl_visual_candidates.push(items.len());
                                 } else {
                                     rtl_logical_ops += 1;
@@ -1144,8 +1282,8 @@ pub(crate) fn extract_page_text_items(
                 // Advance regardless of visibility so later show-text
                 // operators on the same line stay positioned (as for Tj).
                 let cursor_ts = w_ts_opt.unwrap_or(estimate_ts);
-                text_matrix[4] += cursor_ts * text_matrix[0];
-                text_matrix[5] += cursor_ts * text_matrix[1];
+                text_matrix[4] += cursor_ts * horizontal_scale * text_matrix[0];
+                text_matrix[5] += cursor_ts * horizontal_scale * text_matrix[1];
             }
             "Do" => {
                 // XObject invocation - could be an image or form
@@ -1198,6 +1336,7 @@ pub(crate) fn extract_page_text_items(
                                         include_invisible,
                                         text_rendering_mode,
                                         text_rise,
+                                        horizontal_scale,
                                         &mut cmap_decisions,
                                         style_cache,
                                         form_budget,
@@ -1257,6 +1396,8 @@ pub(crate) fn extract_page_text_items(
                 if actual_text.is_some() {
                     suppress_glyph_extraction = true;
                     actual_text_start_tm = Some(text_matrix);
+                    actual_text_start_scale = horizontal_scale;
+                    actual_text_glyph_scale = None;
                     actual_text_start_rise = text_rise;
                     actual_text_glyph_tm = None; // reset — will be captured at first Tj/TJ
                     actual_text_glyph_rise = None;
@@ -1265,6 +1406,7 @@ pub(crate) fn extract_page_text_items(
                     actual_text_glyphs_measured = true;
                     actual_text_estimate_ts = 0.0;
                     actual_text_glyph_count = 0;
+                    actual_text_bounds = ActualTextBounds::default();
                 }
                 marked_content_stack.push(MarkedContentEntry { actual_text, mcid });
             }
@@ -1320,19 +1462,30 @@ pub(crate) fn extract_page_text_items(
                                         None
                                     }
                                 };
-                            let geometry = run_geometry(
+                            // The cursor displacement and accumulated estimate
+                            // already include each painted run's Tz. Only its
+                            // sign is needed here to preserve glyph orientation.
+                            let paint_scale = actual_text_glyph_scale
+                                .take()
+                                .unwrap_or(actual_text_start_scale);
+                            let reflection = if paint_scale < 0.0 { -1.0 } else { 1.0 };
+                            let mut geometry = scaled_run_geometry(
                                 &combined,
-                                advance_ts,
+                                advance_ts.map(|advance| advance * reflection),
                                 // Size the estimate from what was painted, each
                                 // run at its own size and spacing; the
                                 // replacement text is only what gets emitted.
-                                actual_text_estimate_ts,
+                                actual_text_estimate_ts * reflection,
                                 rendered_size.copysign(paint_size),
                                 type3_y_flips.contains(&paint_font),
+                                reflection,
                             );
+                            actual_text_bounds.apply_to(&mut geometry);
                             if !at.trim().is_empty() {
-                                rotation_votes
-                                    .cast_direction(reading_direction(&combined, paint_size));
+                                rotation_votes.cast_direction(reading_direction(
+                                    &combined,
+                                    paint_size * paint_scale,
+                                ));
                                 let base_font = font_base_names
                                     .get(&current_font)
                                     .map(|s| s.as_str())

--- a/src/extractor/geometry.rs
+++ b/src/extractor/geometry.rs
@@ -138,6 +138,31 @@ pub(crate) fn reading_direction(combined: &[f32; 6], font_size: f32) -> (f32, f3
     }
 }
 
+/// Apply the text state's horizontal scale (`Tz`) to a run without scaling
+/// its height. Advances and spacing are measured before `Tz`; a negative
+/// scale also reflects the baseline axis used to determine orientation.
+pub(crate) fn scaled_run_geometry(
+    combined: &[f32; 6],
+    advance_ts: Option<f32>,
+    fallback_advance_ts: f32,
+    em: f32,
+    glyph_up_flipped: bool,
+    horizontal_scale: f32,
+) -> RunGeometry {
+    let mut reflected = *combined;
+    if horizontal_scale < 0.0 {
+        reflected[0] = -reflected[0];
+        reflected[1] = -reflected[1];
+    }
+    run_geometry(
+        &reflected,
+        advance_ts.map(|advance| advance * horizontal_scale.abs()),
+        fallback_advance_ts * horizontal_scale.abs(),
+        em,
+        glyph_up_flipped,
+    )
+}
+
 /// `em` is the rendered font size, negative when the `Tf` size was.
 pub(crate) fn run_geometry(
     combined: &[f32; 6],

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -14,7 +14,7 @@ use super::fonts::{
     CMapDecisionCache, FontStyleCache,
 };
 use super::geometry::{
-    baseline_rotation, estimated_advance_ts, reading_direction, rise_adjusted, run_geometry,
+    baseline_rotation, estimated_advance_ts, reading_direction, rise_adjusted, scaled_run_geometry,
 };
 use super::{get_number, image_bbox_from_ctm, multiply_matrices};
 
@@ -243,6 +243,7 @@ pub(crate) fn extract_form_xobject_text(
     include_invisible: bool,
     inherited_render_mode: i32,
     inherited_text_rise: f32,
+    inherited_horizontal_scale: f32,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     budget: &mut FormWalkBudget,
@@ -256,6 +257,7 @@ pub(crate) fn extract_form_xobject_text(
         include_invisible,
         inherited_render_mode,
         inherited_text_rise,
+        inherited_horizontal_scale,
         cmap_decisions,
         style_cache,
         0,
@@ -273,6 +275,7 @@ fn extract_form_xobject_text_inner(
     include_invisible: bool,
     inherited_render_mode: i32,
     inherited_text_rise: f32,
+    inherited_horizontal_scale: f32,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     depth: u8,
@@ -403,6 +406,7 @@ fn extract_form_xobject_text_inner(
     let mut word_spacing: f32 = 0.0; // Tw parameter
                                      // Ts parameter (baseline shift, unscaled). Text state is graphics state,
                                      // so a form starts with the rise in force where it was invoked.
+    let mut horizontal_scale: f32 = inherited_horizontal_scale;
     let mut text_rise: f32 = inherited_text_rise;
     // Tr is graphics state, so a form starts in the mode the invoking stream
     // left it in: `3 Tr` set on the page or in an outer form hides the text
@@ -419,6 +423,7 @@ fn extract_form_xobject_text_inner(
         ctm: [f32; 6],
         char_spacing: f32,
         word_spacing: f32,
+        horizontal_scale: f32,
         text_rise: f32,
         text_rendering_mode: i32,
         text_leading: f32,
@@ -438,6 +443,7 @@ fn extract_form_xobject_text_inner(
                     ctm,
                     char_spacing,
                     word_spacing,
+                    horizontal_scale,
                     text_rise,
                     text_rendering_mode,
                     text_leading,
@@ -451,6 +457,7 @@ fn extract_form_xobject_text_inner(
                     ctm = saved.ctm;
                     char_spacing = saved.char_spacing;
                     word_spacing = saved.word_spacing;
+                    horizontal_scale = saved.horizontal_scale;
                     text_rise = saved.text_rise;
                     text_rendering_mode = saved.text_rendering_mode;
                     text_leading = saved.text_leading;
@@ -484,6 +491,7 @@ fn extract_form_xobject_text_inner(
                                         include_invisible,
                                         text_rendering_mode,
                                         text_rise,
+                                        horizontal_scale,
                                         cmap_decisions,
                                         style_cache,
                                         depth + 1,
@@ -569,6 +577,13 @@ fn extract_form_xobject_text_inner(
                 // the caller asked for the hidden layer.
                 if let Some(mode) = op.operands.first().and_then(get_number) {
                     text_rendering_mode = mode as i32;
+                }
+            }
+            "Tz" => {
+                if let Some(scale) = op.operands.first().and_then(get_number) {
+                    if scale.is_finite() {
+                        horizontal_scale = scale / 100.0;
+                    }
                 }
             }
             "Ts" => {
@@ -681,8 +696,8 @@ fn extract_form_xobject_text_inner(
                                     char_spacing,
                                     word_spacing,
                                 );
-                                text_matrix[4] += w_ts * text_matrix[0];
-                                text_matrix[5] += w_ts * text_matrix[1];
+                                text_matrix[4] += w_ts * horizontal_scale * text_matrix[0];
+                                text_matrix[5] += w_ts * horizontal_scale * text_matrix[1];
                             }
                         } else {
                             // No width metrics: move by the estimate the run
@@ -695,8 +710,8 @@ fn extract_form_xobject_text_inner(
                                 char_spacing,
                                 word_spacing,
                             );
-                            text_matrix[4] += estimate_ts * text_matrix[0];
-                            text_matrix[5] += estimate_ts * text_matrix[1];
+                            text_matrix[4] += estimate_ts * horizontal_scale * text_matrix[0];
+                            text_matrix[5] += estimate_ts * horizontal_scale * text_matrix[1];
                         }
                         continue;
                     }
@@ -741,22 +756,25 @@ fn extract_form_xobject_text_inner(
                         } else {
                             estimated_advance_ts(&text, em_ts)
                         };
-                        let geometry = run_geometry(
+                        let geometry = scaled_run_geometry(
                             &combined,
                             advance_ts,
                             fallback_ts,
                             rendered_size.copysign(current_font_size),
                             type3_y_flips.contains(&current_font),
+                            horizontal_scale,
                         );
                         // Without width metrics the cursor moves by the same
                         // estimate the run's box carries.
                         let cursor_ts = advance_ts.unwrap_or(fallback_ts);
-                        text_matrix[4] += cursor_ts * text_matrix[0];
-                        text_matrix[5] += cursor_ts * text_matrix[1];
+                        text_matrix[4] += cursor_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += cursor_ts * horizontal_scale * text_matrix[1];
                         // Only create text item for non-whitespace; whitespace
                         // still advances the text matrix above so gap detection works
                         if !text.trim().is_empty() {
-                            run_rotations.push(geometry.rotation);
+                            let (dir_x, dir_y) =
+                                reading_direction(&combined, current_font_size * horizontal_scale);
+                            run_rotations.push(baseline_rotation(dir_x, dir_y));
                             let base_font = font_base_names
                                 .get(&current_font)
                                 .map(|s| s.as_str())
@@ -773,7 +791,7 @@ fn extract_form_xobject_text_inner(
                             if crate::text_utils::is_visual_rtl_candidate(&text)
                                 && combined[0].abs() > combined[1].abs()
                             {
-                                if combined[0] > 0.0 {
+                                if combined[0] * horizontal_scale > 0.0 {
                                     rtl_visual_candidates.push(items.len());
                                 } else {
                                     *rtl_logical_ops += 1;
@@ -972,7 +990,8 @@ fn extract_form_xobject_text_inner(
                         }
                         if !sub_items.is_empty() {
                             let combined = multiply_matrices(&text_matrix, &ctm);
-                            let (dir_x, dir_y) = reading_direction(&combined, current_font_size);
+                            let (dir_x, dir_y) =
+                                reading_direction(&combined, current_font_size * horizontal_scale);
                             run_rotations.push(baseline_rotation(dir_x, dir_y));
                             let rendered_size = effective_font_size(current_font_size, &combined)
                                 * type3_scales.get(&current_font).copied().unwrap_or(1.0);
@@ -984,10 +1003,12 @@ fn extract_form_xobject_text_inner(
                                 .get(&current_font)
                                 .copied()
                                 .unwrap_or((false, false));
-                            let scale_x = text_matrix[0] * ctm[0] + text_matrix[1] * ctm[2];
+                            let scale_x = (text_matrix[0] * ctm[0] + text_matrix[1] * ctm[2])
+                                * horizontal_scale;
                             // Rotated matrices carry no horizontal evidence:
                             // stay neutral unless the advance is x-dominant.
-                            let scale_y = text_matrix[0] * ctm[1] + text_matrix[1] * ctm[3];
+                            let scale_y = (text_matrix[0] * ctm[1] + text_matrix[1] * ctm[3])
+                                * horizontal_scale;
                             let horizontal_advance = scale_x.abs() > scale_y.abs();
                             // The op-wide backtrack marker votes once per op —
                             // per-sub-run geometry (mirrored matrices) still
@@ -999,12 +1020,12 @@ fn extract_form_xobject_text_inner(
                                     text_matrix[1],
                                     text_matrix[2],
                                     text_matrix[3],
-                                    text_matrix[4] + start_w * text_matrix[0],
-                                    text_matrix[5] + start_w * text_matrix[1],
+                                    text_matrix[4] + start_w * horizontal_scale * text_matrix[0],
+                                    text_matrix[5] + start_w * horizontal_scale * text_matrix[1],
                                 ];
                                 let combined_mat =
                                     multiply_matrices(&rise_adjusted(&offset_tm, text_rise), &ctm);
-                                let geometry = run_geometry(
+                                let geometry = scaled_run_geometry(
                                     &combined_mat,
                                     font_info.map(|_| end_w - start_w),
                                     // A measured sub-run's advance is the `Some`
@@ -1033,6 +1054,7 @@ fn extract_form_xobject_text_inner(
                                     },
                                     rendered_size.copysign(current_font_size),
                                     type3_y_flips.contains(&current_font),
+                                    horizontal_scale,
                                 );
                                 if horizontal_advance
                                     && crate::text_utils::is_visual_rtl_candidate(text)
@@ -1076,8 +1098,8 @@ fn extract_form_xobject_text_inner(
                         }
                         // Always advance the text matrix by the total width —
                         // measured, or estimated for a font without metrics.
-                        text_matrix[4] += total_width_ts * text_matrix[0];
-                        text_matrix[5] += total_width_ts * text_matrix[1];
+                        text_matrix[4] += total_width_ts * horizontal_scale * text_matrix[0];
+                        text_matrix[5] += total_width_ts * horizontal_scale * text_matrix[1];
                     }
                 }
             }
@@ -1232,6 +1254,7 @@ mod tests {
             false,
             0,
             0.0,
+            1.0,
             &mut CMapDecisionCache::new(),
             &mut FontStyleCache::new(),
             budget,

--- a/tests/horizontal_scale.rs
+++ b/tests/horizontal_scale.rs
@@ -338,6 +338,121 @@ fn actual_text_unions_painted_bounds_when_horizontal_scales_change_sign() {
 }
 
 #[test]
+fn actual_text_unions_painted_bounds_when_font_sizes_change_sign() {
+    for (font, advance) in [("F1", 14.4), ("F2", 12.0)] {
+        for (shows, x, y, width, height) in [
+            (
+                format!("(AB) Tj /{font} -12 Tf (CD) Tj"),
+                100.0,
+                288.0,
+                advance,
+                24.0,
+            ),
+            (
+                format!("[(AB) -100 (CD)] TJ /{font} -12 Tf [(EFGH)] TJ"),
+                100.0,
+                288.0,
+                advance * 2.0 + 1.2,
+                24.0,
+            ),
+            (
+                format!("(AB) Tj /{font} -12 Tf 20 TL (CD) '"),
+                100.0 - advance,
+                268.0,
+                advance * 2.0,
+                44.0,
+            ),
+            (
+                format!("(AB) Tj q /{font} -12 Tf (CD) Tj Q (EF) Tj"),
+                100.0,
+                288.0,
+                advance,
+                24.0,
+            ),
+            // With a negative Tz, flipping Tf also reverses the advance.
+            (
+                format!("-100 Tz (AB) Tj /{font} -12 Tf (CD) Tj"),
+                100.0 - advance,
+                288.0,
+                advance,
+                24.0,
+            ),
+            // Flipping both signs preserves advance direction, but reverses
+            // glyph-up: the existing vertical bounds union must survive.
+            (
+                format!("(AB) Tj /{font} -12 Tf -100 Tz (CD) Tj"),
+                100.0,
+                288.0,
+                advance * 2.0,
+                24.0,
+            ),
+        ] {
+            let extracted = items(&pdf(
+                &format!("BT /{font} 12 Tf 100 Tz 1 0 0 1 100 300 Tm /Span << /ActualText (REPLACEMENT) >> BDC {shows} EMC ET"),
+                0,
+                "",
+                false,
+            ));
+            let text = find(&extracted, "REPLACEMENT");
+            close(text.x, x);
+            close(text.y, y);
+            close(text.width, width);
+            close(text.height, height);
+            assert_eq!(text.advance_known, font == "F1");
+        }
+    }
+}
+
+#[test]
+fn actual_text_zero_scale_does_not_vote_for_a_reflection() {
+    for (font, advance) in [("F1", 14.4), ("F2", 12.0)] {
+        for zero_scale in ["0", "-0.0"] {
+            let extracted = items(&pdf(
+                &format!("BT /{font} 12 Tf 100 Tz 1 0 0 1 100 300 Tm /Span << /ActualText (REPLACEMENT) >> BDC
+                    (AB) Tj q /{font} -12 Tf {zero_scale} Tz (CD) Tj Q (EF) Tj EMC ET"),
+                0,
+                "",
+                false,
+            ));
+            let text = find(&extracted, "REPLACEMENT");
+            close(text.x, 100.0);
+            close(text.y, 300.0);
+            close(text.width, advance * 2.0);
+            close(text.height, 12.0);
+            assert_eq!(text.advance_known, font == "F1");
+        }
+    }
+}
+
+#[test]
+fn actual_text_zero_scale_strokes_keep_their_vertical_reflection() {
+    for (font, advance) in [("F1", 14.4), ("F2", 12.0)] {
+        for zero_scale in ["0", "-0.0"] {
+            for render_mode in [1, 2, 5, 6] {
+                for show in ["(CD) Tj", "[(CD)] TJ", "20 TL (CD) '"] {
+                    let extracted = items(&pdf(
+                        &format!("BT /{font} 12 Tf 100 Tz 1 0 0 1 100 300 Tm /Span << /ActualText (REPLACEMENT) >> BDC
+                            (AB) Tj q /{font} -12 Tf {zero_scale} Tz {render_mode} Tr 2 w {show} Q (EF) Tj EMC ET"),
+                        0,
+                        "",
+                        false,
+                    ));
+                    let text = find(&extracted, "REPLACEMENT");
+                    let next_line = show.contains('\'');
+                    close(text.x, 100.0);
+                    close(text.y, if next_line { 268.0 } else { 288.0 });
+                    // Quote resets the cursor to the next line's start;
+                    // the other operators leave it after AB.
+                    close(text.width, if next_line { advance } else { advance * 2.0 });
+                    close(text.height, if next_line { 44.0 } else { 24.0 });
+                    assert_eq!(text.advance_known, font == "F1");
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn reflected_vertical_runs_choose_the_same_page_frame_inside_forms() {
     for scale in [-100, 100] {
         for font_size in [-12, 12] {

--- a/tests/horizontal_scale.rs
+++ b/tests/horizontal_scale.rs
@@ -1,0 +1,379 @@
+use lopdf::{dictionary, Document, Object, Stream};
+use pdf_inspector::{
+    extract_text_in_regions_mem, extract_text_with_positions_and_rotations_mem,
+    extract_text_with_positions_mem, PageRotation, TextItem,
+};
+
+/// Keep every glyph's advance at 600/1000 em so the geometry assertions
+/// follow the PDF operators directly, without depending on system fonts.
+fn pdf(content: &str, form_depth: usize, prefix: &str, crop: bool) -> Vec<u8> {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+        "FirstChar" => 0, "LastChar" => 255,
+        "Widths" => Object::Array((0..=255).map(|_| 600.into()).collect()),
+    });
+    let unknown_font_id = doc.add_object(dictionary! {
+        "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "SyntheticUnknown",
+    });
+    let mut resources = dictionary! {
+        "Font" => dictionary! { "F1" => font_id, "F2" => unknown_font_id },
+    };
+    let mut stream = content.to_owned();
+    for _ in 0..form_depth {
+        let form_id = doc.add_object(Stream::new(
+            dictionary! {
+                "Type" => "XObject", "Subtype" => "Form",
+                "BBox" => vec![0.into(), 0.into(), 600.into(), 400.into()],
+                "Resources" => resources,
+            },
+            stream.into_bytes(),
+        ));
+        resources = dictionary! { "XObject" => dictionary! { "Form" => form_id } };
+        stream = "/Form Do".to_owned();
+    }
+    let content_id = doc.add_object(Stream::new(
+        dictionary! {},
+        format!("{prefix}\n{stream}").into_bytes(),
+    ));
+    let mut page = dictionary! {
+        "Type" => "Page", "Parent" => pages_id,
+        "MediaBox" => vec![0.into(), 0.into(), 600.into(), 400.into()],
+        "Resources" => resources, "Contents" => content_id,
+    };
+    if crop {
+        page.set(
+            "CropBox",
+            vec![50.into(), 70.into(), 550.into(), 370.into()],
+        );
+        // The public native-coordinate contract deliberately does not apply
+        // /Rotate; text matrices and CropBox offsets still must compose.
+        page.set("Rotate", 90);
+    }
+    let page_id = doc.add_object(page);
+    doc.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages", "Count" => 1,
+            "Kids" => vec![page_id.into()],
+        }
+        .into(),
+    );
+    let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog_id);
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    bytes
+}
+
+fn items(bytes: &[u8]) -> Vec<TextItem> {
+    extract_text_with_positions_mem(bytes).unwrap()
+}
+
+fn find<'a>(items: &'a [TextItem], text: &str) -> &'a TextItem {
+    items
+        .iter()
+        .find(|item| item.text == text)
+        .unwrap_or_else(|| panic!("missing {text:?} in {items:?}"))
+}
+
+fn close(actual: f32, expected: f32) {
+    assert!(
+        (actual - expected).abs() < 0.002,
+        "expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn horizontal_scale_changes_width_without_changing_height() {
+    for depth in [0, 1, 2] {
+        for scale in [50, 100, 150, 200] {
+            let bytes = pdf(
+                &format!("BT /F1 12 Tf {scale} Tz 1 0 0 1 100 300 Tm (ABCDE) Tj ET"),
+                depth,
+                "",
+                false,
+            );
+            let extracted = items(&bytes);
+            let text = find(&extracted, "ABCDE");
+            close(text.x, 100.0);
+            close(text.width, 36.0 * scale as f32 / 100.0);
+            close(text.y, 300.0);
+            close(text.height, 12.0);
+            close(text.font_size, 12.0);
+        }
+    }
+}
+
+#[test]
+fn negative_font_size_and_scale_preserve_body_region_ownership() {
+    for depth in [0, 1, 2] {
+        let bytes = pdf(
+            "q 1 0 0 -1 0 400 cm -100 Tz
+             BT /F1 -12 Tf 1 0 0 1 250 100 Tm (Northstar survey recorded twelve seedlings.) Tj ET Q",
+            depth,
+            "",
+            false,
+        );
+        let extracted = items(&bytes);
+        let text = find(&extracted, "Northstar survey recorded twelve seedlings.");
+        close(text.x, 250.0);
+        close(text.width, text.text.len() as f32 * 7.2);
+        close(text.y, 300.0);
+        close(text.height, 12.0);
+        close(text.rotation, 0.0);
+
+        let regions = extract_text_in_regions_mem(
+            &bytes,
+            &[(
+                0,
+                vec![[10.0, 80.0, 50.0, 120.0], [245.0, 80.0, 560.0, 120.0]],
+            )],
+        )
+        .unwrap();
+        assert!(regions[0].regions[0].text.is_empty());
+        assert_eq!(regions[0].regions[1].text, text.text);
+        assert!(!regions[0].regions[1].needs_ocr);
+    }
+}
+
+#[test]
+fn negative_size_and_negative_scale_individually_still_run_left() {
+    for depth in [0, 1] {
+        for content in [
+            "q 1 0 0 -1 0 400 cm BT /F1 -12 Tf 100 Tz 1 0 0 1 300 100 Tm (ABCDE) Tj ET Q",
+            "BT /F1 12 Tf -100 Tz 1 0 0 1 300 300 Tm (ABCDE) Tj ET",
+        ] {
+            let extracted = items(&pdf(content, depth, "", false));
+            let text = find(&extracted, "ABCDE");
+            close(text.x, 264.0);
+            close(text.width, 36.0);
+            close(text.height, 12.0);
+        }
+    }
+}
+
+#[test]
+fn horizontal_scale_applies_to_tj_spacing_and_tj_array_cursor() {
+    for depth in [0, 1] {
+        for (show, expected_advance) in [
+            ("1 Tc 2 Tw (A B) Tj", 13.3),
+            ("[(AA) -100 (BB)] TJ", 15.0),
+            ("[(AA) -3000 (BB)] TJ", 32.4),
+            ("3 Tr (AB) Tj 0 Tr", 7.2),
+            ("3 Tr [(AA) -100 (BB)] TJ 0 Tr", 15.0),
+        ] {
+            let bytes = pdf(
+                &format!("BT /F1 12 Tf 50 Tz 1 0 0 1 100 300 Tm {show} 0 Tc 0 Tw 40 Ts /F1 10 Tf (FOLLOW) Tj ET"),
+                depth,
+                "",
+                false,
+            );
+            let extracted = items(&bytes);
+            let following = find(&extracted, "FOLLOW");
+            close(following.x, 100.0 + expected_advance);
+            close(following.width, 18.0);
+        }
+    }
+}
+
+#[test]
+fn horizontal_scale_restores_with_graphics_state_and_survives_text_blocks() {
+    let content = "50 Tz BT /F1 12 Tf 1 0 0 1 100 300 Tm (BEFORE) Tj ET
+        q 200 Tz BT /F1 12 Tf 1 0 0 1 100 250 Tm (INSIDE) Tj ET Q
+        BT /F1 12 Tf 1 0 0 1 100 200 Tm (AFTER) Tj ET";
+    for depth in [0, 1, 2] {
+        let extracted = items(&pdf(content, depth, "", false));
+        close(find(&extracted, "BEFORE").width, 21.6);
+        close(find(&extracted, "INSIDE").width, 86.4);
+        close(find(&extracted, "AFTER").width, 18.0);
+    }
+}
+
+#[test]
+fn nested_forms_inherit_the_invoking_streams_horizontal_scale() {
+    for depth in [1, 2, 3] {
+        let extracted = items(&pdf(
+            "BT /F1 12 Tf 1 0 0 1 100 300 Tm (INHERITED) Tj ET",
+            depth,
+            "50 Tz",
+            false,
+        ));
+        close(find(&extracted, "INHERITED").width, 32.4);
+    }
+}
+
+#[test]
+fn horizontal_scale_composes_with_rotated_runs_and_visible_page_offsets() {
+    // Three horizontal shows keep this a page with marginalia rather than
+    // a predominantly rotated page whose coordinate frame is rebased.
+    let content = "BT /F1 12 Tf 50 Tz 0 1 -1 0 300 150 Tm (SIDE) Tj ET
+        BT /F1 12 Tf 100 Tz 1 0 0 1 100 300 Tm (FIRST) Tj ET
+        BT /F1 12 Tf 1 0 0 1 100 250 Tm (SECOND) Tj ET
+        BT /F1 12 Tf 1 0 0 1 100 200 Tm (THIRD) Tj ET";
+    for depth in [0, 1] {
+        let extracted = items(&pdf(content, depth, "", true));
+        let side = find(&extracted, "SIDE");
+        close(side.x, 238.0);
+        close(side.y, 80.0);
+        close(side.width, 12.0);
+        close(side.height, 14.4);
+        close(side.rotation, 90.0);
+    }
+}
+
+#[test]
+fn actual_text_uses_the_scale_at_the_painted_runs_not_at_emc() {
+    for show in ["(ABCDE) Tj", "[(AB) -100 (CDE)] TJ"] {
+        let bytes = pdf(
+            &format!("q 1 0 0 -1 0 400 cm BT /F1 -12 Tf -100 Tz 1 0 0 1 250 100 Tm /Span << /ActualText (REPLACEMENT) >> BDC {show} 50 Tz EMC ET Q"),
+            0,
+            "",
+            false,
+        );
+        let extracted = items(&bytes);
+        let text = find(&extracted, "REPLACEMENT");
+        close(text.x, 250.0);
+        close(text.width, if show.contains("TJ") { 37.2 } else { 36.0 });
+        close(text.rotation, 0.0);
+    }
+}
+
+#[test]
+fn horizontal_scale_applies_to_metricless_estimates_and_zero_scale() {
+    for depth in [0, 1] {
+        for (font_size, scale, expected_width) in [(12, 50, 15.0), (-12, -100, 30.0), (12, 0, 0.0)]
+        {
+            let extracted = items(&pdf(
+                &format!("BT /F2 {font_size} Tf {scale} Tz 1 0 0 1 100 300 Tm (ABCDE) Tj 40 Ts /F1 {font_size} Tf (FOLLOW) Tj ET"),
+                depth,
+                "",
+                false,
+            ));
+            let text = find(&extracted, "ABCDE");
+            close(text.x, 100.0);
+            close(text.width, expected_width);
+            assert!(!text.advance_known);
+            close(find(&extracted, "FOLLOW").x, 100.0 + expected_width);
+        }
+    }
+}
+
+#[test]
+fn metricless_tj_array_scales_kerning_and_following_cursor() {
+    for depth in [0, 1] {
+        let extracted = items(&pdf(
+            "BT /F2 12 Tf 50 Tz 1 0 0 1 100 300 Tm [(AA) -100 (BB)] TJ 40 Ts /F1 12 Tf (FOLLOW) Tj ET",
+            depth,
+            "",
+            false,
+        ));
+        close(find(&extracted, "FOLLOW").x, 112.6);
+    }
+}
+
+#[test]
+fn actual_text_estimate_accumulates_each_painted_runs_scale() {
+    let extracted = items(&pdf(
+        "BT /F2 12 Tf 50 Tz 1 0 0 1 100 300 Tm /Span << /ActualText (REPLACEMENT) >> BDC
+         (ABC) Tj 200 Tz (DE) Tj -100 Tz EMC ET",
+        0,
+        "",
+        false,
+    ));
+    let text = find(&extracted, "REPLACEMENT");
+    close(text.x, 100.0);
+    close(text.width, 33.0);
+    assert!(!text.advance_known);
+}
+
+#[test]
+fn actual_text_unions_painted_bounds_when_horizontal_scales_change_sign() {
+    for (font, advance) in [("F1", 14.4), ("F2", 12.0)] {
+        for (shows, x, y, width, height) in [
+            (
+                "100 Tz (AB) Tj -100 Tz (CD) Tj",
+                100.0,
+                300.0,
+                advance,
+                12.0,
+            ),
+            (
+                "100 Tz [(AB) -100 (CD)] TJ -100 Tz (EFGH) Tj",
+                100.0,
+                300.0,
+                advance * 2.0 + 1.2,
+                12.0,
+            ),
+            (
+                "100 Tz (AB) Tj -100 Tz 20 TL (CD) '",
+                100.0 - advance,
+                280.0,
+                advance * 2.0,
+                32.0,
+            ),
+            (
+                "100 Tz (AB) Tj q -100 Tz (CD) Tj Q (EF) Tj",
+                100.0,
+                300.0,
+                advance,
+                12.0,
+            ),
+        ] {
+            let extracted = items(&pdf(
+                &format!("BT /{font} 12 Tf 1 0 0 1 100 300 Tm /Span << /ActualText (REPLACEMENT) >> BDC {shows} EMC ET"),
+                0,
+                "",
+                false,
+            ));
+            let text = find(&extracted, "REPLACEMENT");
+            close(text.x, x);
+            close(text.y, y);
+            close(text.width, width);
+            close(text.height, height);
+            assert_eq!(text.advance_known, font == "F1");
+        }
+    }
+}
+
+#[test]
+fn reflected_vertical_runs_choose_the_same_page_frame_inside_forms() {
+    for scale in [-100, 100] {
+        for font_size in [-12, 12] {
+            for baseline_y in [-1, 1] {
+                for show in ["(FIRST) Tj", "[(FIRST)] TJ"] {
+                    let content = format!(
+                        "BT /F1 {font_size} Tf {scale} Tz 0 {baseline_y} -1 0 300 300 Tm {show} ET
+                         BT /F1 {font_size} Tf {scale} Tz 0 {baseline_y} -1 0 350 300 Tm (SECOND) Tj ET"
+                    );
+                    let (reference, frames) =
+                        extract_text_with_positions_and_rotations_mem(&pdf(&content, 0, "", false))
+                            .unwrap();
+                    let expected_frame = if baseline_y * font_size * scale > 0 {
+                        PageRotation::Ccw
+                    } else {
+                        PageRotation::Cw
+                    };
+                    assert_eq!(frames.get(&1), Some(&expected_frame));
+                    for depth in [1, 2] {
+                        let (extracted, frames) = extract_text_with_positions_and_rotations_mem(
+                            &pdf(&content, depth, "", false),
+                        )
+                        .unwrap();
+                        assert_eq!(frames.get(&1), Some(&expected_frame));
+                        for text in ["FIRST", "SECOND"] {
+                            let expected = find(&reference, text);
+                            let actual = find(&extracted, text);
+                            close(actual.x, expected.x);
+                            close(actual.y, expected.y);
+                            close(actual.width, expected.width);
+                            close(actual.height, expected.height);
+                            close(actual.rotation, expected.rotation);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Honor PDF text horizontal scaling (`Tz`) when calculating text bounds and advances, including reflected text and nested Form XObjects. Preserve the scale through graphics-state changes and retain painted bounds when font size or horizontal scaling reflects glyphs inside `ActualText`, preventing scaled text from being assigned to unrelated regions.

Corrected coordinates can expose existing whitespace and layout inference edge cases in tightly spaced text; those heuristics are unchanged by this correction.
