### PR TITLE
Expose positioned OCR spans in OcrPageResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ version. A separate release pull request bumps the manifests with
 version and date. Earlier releases are described in their
 [GitHub releases](https://github.com/firecrawl/pdf-inspector/releases).
 
+## [Unreleased]
+
+### Added
+
+- `FusedPageMarkdown::spans`: accepted OCR spans with PDF-space geometry
+  (same frame as `TextItem`), so consumers can place recognized text
+  themselves — selectable text layers, highlight geometries, confidence
+  visualization. Exposed as `spans` on the Node and Python `OcrPageResult`.
+  Empty unless OCR ran for the page.
+
 ## [1.18.0] - 2026-09-07
 
 Changes since 1.17.0.

--- a/docs/python.md
+++ b/docs/python.md
@@ -102,6 +102,8 @@ result = pdf_inspector.extract_pages_markdown("document.pdf", pages=[0, 2])
 ocr = pdf_inspector.process_pdf_with_ocr("document.pdf")
 for page in ocr.pages:
     print(page.page_number, page.provenance.source)
+    for span in page.spans:
+        print(span.text, span.x, span.y, span.width, span.height, span.confidence)
 
 # Restrict OCR processing to 1-indexed PDF pages and prohibit downloads.
 ocr = pdf_inspector.process_pdf_with_ocr(
@@ -193,7 +195,16 @@ class OcrPageProvenance:
 class OcrPageResult:
     page_number: int                 # 1-indexed
     markdown: str
+    spans: list[OcrTextSpan]         # empty unless OCR ran for this page
     provenance: OcrPageProvenance
+
+class OcrTextSpan:                   # OCR recognition line, in recognition order
+    text: str
+    x: float                         # PDF points, same visible-page frame as TextItem
+    y: float                         # y grows upward
+    width: float                     # axis-aligned rectangle
+    height: float
+    confidence: float                 # 0.0 - 1.0
 
 class OcrPdfResult:                  # process_pdf_with_ocr / bytes
     markdown: str

--- a/napi/README.md
+++ b/napi/README.md
@@ -182,6 +182,22 @@ interface RegionText {
   ocrReason?: string        // "suspected_garbled_text" when known
 }
 
+interface OcrTextSpan {
+  text: string              // recognized OCR line, trimmed
+  x: number
+  y: number
+  width: number
+  height: number
+  confidence: number        // 0.0 - 1.0
+}
+
+interface OcrPageResult {
+  pageNumber: number        // 1-indexed
+  markdown: string
+  spans: OcrTextSpan[]      // empty unless OCR ran for this page
+  provenance: OcrPageProvenance
+}
+
 interface OcrPdfResult {
   markdown: string
   pages: OcrPageResult[]              // 1-indexed pages + provenance
@@ -198,6 +214,11 @@ interface OcrPdfResult {
   ocrTimeMs: number
 }
 ```
+
+`OcrTextSpan` rectangles are axis-aligned PDF-point boxes in the same visible-page
+coordinate frame as `TextItem`. They are OCR recognition lines, in recognition order.
+They remain available when fusion chooses native Markdown, but are empty for pages where
+OCR did not run.
 
 ## Platforms
 

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -240,12 +240,33 @@ pub struct OcrPageProvenance {
     pub hosted_recommended: bool,
 }
 
+/// Positioned OCR recognition result, same coordinate frame as TextItem
+/// (PDF points, axis-aligned box). For text layers, highlight geometries,
+/// and confidence visualization without re-running OCR.
+#[napi(object)]
+pub struct OcrTextSpan {
+    /// Recognized line text, trimmed.
+    pub text: String,
+    /// Axis-aligned box, same frame as TextItem.
+    pub x: f64,
+    /// Axis-aligned box, same frame as TextItem.
+    pub y: f64,
+    /// Axis-aligned box, same frame as TextItem.
+    pub width: f64,
+    /// Axis-aligned box, same frame as TextItem.
+    pub height: f64,
+    /// Recognition confidence in the inclusive range 0–1.
+    pub confidence: f64,
+}
+
 /// Final Markdown and provenance for one page.
 #[napi(object)]
 pub struct OcrPageResult {
     /// 1-indexed page number.
     pub page_number: u32,
     pub markdown: String,
+    /// Accepted OCR spans with geometry; empty unless OCR ran for the page.
+    pub spans: Vec<OcrTextSpan>,
     pub provenance: OcrPageProvenance,
 }
 
@@ -370,6 +391,18 @@ fn to_napi_ocr_result(result: pdf_inspector::vision::OcrPdfResult) -> OcrPdfResu
                 OcrPageResult {
                     page_number: page.page_number,
                     markdown: page.markdown,
+                    spans: page
+                        .spans
+                        .into_iter()
+                        .map(|span| OcrTextSpan {
+                            text: span.text,
+                            x: f64::from(span.x),
+                            y: f64::from(span.y),
+                            width: f64::from(span.width),
+                            height: f64::from(span.height),
+                            confidence: f64::from(span.confidence),
+                        })
+                        .collect(),
                     provenance: OcrPageProvenance {
                         page_number: provenance.page_number,
                         source: convert_page_content_source(provenance.source),

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1274,3 +1274,77 @@ pub fn extract_pages_markdown_async(
         pages,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pdf_inspector::vision::{
+        FusedPageMarkdown, OcrPdfResult as CoreOcrPdfResult, OcrTextSpan as CoreOcrTextSpan,
+        PageContentSource, PageProvenance, VisionTimings,
+    };
+
+    fn page(page_number: u32, spans: Vec<CoreOcrTextSpan>) -> FusedPageMarkdown {
+        FusedPageMarkdown {
+            page_number,
+            markdown: format!("page {page_number}"),
+            spans,
+            provenance: PageProvenance {
+                page_number,
+                source: if page_number == 1 {
+                    PageContentSource::Ocr
+                } else {
+                    PageContentSource::Native
+                },
+                ocr_model: None,
+                render_dpi: None,
+                ocr_confidence: None,
+                timings: VisionTimings::default(),
+                warnings: Vec::new(),
+                hosted_recommended: false,
+            },
+        }
+    }
+
+    #[test]
+    fn maps_positioned_ocr_spans_into_napi_result() {
+        let result = CoreOcrPdfResult {
+            markdown: "page 1\npage 2".into(),
+            pages: vec![
+                page(
+                    1,
+                    vec![CoreOcrTextSpan {
+                        text: "Chapter title".into(),
+                        x: 12.5,
+                        y: 56.0,
+                        width: 180.25,
+                        height: 14.0,
+                        confidence: 0.97,
+                    }],
+                ),
+                page(2, Vec::new()),
+            ],
+            page_count: 2,
+            pages_recommended_for_ocr: vec![1],
+            pages_routed_to_ocr: vec![1],
+            pages_recommending_hosted: Vec::new(),
+            ocr_reasons_by_page: Vec::new(),
+            pages_with_tables: Vec::new(),
+            pages_with_columns: Vec::new(),
+            is_complex: false,
+            processing_time_ms: 10,
+            render_time_ms: 4,
+            ocr_time_ms: 5,
+        };
+
+        let mapped = to_napi_ocr_result(result);
+        assert_eq!(mapped.pages[0].spans.len(), 1);
+        let span = &mapped.pages[0].spans[0];
+        assert_eq!(span.text, "Chapter title");
+        assert_eq!(span.x, 12.5);
+        assert_eq!(span.y, 56.0);
+        assert_eq!(span.width, 180.25);
+        assert_eq!(span.height, 14.0);
+        assert!((span.confidence - 0.97).abs() < 1e-6);
+        assert!(mapped.pages[1].spans.is_empty());
+    }
+}

--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -305,6 +305,7 @@ assert.equal(ocrOff.pages.length, 3);
 assert.deepEqual(ocrOff.pagesRoutedToOcr, []);
 assert.ok(ocrOff.pages.every(page => page.provenance.source === 'Native'));
 assert.ok(ocrOff.pages.every(page => page.provenance.ocrModel === undefined));
+assert.ok(ocrOff.pages.every(page => Array.isArray(page.spans) && page.spans.length === 0));
 assert.ok(ocrOff.markdown.length > 0);
 
 // Auto must preserve the lightweight path for clean text PDFs.

--- a/pdf_inspector.pyi
+++ b/pdf_inspector.pyi
@@ -51,11 +51,22 @@ class OcrPageProvenance:
     warnings: list[str]
     hosted_recommended: bool
 
+class OcrTextSpan:
+    """Positioned OCR recognition result, same coordinate frame as TextItem (PDF points, axis-aligned box)."""
+    text: str
+    x: float
+    y: float
+    width: float
+    height: float
+    confidence: float
+
 class OcrPageResult:
     """Final Markdown and provenance for one page."""
     page_number: int
     """1-indexed page number."""
     markdown: str
+    spans: list[OcrTextSpan]
+    """Accepted OCR spans with geometry; empty unless OCR ran for the page."""
     provenance: OcrPageProvenance
 
 class OcrPdfResult:

--- a/src/python.rs
+++ b/src/python.rs
@@ -131,6 +131,31 @@ pub struct PyOcrPageProvenance {
     pub hosted_recommended: bool,
 }
 
+/// Positioned OCR recognition result, same coordinate frame as TextItem
+/// (PDF points, axis-aligned box).
+#[pyclass(name = "OcrTextSpan")]
+#[derive(Clone)]
+pub struct PyOcrTextSpan {
+    /// Recognized line text, trimmed.
+    #[pyo3(get)]
+    pub text: String,
+    /// Axis-aligned box, same frame as TextItem.
+    #[pyo3(get)]
+    pub x: f32,
+    /// Axis-aligned box, same frame as TextItem.
+    #[pyo3(get)]
+    pub y: f32,
+    /// Axis-aligned box, same frame as TextItem.
+    #[pyo3(get)]
+    pub width: f32,
+    /// Axis-aligned box, same frame as TextItem.
+    #[pyo3(get)]
+    pub height: f32,
+    /// Recognition confidence in the inclusive range 0–1.
+    #[pyo3(get)]
+    pub confidence: f32,
+}
+
 /// Final Markdown and provenance for one page.
 #[pyclass(name = "OcrPageResult")]
 #[derive(Clone)]
@@ -140,6 +165,9 @@ pub struct PyOcrPageResult {
     pub page_number: u32,
     #[pyo3(get)]
     pub markdown: String,
+    /// Accepted OCR spans with geometry; empty unless OCR ran for the page.
+    #[pyo3(get)]
+    pub spans: Vec<PyOcrTextSpan>,
     #[pyo3(get)]
     pub provenance: PyOcrPageProvenance,
 }
@@ -557,6 +585,18 @@ fn to_py_ocr_result(result: crate::vision::OcrPdfResult) -> PyOcrPdfResult {
                 PyOcrPageResult {
                     page_number: page.page_number,
                     markdown: page.markdown,
+                    spans: page
+                        .spans
+                        .into_iter()
+                        .map(|span| PyOcrTextSpan {
+                            text: span.text,
+                            x: span.x,
+                            y: span.y,
+                            width: span.width,
+                            height: span.height,
+                            confidence: span.confidence,
+                        })
+                        .collect(),
                     provenance: PyOcrPageProvenance {
                         page_number: provenance.page_number,
                         source: page_content_source_str(provenance.source),

--- a/src/python.rs
+++ b/src/python.rs
@@ -677,6 +677,80 @@ fn convert_structure_elements(elements: Vec<crate::StructureElement>) -> Vec<PyS
         .collect()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vision::{
+        FusedPageMarkdown, OcrPdfResult, OcrTextSpan, PageContentSource, PageProvenance,
+        VisionTimings,
+    };
+
+    fn page(page_number: u32, spans: Vec<OcrTextSpan>) -> FusedPageMarkdown {
+        FusedPageMarkdown {
+            page_number,
+            markdown: format!("page {page_number}"),
+            spans,
+            provenance: PageProvenance {
+                page_number,
+                source: if page_number == 1 {
+                    PageContentSource::Ocr
+                } else {
+                    PageContentSource::Native
+                },
+                ocr_model: None,
+                render_dpi: None,
+                ocr_confidence: None,
+                timings: VisionTimings::default(),
+                warnings: Vec::new(),
+                hosted_recommended: false,
+            },
+        }
+    }
+
+    #[test]
+    fn maps_positioned_ocr_spans_into_python_result() {
+        let result = OcrPdfResult {
+            markdown: "page 1\npage 2".into(),
+            pages: vec![
+                page(
+                    1,
+                    vec![OcrTextSpan {
+                        text: "Chapter title".into(),
+                        x: 12.5,
+                        y: 56.0,
+                        width: 180.25,
+                        height: 14.0,
+                        confidence: 0.97,
+                    }],
+                ),
+                page(2, Vec::new()),
+            ],
+            page_count: 2,
+            pages_recommended_for_ocr: vec![1],
+            pages_routed_to_ocr: vec![1],
+            pages_recommending_hosted: Vec::new(),
+            ocr_reasons_by_page: Vec::new(),
+            pages_with_tables: Vec::new(),
+            pages_with_columns: Vec::new(),
+            is_complex: false,
+            processing_time_ms: 10,
+            render_time_ms: 4,
+            ocr_time_ms: 5,
+        };
+
+        let mapped = to_py_ocr_result(result);
+        assert_eq!(mapped.pages[0].spans.len(), 1);
+        let span = &mapped.pages[0].spans[0];
+        assert_eq!(span.text, "Chapter title");
+        assert_eq!(span.x, 12.5);
+        assert_eq!(span.y, 56.0);
+        assert_eq!(span.width, 180.25);
+        assert_eq!(span.height, 14.0);
+        assert_eq!(span.confidence, 0.97);
+        assert!(mapped.pages[1].spans.is_empty());
+    }
+}
+
 fn parse_page_regions(
     page_regions: Vec<(u32, Vec<Vec<f64>>)>,
 ) -> PyResult<Vec<(u32, Vec<[f32; 4]>)>> {

--- a/src/python.rs
+++ b/src/python.rs
@@ -749,6 +749,15 @@ mod tests {
         assert_eq!(span.confidence, 0.97);
         assert!(mapped.pages[1].spans.is_empty());
     }
+
+    #[test]
+    fn exports_ocr_text_span_type_from_python_module() {
+        Python::with_gil(|py| {
+            let module = PyModule::new(py, "pdf_inspector").expect("create test module");
+            pdf_inspector(&module).expect("initialize Python module");
+            assert!(module.getattr("OcrTextSpan").is_ok());
+        });
+    }
 }
 
 fn parse_page_regions(
@@ -1243,6 +1252,7 @@ fn pdf_inspector(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOcrModelIdentity>()?;
     m.add_class::<PyOcrTimings>()?;
     m.add_class::<PyOcrPageProvenance>()?;
+    m.add_class::<PyOcrTextSpan>()?;
     m.add_class::<PyOcrPageResult>()?;
     m.add_class::<PyOcrPdfResult>()?;
     m.add_class::<PyPdfClassification>()?;

--- a/src/vision/fusion.rs
+++ b/src/vision/fusion.rs
@@ -14,7 +14,8 @@ use crate::types::{ItemType, PdfRect, TextItem};
 use crate::PageMarkdown;
 
 use super::{
-    OcrRun, PageContentSource, PageProvenance, RoutedOcrPage, VisionTimings, DEFAULT_RENDER_DPI,
+    OcrRun, OcrSpan, PageContentSource, PageProvenance, RenderedPage, RoutedOcrPage, VisionTimings,
+    DEFAULT_RENDER_DPI,
 };
 
 /// OCR assembly and hosted-fallback policy.
@@ -80,6 +81,10 @@ pub struct FusedPageMarkdown {
     pub page_number: u32,
     /// Final page Markdown.
     pub markdown: String,
+    /// Accepted OCR spans with PDF-space geometry, in recognition order.
+    /// Empty unless OCR ran for the page; independent of which content
+    /// (native, OCR, or fused) the Markdown above settled on.
+    pub spans: Vec<OcrTextSpan>,
     /// Native/OCR source, model, timing, and fallback metadata.
     pub provenance: PageProvenance,
 }
@@ -401,6 +406,10 @@ fn fuse_ocr_pages_impl(
         pages.push(FusedPageMarkdown {
             page_number,
             markdown,
+            spans: ocr_by_page
+                .get(&page_number)
+                .map(|page| ocr_text_spans(page))
+                .unwrap_or_default(),
             provenance: PageProvenance {
                 page_number,
                 source,
@@ -580,6 +589,27 @@ fn assess_text_candidate(markdown: &str) -> Option<TextCandidateQuality> {
     })
 }
 
+/// One positioned OCR recognition result in PDF page space.
+///
+/// Same coordinate frame as [`TextItem`]: PDF points, axis-aligned box.
+/// Rendered for consumers that place recognized text themselves
+/// (selectable text layers, highlight geometries, confidence heatmaps).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OcrTextSpan {
+    /// Recognized line text, trimmed.
+    pub text: String,
+    /// Axis-aligned box, same frame as [`TextItem`].
+    pub x: f32,
+    /// Axis-aligned box, same frame as [`TextItem`].
+    pub y: f32,
+    /// Axis-aligned box, same frame as [`TextItem`].
+    pub width: f32,
+    /// Axis-aligned box, same frame as [`TextItem`].
+    pub height: f32,
+    /// Recognition confidence in the inclusive range 0–1.
+    pub confidence: f32,
+}
+
 /// Converts recognized line polygons to ordinary PDF-space text items.
 fn ocr_text_items(page: &RoutedOcrPage) -> (Vec<TextItem>, usize) {
     let mut discarded = 0usize;
@@ -589,20 +619,10 @@ fn ocr_text_items(page: &RoutedOcrPage) -> (Vec<TextItem>, usize) {
             discarded += 1;
             continue;
         }
-        let Some((left, top, right, bottom)) = image_quad_bounds(
-            &span.polygon.points,
-            page.rendered.width(),
-            page.rendered.height(),
-        ) else {
+        let Some(rect) = ocr_span_rect(span, &page.rendered) else {
             discarded += 1;
             continue;
         };
-        let rect = page.rendered.pixel_rect_to_pdf_rect(
-            f64::from(left),
-            f64::from(top),
-            f64::from(right - left),
-            f64::from(bottom - top),
-        );
         items.push(TextItem {
             text: span.text.trim().to_string(),
             x: rect.x,
@@ -635,6 +655,45 @@ fn ocr_text_items(page: &RoutedOcrPage) -> (Vec<TextItem>, usize) {
             .then(first.x.total_cmp(&second.x))
     });
     (items, discarded)
+}
+
+/// Shared geometry for an OCR span: bitmap polygon to PDF-space rect.
+/// Returns `None` for empty text or unusable geometry (same acceptance
+/// rules as [`ocr_text_items`]).
+fn ocr_span_rect(span: &OcrSpan, rendered: &RenderedPage) -> Option<PdfRect> {
+    if span.text.trim().is_empty() {
+        return None;
+    }
+    let (left, top, right, bottom) =
+        image_quad_bounds(&span.polygon.points, rendered.width(), rendered.height())?;
+    Some(rendered.pixel_rect_to_pdf_rect(
+        f64::from(left),
+        f64::from(top),
+        f64::from(right - left),
+        f64::from(bottom - top),
+    ))
+}
+
+/// Accepted OCR spans with PDF-space geometry, in recognition order
+/// (top-to-bottom seed, same order the Markdown assembly consumes).
+/// Unlike the Markdown assembly above, this keeps per-span confidence so
+/// consumers can threshold or visualize recognition quality themselves.
+fn ocr_text_spans(page: &RoutedOcrPage) -> Vec<OcrTextSpan> {
+    page.ocr
+        .spans
+        .iter()
+        .filter_map(|span| {
+            let rect = ocr_span_rect(span, &page.rendered)?;
+            Some(OcrTextSpan {
+                text: span.text.trim().to_string(),
+                x: rect.x,
+                y: rect.y,
+                width: rect.width,
+                height: rect.height,
+                confidence: span.confidence.clamp(0.0, 1.0),
+            })
+        })
+        .collect()
 }
 
 fn image_quad_bounds(
@@ -1371,6 +1430,40 @@ mod tests {
             "test-ocr"
         );
         assert!(!result.pages[0].provenance.hosted_recommended);
+    }
+
+    #[test]
+    fn fused_pages_carry_ocr_spans_with_geometry() {
+        let native = [native(0, "", true)];
+        let run = run(vec![routed_page(
+            1,
+            vec![
+                positioned_span("Alpha line", 10.0, 10.0, 190.0, 22.0),
+                positioned_span("   ", 10.0, 30.0, 190.0, 42.0),
+                positioned_span("Beta line", 10.0, 50.0, 190.0, 62.0),
+            ],
+            Some(0.9),
+        )]);
+
+        let result = fuse_ocr_pages(&native, &run, 1, &OcrFusionOptions::new()).unwrap();
+
+        assert_eq!(result.pages[0].provenance.source, PageContentSource::Ocr);
+        // Empty-text span dropped; text and confidence pass through.
+        let spans = &result.pages[0].spans;
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].text, "Alpha line");
+        assert_eq!(spans[1].text, "Beta line");
+        for span in spans {
+            assert!((span.confidence - 0.9).abs() < f32::EPSILON);
+            assert!(span.width > 100.0 && span.height > 0.0);
+        }
+        // Same frame as TextItem: image top-to-bottom becomes PDF y-down-to-up,
+        // boxes stay inside the 200x100 page.
+        assert!(spans[0].y > spans[1].y);
+        for span in spans {
+            assert!((0.0..=200.0).contains(&span.x));
+            assert!((0.0..=100.0).contains(&span.y));
+        }
     }
 
     #[test]

--- a/src/vision/fusion.rs
+++ b/src/vision/fusion.rs
@@ -674,9 +674,9 @@ fn ocr_span_rect(span: &OcrSpan, rendered: &RenderedPage) -> Option<PdfRect> {
     ))
 }
 
-/// Accepted OCR spans with PDF-space geometry, in recognition order
-/// (top-to-bottom seed, same order the Markdown assembly consumes).
-/// Unlike the Markdown assembly above, this keeps per-span confidence so
+/// Accepted OCR spans with PDF-space geometry, in the OCR engine's recognition
+/// order. Markdown assembly independently reorders its text items into a
+/// geometry-based reading-order seed. Spans retain per-line confidence so
 /// consumers can threshold or visualize recognition quality themselves.
 fn ocr_text_spans(page: &RoutedOcrPage) -> Vec<OcrTextSpan> {
     page.ocr

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -40,7 +40,7 @@ pub use download::{HttpModelDownloadError, HttpModelDownloader, DEFAULT_MODEL_DO
 #[cfg(all(feature = "vision", not(target_arch = "wasm32")))]
 pub use fusion::{
     fuse_ocr_pages, ocr_page_to_markdown, FusedPageMarkdown, FusedPages, OcrFusionError,
-    OcrFusionOptions,
+    OcrFusionOptions, OcrTextSpan,
 };
 #[cfg(all(feature = "model-cache", not(target_arch = "wasm32")))]
 pub use models::{


### PR DESCRIPTION
Closes #513.

## Purpose

Expose the positioned OCR recognition lines already produced by the vision pipeline through the Node.js and Python `OcrPageResult` APIs. This lets downstream readers such as Inkdown place OCR text on a rendered page, show confidence-aware overlays, and search/select scanned content without re-running OCR or parsing Markdown.

## API

Each page now exposes `spans`, a recognition-order, line-level list of:

- `text`
- `x`, `y`, `width`, `height` — axis-aligned PDF-point rectangle in the same visible-page coordinate frame as `TextItem`; y grows upward
- `confidence` — 0.0 to 1.0

`spans` is empty when OCR did not run for a page. When OCR does run, spans remain available even if fusion ultimately chooses native Markdown.

## Compatibility

This is additive only. It does not change existing Markdown, routing, provenance, model, or inference behavior, and does not trigger an extra OCR pass.

## Validation

- `cargo test -j 1` — 1,209 unit + 176 integration + 2 doc tests passed
- `cargo test --lib --features "ocr python"` — 1,298 tests passed, including the new Python mapping test
- `cargo test --manifest-path napi/Cargo.toml maps_positioned_ocr_spans_into_napi_result` — passed
- `node napi/test.mjs` — passed
- `cargo clippy -j 1 -- -D warnings` — passed
- `git diff --check` — passed

The new deterministic NAPI and Python tests assert that text, all geometry fields, confidence, and the empty non-OCR-page case are preserved by each binding.