### PR TITLE
fix(extractor): preserve stroke-simulated bold

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -22,6 +22,7 @@ use super::geometry::{
     estimated_advance_for_glyphs, estimated_advance_ts, normalize_degrees, reading_direction,
     rise_adjusted, run_geometry, PageRotation,
 };
+use super::text_paint::{PaintResources, TextPaint};
 use super::underline::UnderlineLine;
 use super::xobjects::{extract_form_xobject_text, get_page_xobjects, FormWalkBudget, XObjectType};
 use super::{get_number, image_bbox_from_ctm, multiply_matrices};
@@ -202,6 +203,21 @@ pub(crate) fn extract_page_text_items(
 
     // Get fonts for encoding
     let fonts = doc.get_page_fonts(page_id).unwrap_or_default();
+    let paint_resources = PaintResources::page(doc, page_id);
+    // Unknown font resources may be Type3; infer stroke weight only for
+    // positively resolved ordinary text fonts.
+    let paintable_fonts: std::collections::HashSet<String> = fonts
+        .iter()
+        .filter(|(_, font)| {
+            font.get(b"Subtype")
+                .ok()
+                .and_then(|o| o.as_name().ok())
+                .is_some_and(|subtype| {
+                    matches!(subtype, b"Type0" | b"Type1" | b"MMType1" | b"TrueType")
+                })
+        })
+        .map(|(name, _)| String::from_utf8_lossy(name).into_owned())
+        .collect();
 
     // Build font encoding maps from Differences arrays
     let (font_encodings, has_gid_fonts) = build_font_encodings(doc, &fonts, font_cmaps);
@@ -330,11 +346,13 @@ pub(crate) fn extract_page_text_items(
                                           // so an include_invisible retry is attempted only when it can recover.
     let mut skipped_invisible = false;
     let mut line_width: f32 = 1.0;
+    let mut text_paint = TextPaint::default();
     #[derive(Clone)]
     struct SavedGraphicsState {
         ctm: [f32; 6],
         text_rendering_mode: i32,
         line_width: f32,
+        text_paint: TextPaint,
         char_spacing: f32,
         word_spacing: f32,
         text_rise: f32,
@@ -387,6 +405,7 @@ pub(crate) fn extract_page_text_items(
 
     for op in &content.operations {
         trace!("{} {:?}", op.operator, op.operands);
+        text_paint.observe(&op.operator, &op.operands, &paint_resources);
         match op.operator.as_str() {
             "q" => {
                 // Save graphics state
@@ -394,6 +413,7 @@ pub(crate) fn extract_page_text_items(
                     ctm,
                     text_rendering_mode,
                     line_width,
+                    text_paint,
                     char_spacing,
                     word_spacing,
                     text_rise,
@@ -408,6 +428,7 @@ pub(crate) fn extract_page_text_items(
                     ctm = saved.ctm;
                     text_rendering_mode = saved.text_rendering_mode;
                     line_width = saved.line_width;
+                    text_paint = saved.text_paint;
                     char_spacing = saved.char_spacing;
                     word_spacing = saved.word_spacing;
                     text_rise = saved.text_rise;
@@ -440,6 +461,8 @@ pub(crate) fn extract_page_text_items(
                 in_text_block = true;
                 text_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
                 line_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+                // Keep the existing invisible-layer extraction policy. The
+                // separate paint state retains Tr for weight inference.
                 text_rendering_mode = 0;
             }
             "ET" => {
@@ -667,7 +690,15 @@ pub(crate) fn extract_page_text_items(
                                 font_tag: current_font.clone(),
                                 font_size: rendered_size,
                                 page: page_num,
-                                is_bold: is_bold_font(base_font) || desc_bold,
+                                is_bold: is_bold_font(base_font)
+                                    || desc_bold
+                                    || (paintable_fonts.contains(&current_font)
+                                        && text_paint.adds_bold(
+                                            &text,
+                                            rendered_size,
+                                            base_font,
+                                            &ctm,
+                                        )),
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
@@ -968,7 +999,15 @@ pub(crate) fn extract_page_text_items(
                                     font_tag: current_font.clone(),
                                     font_size: rendered_size,
                                     page: page_num,
-                                    is_bold: is_bold_font(base_font) || desc_bold,
+                                    is_bold: is_bold_font(base_font)
+                                        || desc_bold
+                                        || (paintable_fonts.contains(&current_font)
+                                            && text_paint.adds_bold(
+                                                text,
+                                                rendered_size,
+                                                base_font,
+                                                &ctm,
+                                            )),
                                     is_italic: is_italic_font(base_font) || desc_italic,
                                     is_underline: false,
                                     is_strikeout: false,
@@ -1128,7 +1167,15 @@ pub(crate) fn extract_page_text_items(
                                 font_tag: current_font.clone(),
                                 font_size: rendered_size,
                                 page: page_num,
-                                is_bold: is_bold_font(base_font) || desc_bold,
+                                is_bold: is_bold_font(base_font)
+                                    || desc_bold
+                                    || (paintable_fonts.contains(&current_font)
+                                        && text_paint.adds_bold(
+                                            &text,
+                                            rendered_size,
+                                            base_font,
+                                            &ctm,
+                                        )),
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
@@ -1198,6 +1245,7 @@ pub(crate) fn extract_page_text_items(
                                         include_invisible,
                                         text_rendering_mode,
                                         text_rise,
+                                        text_paint,
                                         &mut cmap_decisions,
                                         style_cache,
                                         form_budget,
@@ -1946,6 +1994,203 @@ mod tests {
         )
         .unwrap();
         items
+    }
+
+    #[test]
+    fn painted_bold_survives_text_objects_and_graphics_state() {
+        let items = extract_simple_items(
+            b"
+            0.3 w 2 Tr BT /F1 12 Tf 72 700 Td (Lead) Tj ET
+            BT /F1 12 Tf 72 680 Td (Still bold) Tj ET
+            q 0 Tr BT /F1 12 Tf 72 660 Td (Plain) Tj ET Q
+            BT /F1 12 Tf 72 640 Td (Restored) Tj ET
+            0 Tr BT /F1 12 Tf 72 620 Td (Body) Tj ET",
+        );
+        let styles: Vec<_> = items.iter().map(|i| (i.text.as_str(), i.is_bold)).collect();
+        assert_eq!(
+            styles,
+            [
+                ("Lead", true),
+                ("Still bold", true),
+                ("Plain", false),
+                ("Restored", true),
+                ("Body", false)
+            ]
+        );
+    }
+
+    #[test]
+    fn painted_bold_covers_supported_page_show_operators() {
+        for show in ["(Styled) Tj", "[(Sty) (led)] TJ", "(Styled) '"] {
+            let content = format!("0.3 w 2 Tr BT /F1 12 Tf 72 700 Td {show} ET");
+            let items = extract_simple_items(content.as_bytes());
+            assert_eq!(items.len(), 1, "{show}: {items:?}");
+            assert_eq!(items[0].text, "Styled");
+            assert!(items[0].is_bold, "{show}: {items:?}");
+        }
+    }
+
+    #[test]
+    fn painted_bold_restores_paint_and_preserves_explicit_font_styles() {
+        let items = extract_simple_items(
+            b"0.3 w 2 Tr BT /F1 12 Tf 72 700 Td (Lead) Tj ET
+              q 1 0 0 RG BT /F1 12 Tf 72 680 Td (Outline) Tj ET Q
+              BT /F1 12 Tf 72 660 Td (Restored) Tj ET",
+        );
+        assert_eq!(
+            items.iter().map(|i| i.is_bold).collect::<Vec<_>>(),
+            [true, false, true]
+        );
+
+        for (subtype, name, expected_bold, expected_italic) in [
+            ("Type1", "Helvetica-BoldOblique", true, true),
+            ("Type3", "Helvetica", false, false),
+            ("Unknown", "Helvetica", false, false),
+            ("Type1", "Wingdings", false, false),
+        ] {
+            let (mut doc, page_id) =
+                simple_doc_with_content(b"0.3 w 2 Tr BT /F1 12 Tf 72 700 Td (A) Tj ET");
+            let font = doc.get_object_mut((1, 0)).unwrap().as_dict_mut().unwrap();
+            font.set("Subtype", Object::Name(subtype.as_bytes().to_vec()));
+            font.set("BaseFont", Object::Name(name.as_bytes().to_vec()));
+            let font_cmaps = FontCMaps::from_doc(&doc);
+            let ((items, _, _), _, _, _) = extract_page_text_items(
+                &doc,
+                page_id,
+                1,
+                &font_cmaps,
+                false,
+                &mut FontStyleCache::new(),
+                &mut FormWalkBudget::new(),
+            )
+            .unwrap();
+            assert_eq!(items.len(), 1, "{name}");
+            assert_eq!(items[0].is_bold, expected_bold, "{name}");
+            assert_eq!(items[0].is_italic, expected_italic, "{name}");
+        }
+    }
+
+    #[test]
+    fn stroke_only_clip_and_hairline_text_do_not_gain_bold() {
+        for setup in [
+            "0 Tr",
+            "1 Tr",
+            "3 Tr",
+            "4 Tr",
+            "5 Tr",
+            "7 Tr",
+            "0 w 2 Tr",
+            "0.001 w 2 Tr",
+            "1 0 0 RG 2 Tr",
+            "[1 2] 0 d 2 Tr",
+            "/Unknown gs 2 Tr",
+        ] {
+            let content = format!("{setup} BT /F1 12 Tf 72 700 Td (Body) Tj ET");
+            let items = extract_simple_items(content.as_bytes());
+            assert!(items.iter().all(|i| !i.is_bold), "{setup}: {items:?}");
+        }
+        let items = extract_simple_items(b"0.3 w 6 Tr BT /F1 12 Tf 72 700 Td (Weighted) Tj ET");
+        assert!(items[0].is_bold);
+    }
+
+    #[test]
+    fn painted_bold_preserves_word_boundary_and_plain_text() {
+        let items =
+            extract_simple_items(b"BT /F1 12 Tf 72 700 Td 0.3 w 2 Tr (Lead) Tj 0 Tr ( body) Tj ET");
+        assert_eq!(items.len(), 2);
+        let line = crate::types::TextLine {
+            items,
+            y: 700.0,
+            page: 1,
+            adaptive_threshold: 0.1,
+        };
+        assert_eq!(line.text(), "Lead body");
+        assert_eq!(
+            line.text_with_formatting(true, false, false),
+            "**Lead** body"
+        );
+    }
+
+    #[test]
+    fn painted_bold_preserves_invisible_layer_extraction_policy() {
+        let items = extract_simple_items(
+            b"0.3 w 3 Tr BT /F1 12 Tf 72 700 Td (First) Tj ET
+              BT /F1 12 Tf 72 680 Td 3 Tr (Hidden) Tj ET
+              BT /F1 12 Tf 72 660 Td (Layer body) Tj ET",
+        );
+        assert_eq!(
+            items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["First", "Layer body"]
+        );
+        assert!(items.iter().all(|i| !i.is_bold));
+    }
+
+    #[test]
+    fn unresolved_ancestor_type3_font_does_not_gain_painted_bold() {
+        use lopdf::{dictionary, Stream};
+
+        let (mut doc, page_id) =
+            simple_doc_with_content(b"0.3 w 2 Tr BT /F1 12 Tf 72 700 Td (A) Tj ET");
+        let glyph = doc.add_object(Stream::new(
+            dictionary! {},
+            b"600 0 0 0 600 700 d1 0 0 600 700 re f".to_vec(),
+        ));
+        let font = doc.get_object_mut((1, 0)).unwrap().as_dict_mut().unwrap();
+        font.set("Subtype", "Type3");
+        font.set(
+            "FontMatrix",
+            vec![
+                0.001.into(),
+                0.into(),
+                0.into(),
+                0.001.into(),
+                0.into(),
+                0.into(),
+            ],
+        );
+        font.set("FontBBox", vec![0.into(), 0.into(), 600.into(), 700.into()]);
+        font.set("CharProcs", dictionary! { "A" => Object::Reference(glyph) });
+        font.set(
+            "Encoding",
+            dictionary! { "Differences" => vec![65.into(), Object::Name(b"A".to_vec())] },
+        );
+
+        let resources = doc
+            .get_dictionary_mut(page_id)
+            .unwrap()
+            .remove(b"Resources")
+            .unwrap();
+        let catalog = doc.trailer.get(b"Root").unwrap().as_reference().unwrap();
+        let parent = doc
+            .get_dictionary(catalog)
+            .unwrap()
+            .get(b"Pages")
+            .unwrap()
+            .as_reference()
+            .unwrap();
+        doc.get_dictionary_mut(parent)
+            .unwrap()
+            .set("Resources", resources);
+        doc.get_dictionary_mut(page_id)
+            .unwrap()
+            .set("Parent", Object::Reference(parent));
+        // Direct ancestor resources are not resolved by the current font
+        // reader. An unresolved name must not bypass the Type3 exclusion.
+        assert!(doc.get_page_fonts(page_id).unwrap().is_empty());
+        let font_cmaps = FontCMaps::from_doc(&doc);
+        let ((items, _, _), _, _, _) = extract_page_text_items(
+            &doc,
+            page_id,
+            1,
+            &font_cmaps,
+            false,
+            &mut FontStyleCache::new(),
+            &mut FormWalkBudget::new(),
+        )
+        .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].text, "A");
+        assert!(!items[0].is_bold);
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -12,6 +12,7 @@ mod links;
 pub(crate) mod page_box;
 mod reading_order;
 mod scripts;
+mod text_paint;
 pub(crate) mod underline;
 mod xobjects;
 

--- a/src/extractor/text_paint.rs
+++ b/src/extractor/text_paint.rs
@@ -1,0 +1,443 @@
+//! Conservative recognition of weight added by painting a glyph twice.
+
+use std::collections::HashMap;
+
+use lopdf::{Dictionary, Document, Object, ObjectId};
+
+use super::get_number;
+
+#[derive(Clone, Copy, PartialEq)]
+enum ColorSpace {
+    Gray,
+    Rgb,
+    Cmyk,
+    Icc(ObjectId, usize),
+}
+
+impl ColorSpace {
+    fn components(self) -> usize {
+        match self {
+            Self::Gray => 1,
+            Self::Rgb => 3,
+            Self::Cmyk => 4,
+            Self::Icc(_, n) => n,
+        }
+    }
+}
+
+fn resolve<'a>(doc: &'a Document, mut obj: &'a Object) -> Option<&'a Object> {
+    for _ in 0..8 {
+        match obj {
+            Object::Reference(id) => obj = doc.get_object(*id).ok()?,
+            _ => return Some(obj),
+        }
+    }
+    None
+}
+
+fn device_space(name: &[u8]) -> Option<ColorSpace> {
+    match name {
+        b"DeviceGray" => Some(ColorSpace::Gray),
+        b"DeviceRGB" => Some(ColorSpace::Rgb),
+        b"DeviceCMYK" => Some(ColorSpace::Cmyk),
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct PaintResources {
+    spaces: HashMap<Vec<u8>, Option<ColorSpace>>,
+    harmless_states: HashMap<Vec<u8>, bool>,
+}
+
+impl PaintResources {
+    pub(crate) fn add(&mut self, doc: &Document, resources: &Dictionary) {
+        if let Some(spaces) = resources
+            .get(b"ColorSpace")
+            .ok()
+            .and_then(|o| resolve(doc, o))
+            .and_then(|o| o.as_dict().ok())
+        {
+            for (name, obj) in spaces {
+                let space = resolve(doc, obj).and_then(|obj| match obj {
+                    Object::Name(name) => device_space(name),
+                    Object::Array(a)
+                        if a.len() == 2 && a[0].as_name().ok() == Some(b"ICCBased") =>
+                    {
+                        let id = a[1].as_reference().ok()?;
+                        let profile = doc.get_object(id).ok()?.as_stream().ok()?;
+                        let n = profile.dict.get(b"N").ok()?.as_i64().ok()?;
+                        matches!(n, 1 | 3 | 4).then_some(ColorSpace::Icc(id, n as usize))
+                    }
+                    _ => None,
+                });
+                self.spaces.entry(name.clone()).or_insert(space);
+            }
+        }
+        if let Some(states) = resources
+            .get(b"ExtGState")
+            .ok()
+            .and_then(|o| resolve(doc, o))
+            .and_then(|o| o.as_dict().ok())
+        {
+            for (name, obj) in states {
+                let harmless = resolve(doc, obj)
+                    .and_then(|o| o.as_dict().ok())
+                    .is_some_and(|state| {
+                        state.iter().all(|(key, value)| {
+                            let Some(value) = resolve(doc, value) else {
+                                return false;
+                            };
+                            match key.as_slice() {
+                                b"Type" => value.as_name().ok() == Some(b"ExtGState"),
+                                b"SM" => get_number(value)
+                                    .is_some_and(|n| n.is_finite() && (0.0..=1.0).contains(&n)),
+                                b"OPM" => value.as_i64().is_ok_and(|n| matches!(n, 0 | 1)),
+                                _ => false,
+                            }
+                        })
+                    });
+                self.harmless_states.entry(name.clone()).or_insert(harmless);
+            }
+        }
+    }
+
+    pub(crate) fn page(doc: &Document, page_id: ObjectId) -> Self {
+        let mut result = Self::default();
+        if let Ok((own, inherited)) = doc.get_page_resources(page_id) {
+            if let Some(resources) = own {
+                result.add(doc, resources);
+            }
+            for id in inherited {
+                if let Ok(resources) = doc.get_dictionary(id) {
+                    result.add(doc, resources);
+                }
+            }
+        }
+        result
+    }
+
+    pub(crate) fn form(doc: &Document, form: &Dictionary) -> Self {
+        let mut result = Self::default();
+        if let Some(resources) = form
+            .get(b"Resources")
+            .ok()
+            .and_then(|o| resolve(doc, o))
+            .and_then(|o| o.as_dict().ok())
+        {
+            result.add(doc, resources);
+        }
+        result
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+struct Color {
+    space: ColorSpace,
+    values: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TextPaint {
+    // Paint semantics persist across BT/ET independently of the extractor's
+    // existing invisible-layer visibility policy.
+    rendering_mode: i32,
+    fill_space: Option<ColorSpace>,
+    stroke_space: Option<ColorSpace>,
+    fill: Option<Color>,
+    stroke: Option<Color>,
+    width: f32,
+    solid: bool,
+    known_compositing: bool,
+}
+
+impl Default for TextPaint {
+    fn default() -> Self {
+        let black = Some(Color {
+            space: ColorSpace::Gray,
+            values: [0.0; 4],
+        });
+        Self {
+            rendering_mode: 0,
+            fill_space: Some(ColorSpace::Gray),
+            stroke_space: Some(ColorSpace::Gray),
+            fill: black,
+            stroke: black,
+            width: 1.0,
+            solid: true,
+            known_compositing: true,
+        }
+    }
+}
+
+impl TextPaint {
+    pub(crate) fn observe(
+        &mut self,
+        operator: &str,
+        operands: &[Object],
+        resources: &PaintResources,
+    ) {
+        let set_color = |space: Option<ColorSpace>, operands: &[Object]| -> Option<Color> {
+            let space = space?;
+            if operands.len() != space.components() {
+                return None;
+            }
+            let mut values = [0.0; 4];
+            for (value, operand) in values.iter_mut().zip(operands) {
+                *value = get_number(operand)?;
+                if !value.is_finite() || !(0.0..=1.0).contains(value) {
+                    return None;
+                }
+            }
+            Some(Color { space, values })
+        };
+        match operator {
+            "Tr" => {
+                if let Some(mode) = operands.first().and_then(get_number) {
+                    self.rendering_mode = mode as i32;
+                }
+            }
+            "w" => self.width = operands.first().and_then(get_number).unwrap_or(f32::NAN),
+            "d" => {
+                self.solid = operands
+                    .first()
+                    .and_then(|o| o.as_array().ok())
+                    .is_some_and(|a| a.is_empty())
+            }
+            // Smoothness does not change paint. OPM alone cannot enable
+            // overprinting while the default disabled state is still known.
+            // Other entries may affect opacity, blending, masks or stroke
+            // geometry. Never clear an earlier unknown-state latch.
+            "gs" => {
+                self.known_compositing &= operands
+                    .first()
+                    .and_then(|o| o.as_name().ok())
+                    .and_then(|name| resources.harmless_states.get(name))
+                    .copied()
+                    .unwrap_or(false);
+            }
+            "cs" | "CS" => {
+                let space = operands
+                    .first()
+                    .and_then(|o| o.as_name().ok())
+                    .and_then(|n| {
+                        device_space(n).or_else(|| resources.spaces.get(n).copied().flatten())
+                    });
+                // Wait for an explicit colour; unknown/pattern spaces fail closed.
+                if operator == "cs" {
+                    self.fill_space = space;
+                    self.fill = None;
+                } else {
+                    self.stroke_space = space;
+                    self.stroke = None;
+                }
+            }
+            "g" | "rg" | "k" => {
+                self.fill_space = Some(match operator {
+                    "g" => ColorSpace::Gray,
+                    "rg" => ColorSpace::Rgb,
+                    _ => ColorSpace::Cmyk,
+                });
+                self.fill = set_color(self.fill_space, operands);
+            }
+            "G" | "RG" | "K" => {
+                self.stroke_space = Some(match operator {
+                    "G" => ColorSpace::Gray,
+                    "RG" => ColorSpace::Rgb,
+                    _ => ColorSpace::Cmyk,
+                });
+                self.stroke = set_color(self.stroke_space, operands);
+            }
+            "sc" | "scn" => self.fill = set_color(self.fill_space, operands),
+            "SC" | "SCN" => self.stroke = set_color(self.stroke_space, operands),
+            _ => {}
+        }
+    }
+
+    pub(crate) fn adds_bold(
+        &self,
+        text: &str,
+        rendered_size: f32,
+        font_name: &str,
+        ctm: &[f32; 6],
+    ) -> bool {
+        if !matches!(self.rendering_mode, 2 | 6) {
+            return false;
+        }
+        let family = font_name.to_ascii_lowercase();
+        let symbol_font = ["wingdings", "webdings", "zapfdingbats"]
+            .iter()
+            .any(|name| family.contains(name));
+        // Modes 2/6 fill and stroke; 1/5 merely outline and 7 only clips.
+        // Symbol-only runs are glyph drawings, not evidence of text emphasis.
+        if symbol_font
+            || !self.known_compositing
+            || !self.solid
+            || self.fill.is_none()
+            || self.fill != self.stroke
+            || !text.chars().any(char::is_alphanumeric)
+            || !self.width.is_finite()
+            || self.width <= 0.0
+            || !rendered_size.is_finite()
+            || rendered_size <= 0.0
+        {
+            return false;
+        }
+        // Stroke width is in user space, independent of the text matrix.
+        // A device hairline or a stroke below 1% of the em does not provide
+        // dependable evidence of extra weight. Require it on both CTM axes.
+        let determinant = ctm[0] * ctm[3] - ctm[1] * ctm[2];
+        if !ctm.iter().all(|v| v.is_finite()) || !determinant.is_finite() || determinant == 0.0 {
+            return false;
+        }
+        let scale = ctm[0].hypot(ctm[1]).min(ctm[2].hypot(ctm[3]));
+        let stroke = self.width * scale;
+        stroke.is_finite() && stroke >= rendered_size * 0.01
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::{content::Content, dictionary};
+
+    fn painted(ops: &[u8], resources: &PaintResources) -> TextPaint {
+        let mut paint = TextPaint {
+            rendering_mode: 2,
+            ..TextPaint::default()
+        };
+        for op in Content::decode(ops).unwrap().operations {
+            paint.observe(&op.operator, &op.operands, resources);
+        }
+        paint
+    }
+
+    const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+    #[test]
+    fn paint_requires_matching_known_colors_and_visible_weight() {
+        let resources = PaintResources::default();
+        for ops in [b"0.3 w".as_slice(), b"0.3 w 0 0.2 0.4 rg 0 0.2 0.4 RG"] {
+            assert!(painted(ops, &resources).adds_bold("Label", 12.0, "Regular", &IDENTITY));
+        }
+        for ops in [
+            b"0 w".as_slice(),
+            b"-1 w",
+            b"0.001 w",
+            b"0.3 w 1 G",
+            b"0.3 w /Unknown cs",
+            b"0.3 w /Unknown gs",
+            b"0.3 w [1] 0 d",
+        ] {
+            assert!(!painted(ops, &resources).adds_bold("Label", 12.0, "Regular", &IDENTITY));
+        }
+    }
+
+    #[test]
+    fn symbolic_fonts_and_glyphs_do_not_gain_semantic_emphasis() {
+        let paint = painted(b"0.3 w", &PaintResources::default());
+        for name in ["Wingdings-Regular", "ABCDEF+ZapfDingbats", "Webdings"] {
+            assert!(!paint.adds_bold("A", 12.0, name, &IDENTITY));
+        }
+        for glyph in ["✓", "\u{f0fc}", "•", ""] {
+            assert!(!paint.adds_bold(glyph, 12.0, "Regular", &IDENTITY));
+        }
+    }
+
+    #[test]
+    fn stroke_weight_uses_user_space_and_rejects_degenerate_geometry() {
+        let paint = painted(b"0.3 w", &PaintResources::default());
+        assert!(paint.adds_bold("Label", 6.0, "Regular", &[0.5, 0.0, 0.0, 0.5, 0.0, 0.0]));
+        for size in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            assert!(!paint.adds_bold("Label", size, "Regular", &IDENTITY));
+        }
+        for ctm in [
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0],
+            [f32::NAN, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.01, 0.0, 0.0, 0.01, 0.0, 0.0],
+        ] {
+            assert!(!paint.adds_bold("Label", 12.0, "Regular", &ctm));
+        }
+    }
+
+    #[test]
+    fn unsupported_local_color_space_shadows_parent_alias() {
+        let doc = Document::new();
+        let local = dictionary! { "ColorSpace" => dictionary! { "Tone" => "Pattern" } };
+        let parent = dictionary! { "ColorSpace" => dictionary! { "Tone" => "DeviceRGB" } };
+        let mut resources = PaintResources::default();
+        resources.add(&doc, &local);
+        resources.add(&doc, &parent);
+        let paint = painted(b"0.3 w /Tone cs 0 0 0 sc /Tone CS 0 0 0 SC", &resources);
+        assert!(!paint.adds_bold("Label", 12.0, "Regular", &IDENTITY));
+    }
+
+    #[test]
+    fn harmless_graphics_states_do_not_clear_unknown_compositing() {
+        let mut doc = Document::new();
+        let smooth = doc.add_object(dictionary! { "Type" => "ExtGState", "SM" => 0.02 });
+        let resources_dict = dictionary! { "ExtGState" => dictionary! {
+            "Smooth" => Object::Reference(smooth),
+            "OverprintMode" => dictionary! { "OPM" => 1 },
+            "Alpha" => dictionary! { "ca" => 0.5 },
+            "Blend" => dictionary! { "BM" => "Multiply" },
+            "Mask" => dictionary! { "SMask" => "None" },
+            "Overprint" => dictionary! { "OP" => true },
+            "Stroke" => dictionary! { "LW" => 1 },
+            "InvalidSmooth" => dictionary! { "SM" => 2 },
+            "NotFiniteSmooth" => dictionary! { "SM" => Object::Real(f32::NAN) },
+            "InvalidMode" => dictionary! { "OPM" => 2 },
+            "InvalidType" => dictionary! { "Type" => "Other" },
+        }};
+        let mut resources = PaintResources::default();
+        resources.add(&doc, &resources_dict);
+        assert!(painted(b"0.3 w /Smooth gs /OverprintMode gs", &resources)
+            .adds_bold("Label", 12.0, "Regular", &IDENTITY));
+        for name in [
+            "Alpha",
+            "Blend",
+            "Mask",
+            "Overprint",
+            "Stroke",
+            "InvalidSmooth",
+            "NotFiniteSmooth",
+            "InvalidMode",
+            "InvalidType",
+            "Missing",
+        ] {
+            let ops = format!("0.3 w /{name} gs /Smooth gs /OverprintMode gs");
+            assert!(
+                !painted(ops.as_bytes(), &resources).adds_bold("Label", 12.0, "Regular", &IDENTITY),
+                "{name}"
+            );
+        }
+
+        let mut shadowed = PaintResources::default();
+        shadowed.add(
+            &doc,
+            &dictionary! { "ExtGState" => dictionary! { "Smooth" => Object::Reference((999, 0)) } },
+        );
+        shadowed.add(&doc, &resources_dict);
+        assert!(
+            !painted(b"0.3 w /Smooth gs", &shadowed).adds_bold("Label", 12.0, "Regular", &IDENTITY)
+        );
+    }
+
+    #[test]
+    fn same_icc_profile_and_components_establish_same_paint() {
+        let mut doc = Document::new();
+        let profile = doc.add_object(lopdf::Stream::new(dictionary! { "N" => 3 }, vec![]));
+        let mut resources = PaintResources::default();
+        resources.add(
+            &doc,
+            &dictionary! { "ColorSpace" => dictionary! {
+                "Tone" => vec![Object::Name(b"ICCBased".to_vec()), Object::Reference(profile)]
+            }},
+        );
+        let paint = painted(
+            b"0.3 w /Tone cs 0 0.2 0.4 sc /Tone CS 0 0.2 0.4 SC",
+            &resources,
+        );
+        assert!(paint.adds_bold("Label", 12.0, "Regular", &IDENTITY));
+    }
+}

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -1132,7 +1132,7 @@ fn extract_form_xobject_text_inner(
 /// Get fonts from a Form XObject's Resources
 pub(crate) fn get_form_fonts<'a>(
     doc: &'a Document,
-    form_dict: &lopdf::Dictionary,
+    form_dict: &'a lopdf::Dictionary,
 ) -> std::collections::BTreeMap<Vec<u8>, &'a lopdf::Dictionary> {
     let mut fonts = std::collections::BTreeMap::new();
 
@@ -1168,10 +1168,13 @@ pub(crate) fn get_form_fonts<'a>(
 
     // Collect fonts
     for (name, value) in font_dict.iter() {
-        if let Ok(obj_ref) = value.as_reference() {
-            if let Ok(dict) = doc.get_dictionary(obj_ref) {
-                fonts.insert(name.clone(), dict);
-            }
+        let dict = match value {
+            Object::Reference(id) => doc.get_dictionary(*id).ok(),
+            Object::Dictionary(dict) => Some(dict),
+            _ => None,
+        };
+        if let Some(dict) = dict {
+            fonts.insert(name.clone(), dict);
         }
     }
 
@@ -1903,6 +1906,96 @@ BT 3 Tr /F1 12 Tf 0 1 -1 0 240 100 Tm [(ALSO) -3000 (HIDDEN)] TJ ET";
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].text, "Alpha");
         assert!(!items[0].is_bold);
+    }
+
+    #[test]
+    fn inline_form_fonts_match_referenced_style_and_geometry() {
+        for (subtype, name, mode, text, bold, italic) in [
+            ("Type1", "Helvetica", 2, "Alpha", true, false),
+            ("Type1", "Helvetica-BoldOblique", 0, "Alpha", true, true),
+            ("Type1", "Wingdings", 2, "A", false, false),
+            ("Type3", "Shape", 2, "A", false, false),
+        ] {
+            let content = format!("0.3 w {mode} Tr BT /F1 12 Tf 72 700 Td ({text}) Tj ET");
+            let (mut referenced_doc, page_id) =
+                doc_with_page_and_forms(b"/X1 Do", &[content.as_bytes()]);
+            let glyph = referenced_doc.add_object(Stream::new(
+                dictionary! {},
+                b"600 0 0 0 600 700 d1 0 0 600 700 re f".to_vec(),
+            ));
+            let font = referenced_doc.get_dictionary_mut((1, 0)).unwrap();
+            font.set("Subtype", Object::Name(subtype.as_bytes().to_vec()));
+            font.set("BaseFont", Object::Name(name.as_bytes().to_vec()));
+            if subtype == "Type3" {
+                font.set(
+                    "FontMatrix",
+                    vec![
+                        0.001.into(),
+                        0.into(),
+                        0.into(),
+                        0.001.into(),
+                        0.into(),
+                        0.into(),
+                    ],
+                );
+                font.set("FontBBox", vec![0.into(), 0.into(), 600.into(), 700.into()]);
+                font.set("CharProcs", dictionary! { "A" => Object::Reference(glyph) });
+                font.set(
+                    "Encoding",
+                    dictionary! { "Differences" => vec![65.into(), Object::Name(b"A".to_vec())] },
+                );
+            }
+            let direct_font = font.clone();
+            let mut inline_doc = referenced_doc.clone();
+            inline_doc
+                .get_object_mut((2, 0))
+                .unwrap()
+                .as_stream_mut()
+                .unwrap()
+                .dict
+                .get_mut(b"Resources")
+                .unwrap()
+                .as_dict_mut()
+                .unwrap()
+                .get_mut(b"Font")
+                .unwrap()
+                .as_dict_mut()
+                .unwrap()
+                .set("F1", direct_font);
+            let (referenced_items, _) = extract_page(&referenced_doc, page_id, false);
+            let (inline_items, _) = extract_page(&inline_doc, page_id, false);
+            assert_eq!(referenced_items.len(), 1, "{name}");
+            assert_eq!(inline_items.len(), 1, "{name}");
+            let expected = &referenced_items[0];
+            let actual = &inline_items[0];
+            assert_eq!(actual.text, text, "{name}");
+            assert_eq!((actual.is_bold, actual.is_italic), (bold, italic), "{name}");
+            assert_eq!(
+                (
+                    &actual.font,
+                    actual.font_size,
+                    actual.width,
+                    actual.height,
+                    actual.x,
+                    actual.y,
+                    actual.is_bold,
+                    actual.is_italic,
+                    actual.advance_known
+                ),
+                (
+                    &expected.font,
+                    expected.font_size,
+                    expected.width,
+                    expected.height,
+                    expected.x,
+                    expected.y,
+                    expected.is_bold,
+                    expected.is_italic,
+                    expected.advance_known
+                ),
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -1,6 +1,7 @@
 //! Form XObject and image XObject extraction.
 
 use super::fonts::descriptor_style_flags;
+use super::text_paint::{PaintResources, TextPaint};
 use crate::text_utils::{effective_font_size, expand_ligatures, is_bold_font, is_italic_font};
 use crate::tounicode::FontCMaps;
 use crate::types::{ItemType, TextItem};
@@ -243,6 +244,7 @@ pub(crate) fn extract_form_xobject_text(
     include_invisible: bool,
     inherited_render_mode: i32,
     inherited_text_rise: f32,
+    inherited_text_paint: TextPaint,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     budget: &mut FormWalkBudget,
@@ -256,6 +258,7 @@ pub(crate) fn extract_form_xobject_text(
         include_invisible,
         inherited_render_mode,
         inherited_text_rise,
+        inherited_text_paint,
         cmap_decisions,
         style_cache,
         0,
@@ -273,6 +276,7 @@ fn extract_form_xobject_text_inner(
     include_invisible: bool,
     inherited_render_mode: i32,
     inherited_text_rise: f32,
+    inherited_text_paint: TextPaint,
     cmap_decisions: &mut CMapDecisionCache,
     style_cache: &mut FontStyleCache,
     depth: u8,
@@ -311,6 +315,21 @@ fn extract_form_xobject_text_inner(
 
     // Get fonts from the Form's Resources
     let form_fonts = get_form_fonts(doc, &stream.dict);
+    let paint_resources = PaintResources::form(doc, &stream.dict);
+    // Unknown font resources may be Type3; infer stroke weight only for
+    // positively resolved ordinary text fonts.
+    let paintable_fonts: std::collections::HashSet<String> = form_fonts
+        .iter()
+        .filter(|(_, font)| {
+            font.get(b"Subtype")
+                .ok()
+                .and_then(|o| o.as_name().ok())
+                .is_some_and(|subtype| {
+                    matches!(subtype, b"Type0" | b"Type1" | b"MMType1" | b"TrueType")
+                })
+        })
+        .map(|(name, _)| String::from_utf8_lossy(name).into_owned())
+        .collect();
     let (font_encodings, _has_gid_fonts) = build_font_encodings(doc, &form_fonts, font_cmaps);
 
     // Build font width info for the form
@@ -408,6 +427,7 @@ fn extract_form_xobject_text_inner(
     // left it in: `3 Tr` set on the page or in an outer form hides the text
     // drawn here too.
     let mut text_rendering_mode: i32 = inherited_render_mode;
+    let mut text_paint = inherited_text_paint;
     let mut in_text_block = false;
     let mut fill_is_white = false;
     let mut ctm = base_ctm;
@@ -421,6 +441,7 @@ fn extract_form_xobject_text_inner(
         word_spacing: f32,
         text_rise: f32,
         text_rendering_mode: i32,
+        text_paint: TextPaint,
         text_leading: f32,
         current_font: String,
         current_font_size: f32,
@@ -432,6 +453,7 @@ fn extract_form_xobject_text_inner(
         if !budget.charge_operation() {
             break;
         }
+        text_paint.observe(&op.operator, &op.operands, &paint_resources);
         match op.operator.as_str() {
             "q" => {
                 ctm_stack.push(GraphicsState {
@@ -440,6 +462,7 @@ fn extract_form_xobject_text_inner(
                     word_spacing,
                     text_rise,
                     text_rendering_mode,
+                    text_paint,
                     text_leading,
                     current_font: current_font.clone(),
                     current_font_size,
@@ -453,6 +476,7 @@ fn extract_form_xobject_text_inner(
                     word_spacing = saved.word_spacing;
                     text_rise = saved.text_rise;
                     text_rendering_mode = saved.text_rendering_mode;
+                    text_paint = saved.text_paint;
                     text_leading = saved.text_leading;
                     current_font = saved.current_font;
                     current_font_size = saved.current_font_size;
@@ -484,6 +508,7 @@ fn extract_form_xobject_text_inner(
                                         include_invisible,
                                         text_rendering_mode,
                                         text_rise,
+                                        text_paint,
                                         cmap_decisions,
                                         style_cache,
                                         depth + 1,
@@ -793,7 +818,15 @@ fn extract_form_xobject_text_inner(
                                 font_tag: current_font.clone(),
                                 font_size: rendered_size,
                                 page: page_num,
-                                is_bold: is_bold_font(base_font) || desc_bold,
+                                is_bold: is_bold_font(base_font)
+                                    || desc_bold
+                                    || (paintable_fonts.contains(&current_font)
+                                        && text_paint.adds_bold(
+                                            &text,
+                                            rendered_size,
+                                            base_font,
+                                            &ctm,
+                                        )),
                                 is_italic: is_italic_font(base_font) || desc_italic,
                                 is_underline: false,
                                 is_strikeout: false,
@@ -1062,7 +1095,15 @@ fn extract_form_xobject_text_inner(
                                     font_tag: current_font.clone(),
                                     font_size: rendered_size,
                                     page: page_num,
-                                    is_bold: is_bold_font(base_font) || desc_bold,
+                                    is_bold: is_bold_font(base_font)
+                                        || desc_bold
+                                        || (paintable_fonts.contains(&current_font)
+                                            && text_paint.adds_bold(
+                                                text,
+                                                rendered_size,
+                                                base_font,
+                                                &ctm,
+                                            )),
                                     is_italic: is_italic_font(base_font) || desc_italic,
                                     is_underline: false,
                                     is_strikeout: false,
@@ -1232,6 +1273,7 @@ mod tests {
             false,
             0,
             0.0,
+            TextPaint::default(),
             &mut CMapDecisionCache::new(),
             &mut FontStyleCache::new(),
             budget,
@@ -1715,6 +1757,152 @@ BT 3 Tr /F1 12 Tf 0 1 -1 0 240 100 Tm [(ALSO) -3000 (HIDDEN)] TJ ET";
         let (items, _) = extract_page(&doc, page_id, true);
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].text, "Hidden");
+    }
+
+    #[test]
+    fn form_inherits_fill_stroke_weight_and_restores_it() {
+        let (doc, page_id) = doc_with_page_and_forms(
+            b"0.3 w 2 Tr BT ET /X1 Do 0 Tr /X2 Do",
+            &[
+                b"BT /F1 12 Tf 72 700 Td (Lead) Tj ET q 0 Tr BT /F1 12 Tf 72 680 Td (Plain) Tj ET Q BT /F1 12 Tf 72 660 Td (Restored) Tj ET",
+                b"BT /F1 12 Tf 72 640 Td (Body) Tj ET",
+            ],
+        );
+        let (items, _) = extract_page(&doc, page_id, false);
+        let styles: Vec<_> = items.iter().map(|i| (i.text.as_str(), i.is_bold)).collect();
+        assert_eq!(
+            styles,
+            [
+                ("Lead", true),
+                ("Plain", false),
+                ("Restored", true),
+                ("Body", false)
+            ]
+        );
+    }
+
+    #[test]
+    fn form_graphics_states_are_scoped_and_restored() {
+        let (mut doc, page_id) = doc_with_page_and_forms(
+            b"/State gs 0.3 w 2 Tr /X1 Do /X2 Do",
+            &[
+                b"/State gs BT /F1 12 Tf 72 700 Td (Plain) Tj ET",
+                b"/State gs BT /F1 12 Tf 72 680 Td (Lead) Tj ET
+                  q /Missing gs BT /F1 12 Tf 72 660 Td (Unknown) Tj ET Q
+                  BT /F1 12 Tf 72 640 Td (Restored) Tj ET",
+            ],
+        );
+        doc.get_dictionary_mut(page_id)
+            .unwrap()
+            .get_mut(b"Resources")
+            .unwrap()
+            .as_dict_mut()
+            .unwrap()
+            .set(
+                "ExtGState",
+                dictionary! { "State" => dictionary! { "SM" => 0.02 } },
+            );
+        for (id, state) in [
+            ((2, 0), dictionary! { "ca" => 0.5 }),
+            ((3, 0), dictionary! { "OPM" => 1 }),
+        ] {
+            doc.get_object_mut(id)
+                .unwrap()
+                .as_stream_mut()
+                .unwrap()
+                .dict
+                .get_mut(b"Resources")
+                .unwrap()
+                .as_dict_mut()
+                .unwrap()
+                .set("ExtGState", dictionary! { "State" => state });
+        }
+        let (items, _) = extract_page(&doc, page_id, false);
+        let styles: Vec<_> = items.iter().map(|i| (i.text.as_str(), i.is_bold)).collect();
+        assert_eq!(
+            styles,
+            [
+                ("Plain", false),
+                ("Lead", true),
+                ("Unknown", false),
+                ("Restored", true)
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_form_resolves_indirect_paint_resources_without_leaking_state() {
+        let (mut doc, page_id) = doc_with_page_and_forms(
+            b"0.3 w 2 Tr /X1 Do",
+            &[
+                b"/Tone cs 0.2 0.3 0.4 sc /Tone CS 0.2 0.3 0.4 SC /State gs
+                  BT /F1 12 Tf 72 700 Td (Outer) Tj ET /X2 Do
+                  0.2 0.3 0.4 rg BT /F1 12 Tf 72 660 Td (Restored) Tj ET",
+                b"/Tone cs 0 sc /Tone CS 0 SC /State gs
+                  BT /F1 12 Tf 72 680 Td (Inner) Tj ET",
+            ],
+        );
+        for (id, color_space, state) in [
+            ((2, 0), "DeviceRGB", dictionary! { "SM" => 0.02 }),
+            ((3, 0), "DeviceGray", dictionary! { "OPM" => 1 }),
+        ] {
+            let mut resources = doc
+                .get_object(id)
+                .unwrap()
+                .as_stream()
+                .unwrap()
+                .dict
+                .get(b"Resources")
+                .unwrap()
+                .as_dict()
+                .unwrap()
+                .clone();
+            let space_id = doc.add_object(Object::Name(color_space.as_bytes().to_vec()));
+            let state_id = doc.add_object(state);
+            let spaces_id = doc.add_object(dictionary! { "Tone" => Object::Reference(space_id) });
+            let states_id = doc.add_object(dictionary! { "State" => Object::Reference(state_id) });
+            resources.set("ColorSpace", Object::Reference(spaces_id));
+            resources.set("ExtGState", Object::Reference(states_id));
+            let resources_id = doc.add_object(resources);
+            doc.get_object_mut(id)
+                .unwrap()
+                .as_stream_mut()
+                .unwrap()
+                .dict
+                .set("Resources", Object::Reference(resources_id));
+        }
+        let (items, _) = extract_page(&doc, page_id, false);
+        assert_eq!(
+            items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["Outer", "Inner", "Restored"]
+        );
+        assert!(items.iter().all(|i| i.is_bold));
+    }
+
+    #[test]
+    fn form_fill_stroke_covers_all_show_operators() {
+        for show in [
+            "(Styled) Tj",
+            "[(Sty) (led)] TJ",
+            "(Styled) '",
+            "0 0 (Styled) \"",
+        ] {
+            let content = format!("BT /F1 12 Tf 72 700 Td {show} ET");
+            let (doc, page_id) =
+                doc_with_page_and_forms(b"0.3 w 2 Tr /X1 Do", &[content.as_bytes()]);
+            let (items, _) = extract_page(&doc, page_id, false);
+            assert_eq!(items.len(), 1, "{show}: {items:?}");
+            assert_eq!(items[0].text, "Styled");
+            assert!(items[0].is_bold, "{show}: {items:?}");
+        }
+    }
+
+    #[test]
+    fn unresolved_form_font_does_not_gain_painted_bold() {
+        let items = form_items(b"0.3 w 2 Tr BT /Missing 12 Tf 72 700 Td (Alpha) Tj ET");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].text, "Alpha");
+        assert!(!items[0].is_bold);
     }
 
     #[test]

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -409,8 +409,9 @@ fn find_wrapped_bold_paragraph_lines(
     lines: &[TextLine],
     base_size: f32,
     para_threshold: f32,
-) -> HashSet<usize> {
+) -> (HashSet<usize>, HashSet<usize>) {
     let mut set = HashSet::new();
+    let mut quoted = HashSet::new();
     let mut i = 0usize;
 
     while i < lines.len() {
@@ -432,16 +433,39 @@ fn find_wrapped_bold_paragraph_lines(
         }
 
         let line_count = end - start + 1;
-        if line_count >= 3 && word_count > 20 {
+        // A long enclosed quotation is prose even when it wraps to only two
+        // lines. Keep its indices separate so only this case also vetoes
+        // font-tier promotion; the existing unquoted paragraph policy stays.
+        let quoted_prose =
+            line_count >= 2 && word_count > 20 && has_enclosing_double_quotes(&lines[start..=end]);
+        if (line_count >= 3 && word_count > 20) || quoted_prose {
             for idx in start..=end {
                 set.insert(idx);
+                if quoted_prose {
+                    quoted.insert(idx);
+                }
             }
         }
 
         i = end + 1;
     }
 
-    set
+    (set, quoted)
+}
+
+fn has_enclosing_double_quotes(lines: &[TextLine]) -> bool {
+    let text = lines
+        .iter()
+        .map(TextLine::text)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let text = text.trim();
+    [('“', '”'), ('"', '"')].iter().any(|&(open, close)| {
+        text.strip_prefix(open)
+            .and_then(|body| body.strip_suffix(close))
+            // Two independently quoted titles are not one quoted paragraph.
+            .is_some_and(|body| !body.contains(open) && !body.contains(close))
+    })
 }
 
 fn is_body_size_all_bold_line(line: &TextLine, base_size: f32) -> bool {
@@ -730,7 +754,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
     // between paragraphs at body font size. Inspired by opendataloader's
     // lookahead in HeadingProcessor (prevNode/nextNode context).
     let isolated_lines = find_isolated_lines(&lines, base_size, para_threshold);
-    let wrapped_bold_paragraph_lines =
+    let (wrapped_bold_paragraph_lines, wrapped_quoted_paragraph_lines) =
         find_wrapped_bold_paragraph_lines(&lines, base_size, para_threshold);
 
     let mut sequence_excluded_lines = wrapped_bold_paragraph_lines.clone();
@@ -1033,6 +1057,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             .is_some_and(StructRole::is_non_heading_content);
         let heuristic_heading = if options.detect_headers
             && !non_heading_role
+            && !wrapped_quoted_paragraph_lines.contains(&line_idx)
             && !is_code_line
             && !looks_like_list_continuation
             && plain_trimmed.len() > 3
@@ -1302,7 +1327,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
     let para_threshold = compute_paragraph_threshold(&lines, base_size);
 
     let isolated_lines = find_isolated_lines(&lines, base_size, para_threshold);
-    let wrapped_bold_paragraph_lines =
+    let (wrapped_bold_paragraph_lines, wrapped_quoted_paragraph_lines) =
         find_wrapped_bold_paragraph_lines(&lines, base_size, para_threshold);
     let sequence_heading_levels = classify_heading_sequences(
         &lines,
@@ -1397,6 +1422,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         // Detect headers by font size
         // Skip very short text (drop caps/labels) and very long text (body paragraphs)
         if options.detect_headers
+            && !wrapped_quoted_paragraph_lines.contains(&line_idx)
             && plain_trimmed.len() > 3
             && plain_trimmed.split_whitespace().count() <= 15
             && !is_toc_entry_line(plain_trimmed)
@@ -2124,6 +2150,142 @@ mod tests {
             md.contains("technique.**\n\nA photon is a single excitation"),
             "body paragraph should be separated from bold abstract: {md}"
         );
+    }
+
+    fn quoted_prose_fixture(first: &str, last: &str, size: f32, italic: bool) -> Vec<TextLine> {
+        let mut lines: Vec<_> = (0..10)
+            .map(|i| {
+                line_at(
+                    "Regular paragraph text provides the surrounding document context.",
+                    1,
+                    740.0 - i as f32 * 14.0,
+                )
+            })
+            .collect();
+        for (index, text) in [first, last].iter().enumerate() {
+            let mut item = make_item(text, 1, Some(index as i64));
+            item.y = 540.0 - index as f32 * 14.0;
+            item.font_size = size;
+            item.is_bold = true;
+            item.is_italic = italic;
+            lines.push(make_line(vec![item]));
+        }
+        lines.push(line_at(
+            "Ordinary body text follows the quotation.",
+            1,
+            480.0,
+        ));
+        lines
+    }
+
+    #[test]
+    fn quoted_bold_prose_stays_one_formatted_paragraph_in_both_renderers() {
+        let first =
+            "Every member keeps a careful record of each decision and its supporting evidence";
+        let last = "so that anyone can review the work and understand how the result was reached.";
+        for (open, close) in [('“', '”'), ('"', '"')] {
+            for size in [12.0, 13.0] {
+                for italic in [false, true] {
+                    let first = format!("{open}{first}");
+                    let last = format!("{last}{close}");
+                    let lines = quoted_prose_fixture(&first, &last, size, italic);
+                    let options = MarkdownOptions {
+                        base_font_size: Some(12.0),
+                        ..MarkdownOptions::default()
+                    };
+                    let outputs = [
+                        to_markdown_from_lines(lines.clone(), options.clone()),
+                        to_markdown_from_lines_with_tables_and_images(
+                            lines,
+                            options,
+                            HashMap::new(),
+                            HashMap::new(),
+                            &HashMap::new(),
+                            &HashSet::new(),
+                            None,
+                        ),
+                    ];
+                    for md in outputs {
+                        let paragraph = md
+                            .split("\n\n")
+                            .find(|p| p.contains("Every member"))
+                            .unwrap();
+                        let markers = if italic { "***" } else { "**" };
+                        assert!(
+                            paragraph.starts_with(&format!("{markers}{open}Every")),
+                            "{md}"
+                        );
+                        assert!(
+                            paragraph.ends_with(&format!("reached.{close}{markers}")),
+                            "{md}"
+                        );
+                        assert_eq!(
+                            paragraph
+                                .replace('*', "")
+                                .split_whitespace()
+                                .collect::<Vec<_>>()
+                                .join(" "),
+                            format!("{first} {last}")
+                        );
+                        assert!(!paragraph.lines().any(|line| line.starts_with('#')), "{md}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn quoted_prose_guard_keeps_quote_and_heading_boundaries() {
+        let first =
+            "“Every member keeps a careful record of each decision and its supporting evidence";
+        let last = "so that anyone can review the work and understand how the result was reached.”";
+        for (left, right, size) in [
+            ("“Collected Notes", "and Practical Examples”", 13.0),
+            (first, last, 16.0),
+            (first, "so that anyone can review the work and understand how the result was reached.", 13.0),
+            (first, "so that anyone can review the work and understand how the result was reached.\"", 13.0),
+            ("“Every Member Keeps a Careful Record of Each Decision and Its Supporting Evidence”", "“Readers Can Review the Work and Understand How the Final Result Was Reached”", 13.0),
+        ] {
+            let lines = quoted_prose_fixture(left, right, size, true);
+            let (_, quoted) = find_wrapped_bold_paragraph_lines(&lines, 12.0, 20.0);
+            assert!(quoted.is_empty(), "{left} / {right}");
+        }
+
+        let options = MarkdownOptions {
+            base_font_size: Some(12.0),
+            ..MarkdownOptions::default()
+        };
+        for lines in [
+            quoted_prose_fixture("“Collected Notes", "and Practical Examples”", 13.0, false),
+            quoted_prose_fixture(first, last, 16.0, true),
+        ] {
+            let md = to_markdown_from_lines_with_tables_and_images(
+                lines,
+                options.clone(),
+                HashMap::new(),
+                HashMap::new(),
+                &HashMap::new(),
+                &HashSet::new(),
+                None,
+            );
+            assert!(
+                md.lines()
+                    .any(|line| line.starts_with('#') && line.contains('“')),
+                "{md}"
+            );
+        }
+        let roles = HashMap::from([(1, HashMap::from([(0, StructRole::H2), (1, StructRole::H2)]))]);
+        let md = to_markdown_from_lines_with_tables_and_images(
+            quoted_prose_fixture(first, last, 13.0, true),
+            options,
+            HashMap::new(),
+            HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+            Some(&roles),
+        );
+        assert!(md.contains("## “Every member"), "{md}");
+        assert!(md.contains("## so that anyone"), "{md}");
     }
 
     #[test]

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -462,10 +462,57 @@ fn has_enclosing_double_quotes(lines: &[TextLine]) -> bool {
     let text = text.trim();
     [('“', '”'), ('"', '"')].iter().any(|&(open, close)| {
         text.strip_prefix(open)
-            .and_then(|body| body.strip_suffix(close))
+            .and_then(|body| body.split_once(close))
             // Two independently quoted titles are not one quoted paragraph.
-            .is_some_and(|body| !body.contains(open) && !body.contains(close))
+            .is_some_and(|(body, suffix)| !body.contains(open) && is_quote_suffix(suffix))
     })
+}
+
+fn is_quote_suffix(mut suffix: &str) -> bool {
+    loop {
+        suffix = suffix.trim_start();
+        let Some(first) = suffix.chars().next() else {
+            return true;
+        };
+        match first {
+            // Accept punctuation and recognizable footnote markers, never
+            // arbitrary prose or another quotation after the closing quote.
+            '.' | ',' | ';' | ':' | '!' | '?' | '…' | '*' | '†' | '‡' | '⁰' | '¹' | '²' | '³'
+            | '⁴' | '⁵' | '⁶' | '⁷' | '⁸' | '⁹' => {
+                suffix = &suffix[first.len_utf8()..];
+            }
+            '[' | '(' => {
+                let close = if first == '[' { ']' } else { ')' };
+                let Some((reference, rest)) = suffix[1..].split_once(close) else {
+                    return false;
+                };
+                if !is_numeric_quote_reference(reference, first == '[') {
+                    return false;
+                }
+                suffix = rest;
+            }
+            _ => return false,
+        }
+    }
+}
+
+fn is_numeric_quote_reference(mut reference: &str, allow_list: bool) -> bool {
+    loop {
+        reference = reference.trim_start();
+        let digits = reference.bytes().take_while(u8::is_ascii_digit).count();
+        if digits == 0 {
+            return false;
+        }
+        reference = reference[digits..].trim_start();
+        if reference.is_empty() {
+            return true;
+        }
+        let separator = reference.chars().next().unwrap();
+        if !allow_list || !matches!(separator, ',' | '-' | '–') {
+            return false;
+        }
+        reference = &reference[separator.len_utf8()..];
+    }
 }
 
 fn is_body_size_all_bold_line(line: &TextLine, base_size: f32) -> bool {
@@ -2231,6 +2278,98 @@ mod tests {
                     }
                 }
             }
+        }
+    }
+
+    #[test]
+    fn quoted_prose_suffixes_preserve_text_and_style_in_both_renderers() {
+        for (open, close) in [('“', '”'), ('"', '"')] {
+            for suffix in [
+                ".",
+                ",",
+                ";",
+                ":",
+                "!",
+                "?",
+                "…",
+                " [1]",
+                " [1, 2]",
+                " [1–3]",
+                " [1-3, 5]",
+                " (1)",
+                "¹",
+                "¹²",
+                "*",
+                "†",
+                "‡",
+                ". [1]†",
+                " [1].",
+            ] {
+                let first = format!(
+                    "{open}Every member keeps a careful record of each decision and its supporting evidence"
+                );
+                let last = format!(
+                    "so that anyone can review the work and understand how the result was reached{close}{suffix}"
+                );
+                let lines = quoted_prose_fixture(&first, &last, 13.0, true);
+                let options = MarkdownOptions {
+                    base_font_size: Some(12.0),
+                    ..MarkdownOptions::default()
+                };
+                let outputs = [
+                    to_markdown_from_lines(lines.clone(), options.clone()),
+                    to_markdown_from_lines_with_tables_and_images(
+                        lines,
+                        options,
+                        HashMap::new(),
+                        HashMap::new(),
+                        &HashMap::new(),
+                        &HashSet::new(),
+                        None,
+                    ),
+                ];
+                for md in outputs {
+                    let paragraph = md
+                        .split("\n\n")
+                        .find(|p| p.contains("Every member"))
+                        .unwrap();
+                    assert!(paragraph.starts_with(&format!("***{open}Every")), "{md}");
+                    assert!(paragraph.ends_with(&format!("{close}{suffix}***")), "{md}");
+                    assert_eq!(paragraph.replace("***", ""), format!("{first} {last}"));
+                    assert!(!paragraph.lines().any(|line| line.starts_with('#')), "{md}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn quoted_prose_suffixes_reject_prose_and_malformed_references() {
+        for suffix in [
+            " and another statement follows",
+            " 2024",
+            " (use this carefully)",
+            " (Smith, 2024)",
+            " [note]",
+            " []",
+            " [1,]",
+            " [1-]",
+            " [1,,2]",
+            " [1",
+            " (1, 2)",
+            " (1",
+            " [1] followed by prose",
+            " “Another title”",
+            " \"Another title\"",
+        ] {
+            assert!(!is_quote_suffix(suffix), "{suffix}");
+            let first =
+                "“Every member keeps a careful record of each decision and its supporting evidence";
+            let last = format!(
+                "so that anyone can review the work and understand how the result was reached.”{suffix}"
+            );
+            let lines = quoted_prose_fixture(first, &last, 13.0, true);
+            let (_, quoted) = find_wrapped_bold_paragraph_lines(&lines, 12.0, 20.0);
+            assert!(quoted.is_empty(), "{suffix}");
         }
     }
 


### PR DESCRIPTION
## Summary

Preserve bold emphasis produced by filling and stroking text when the font metadata alone does not identify it as bold. Track paint state across text objects and nested forms, infer emphasis only for supported text fonts with matching fill and stroke paint, and keep long quoted prose from becoming heuristic headings so its inline styling is retained.
