### PR TITLE
fix(fonts): recover stale single-byte Unicode mappings

### DIFF
--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -2,7 +2,9 @@
 
 use crate::glyph_names::glyph_to_char;
 use crate::tounicode::FontCMaps;
-use crate::types::{FontEncodingMap, FontWidthInfo, PageFontEncodings, PageFontWidths};
+use crate::types::{
+    FontEncoding, FontEncodingMap, FontWidthInfo, PageFontEncodings, PageFontWidths,
+};
 use log::debug;
 use lopdf::{Document, Encoding, Object, ObjectId};
 use std::collections::HashMap;
@@ -772,12 +774,95 @@ pub(crate) fn build_font_encodings(
                 has_gid_fonts = true;
             }
             if !result.map.is_empty() {
-                encodings.insert(resource_name, result.map);
+                let identity_overrides =
+                    stale_identity_cmap_overrides(doc, font_dict, cmaps, &result);
+                encodings.insert(
+                    resource_name,
+                    FontEncoding {
+                        differences: result.map,
+                        identity_overrides,
+                    },
+                );
             }
         }
     }
 
     (encodings, has_gid_fonts)
+}
+
+/// Some subset producers change the simple font's glyph encoding but retain
+/// its original ToUnicode. Repair only corroborated ASCII identity entries:
+/// at least three distinct letters move to ASCII slots, their Unicode values remain
+/// elsewhere in the old CMap, and the embedded CFF contains those exact glyphs.
+/// Other repairs need the same evidence, allowing a single-character case
+/// counterpart in the old CMap once the exact matches establish staleness.
+/// Keep repairs per font, since different encodings can share one CMap stream.
+fn stale_identity_cmap_overrides(
+    doc: &Document,
+    font_dict: &lopdf::Dictionary,
+    cmaps: &FontCMaps,
+    encoding: &EncodingResult,
+) -> FontEncodingMap {
+    let verified = || -> Option<FontEncodingMap> {
+        if font_dict.get(b"Subtype").ok()?.as_name().ok()? != b"Type1" {
+            return None;
+        }
+        let cmap_ref = font_dict.get(b"ToUnicode").ok()?.as_reference().ok()?;
+        let entry = cmaps.get_by_obj(cmap_ref.0)?;
+        if entry.primary.code_byte_length != 1 || entry.remapped.is_some() {
+            return None;
+        }
+        let elsewhere: std::collections::HashSet<String> = (0..=255)
+            .filter_map(|code| entry.primary.lookup(code))
+            .collect();
+        let single_case_match =
+            |case: String| case.chars().count() == 1 && elsewhere.contains(&case);
+        let candidates: FontEncodingMap = encoding
+            .map
+            .iter()
+            .filter_map(|(&code, &ch)| {
+                (code.is_ascii_graphic()
+                    && !ch.is_ascii()
+                    && (ch.is_alphabetic() || ch == '\u{00a0}')
+                    && entry.primary.lookup(code as u16).as_deref()
+                        == Some(&(code as char).to_string())
+                    && (elsewhere.contains(&ch.to_string())
+                        || (ch.is_alphabetic()
+                            && (single_case_match(ch.to_lowercase().to_string())
+                                || single_case_match(ch.to_uppercase().to_string())))))
+                .then_some((code, ch))
+            })
+            .collect();
+        let exact_anchor_count = |map: &FontEncodingMap| {
+            map.values()
+                .copied()
+                .filter(|ch| ch.is_alphabetic() && elsewhere.contains(&ch.to_string()))
+                .collect::<std::collections::HashSet<char>>()
+                .len()
+        };
+        if exact_anchor_count(&candidates) < 3 {
+            return None;
+        }
+        let descriptor = resolve_dict(doc, font_dict.get(b"FontDescriptor").ok()?)?;
+        let font_ref = descriptor.get(b"FontFile3").ok()?.as_reference().ok()?;
+        let stream = doc.get_object(font_ref).ok()?.as_stream().ok()?;
+        if stream.dict.get(b"Subtype").ok()?.as_name().ok()? != b"Type1C" {
+            return None;
+        }
+        let data = font_file_data(doc, font_ref)?;
+        let cff = ttf_parser::cff::Table::parse(&data)?;
+        let overrides: FontEncodingMap = candidates
+            .into_iter()
+            .filter(|(code, _)| {
+                encoding
+                    .glyph_names
+                    .get(code)
+                    .is_some_and(|name| cff.glyph_index_by_name(name).is_some())
+            })
+            .collect();
+        (exact_anchor_count(&overrides) >= 3).then_some(overrides)
+    };
+    verified().unwrap_or_default()
 }
 
 /// True when the font's ToUnicode CMap maps the gid-named character codes,
@@ -846,6 +931,7 @@ pub(crate) fn parse_font_encoding(
 /// Result of parsing an encoding dictionary's Differences array.
 pub(crate) struct EncodingResult {
     pub map: FontEncodingMap,
+    glyph_names: HashMap<u8, String>,
     /// Character codes whose glyph names match the `gidNNNNN` pattern (raw
     /// glyph IDs). These reference the original font's glyph table and are
     /// only decodable when the font's ToUnicode CMap maps the code.
@@ -873,6 +959,7 @@ pub(crate) fn parse_encoding_dictionary(
     };
 
     let mut encoding_map = FontEncodingMap::new();
+    let mut glyph_names = HashMap::new();
     let mut current_code: u8 = 0;
     let mut ligature_count = 0u32;
     let mut gid_codes: Vec<u8> = Vec::new();
@@ -905,6 +992,7 @@ pub(crate) fn parse_encoding_dictionary(
                 }
                 if let Some(ch) = mapped_char {
                     encoding_map.insert(current_code, ch);
+                    glyph_names.insert(current_code, glyph_name);
                 } else {
                     debug!(
                         "  Differences: code=0x{:02X} glyph={:?} (unmapped)",
@@ -934,6 +1022,7 @@ pub(crate) fn parse_encoding_dictionary(
 
     Some(EncodingResult {
         map: encoding_map,
+        glyph_names,
         gid_codes,
     })
 }
@@ -1235,6 +1324,13 @@ pub(crate) fn extract_text_from_operand(
                             // 1. Primary CMap
                             if let Some(s) = entry.primary.lookup(code) {
                                 if !s.contains('\u{FFFD}') {
+                                    if s == (b as char).to_string() {
+                                        if let Some(&ch) = encoding_map
+                                            .and_then(|map| map.identity_overrides.get(&b))
+                                        {
+                                            return Some(ch.to_string());
+                                        }
+                                    }
                                     return Some(s);
                                 }
                             }
@@ -1246,7 +1342,7 @@ pub(crate) fn extract_text_from_operand(
                             }
                             // 3. Differences mapped it? Use Differences result
                             if let Some(map) = encoding_map {
-                                if let Some(&ch) = map.get(&b) {
+                                if let Some(&ch) = map.differences.get(&b) {
                                     return Some(ch.to_string());
                                 }
                             }
@@ -1369,6 +1465,7 @@ pub(crate) fn extract_text_from_operand(
             // WinAnsiEncoding). We must combine Differences entries with the base encoding
             // rather than using filter_map which silently drops unmapped bytes.
             if let Some(encoding_map) = font_encodings.get(current_font) {
+                let encoding_map = &encoding_map.differences;
                 let has_diff_match = bytes.iter().any(|b| encoding_map.contains_key(b));
                 if has_diff_match {
                     let decoded: String = bytes
@@ -2561,3 +2658,7 @@ end",
         assert_eq!(widths.get(&65535), Some(&500));
     }
 }
+
+#[cfg(test)]
+#[path = "stale_cmap_tests.rs"]
+mod stale_cmap_tests;

--- a/src/extractor/stale_cmap_tests.rs
+++ b/src/extractor/stale_cmap_tests.rs
@@ -1,0 +1,243 @@
+use super::*;
+use lopdf::{dictionary, Stream};
+
+const GLYPHS: &[&str] = &["scaron", "ccaron", "rcaron", "uni00A0", "Aacute", "Eacute"];
+const DIFFERENCES: &[(u8, &str)] = &[
+    (33, "scaron"),
+    (34, "ccaron"),
+    (35, "rcaron"),
+    (48, "uni00A0"),
+    (64, "Aacute"),
+    (65, "Eacute"),
+];
+const STALE_MAP: &str = "1 begincodespacerange\n<00><FF>\nendcodespacerange\n\
+1 beginbfrange\n<20><7e><0020>\nendbfrange\n\
+6 beginbfchar\n<90><0161>\n<91><010d>\n<92><0159>\n<93><00a0>\n<40><006600660069>\n<41><03a9>\nendbfchar";
+
+fn cff_index(objects: &[Vec<u8>]) -> Vec<u8> {
+    let mut bytes = (objects.len() as u16).to_be_bytes().to_vec();
+    if objects.is_empty() {
+        return bytes;
+    }
+    bytes.push(2); // two-byte offsets
+    let mut offset = 1u16;
+    bytes.extend(offset.to_be_bytes());
+    for object in objects {
+        offset += object.len() as u16;
+        bytes.extend(offset.to_be_bytes());
+    }
+    for object in objects {
+        bytes.extend(object);
+    }
+    bytes
+}
+
+// A tiny, invented CFF program with named glyphs. All charstrings draw a box;
+// their Unicode names and the PDF's encoding exercise decoding, not OCR.
+fn named_cff(glyphs: &[&str]) -> Vec<u8> {
+    let names = cff_index(&[b"SyntheticFace".to_vec()]);
+    let strings = cff_index(
+        &glyphs
+            .iter()
+            .map(|g| g.as_bytes().to_vec())
+            .collect::<Vec<_>>(),
+    );
+    let top_len = cff_index(&[vec![0; 12]]).len();
+    let charset_offset = 4 + names.len() + top_len + strings.len() + 2;
+    let charstrings_offset = charset_offset + 1 + glyphs.len() * 2;
+    let mut top = vec![29];
+    top.extend((charset_offset as u32).to_be_bytes());
+    top.extend([15, 29]);
+    top.extend((charstrings_offset as u32).to_be_bytes());
+    top.push(17);
+    let mut bytes = vec![1, 0, 4, 4];
+    bytes.extend(names);
+    bytes.extend(cff_index(&[top]));
+    bytes.extend(strings);
+    bytes.extend([0, 0]); // no global subroutines
+    bytes.push(0); // charset format 0
+    for (i, glyph) in glyphs.iter().enumerate() {
+        let sid = match *glyph {
+            "Aacute" => 171u16,
+            "Eacute" => 178,
+            "scaron" => 221,
+            "Scaron" => 192,
+            _ => 391 + i as u16,
+        };
+        bytes.extend(sid.to_be_bytes());
+    }
+    let outline = vec![139, 139, 21, 189, 139, 5, 139, 189, 5, 89, 139, 5, 14];
+    bytes.extend(cff_index(&vec![outline; glyphs.len() + 1]));
+    bytes
+}
+
+fn subset_doc(glyphs: &[&str], differences: &[(u8, &str)], cmap: &str) -> (Document, ObjectId) {
+    let mut doc = Document::with_version("1.4");
+    let cmap_id = doc.add_object(Stream::new(dictionary! {}, cmap.as_bytes().to_vec()));
+    let font_file = doc.add_object(Stream::new(
+        dictionary! { "Subtype" => "Type1C" },
+        named_cff(glyphs),
+    ));
+    let encoding: Vec<Object> = differences
+        .iter()
+        .flat_map(|(code, name)| {
+            [
+                Object::Integer(*code as i64),
+                Object::Name(name.as_bytes().to_vec()),
+            ]
+        })
+        .collect();
+    let font = dictionary! {
+        "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "ABCDEF+SyntheticFace",
+        "FirstChar" => 0, "LastChar" => 255, "Widths" => vec![Object::Integer(500); 256],
+        "Encoding" => dictionary! { "Differences" => encoding },
+        "FontDescriptor" => dictionary! { "FontFile3" => font_file },
+        "ToUnicode" => cmap_id,
+    };
+    let font_id = doc.add_object(font.clone());
+    // A second font shares the same CMap but retains its original encoding.
+    let mut unchanged_font = font;
+    unchanged_font.set("Encoding", "StandardEncoding");
+    let unchanged_id = doc.add_object(unchanged_font);
+    let content = doc.add_object(Stream::new(dictionary! {},
+        b"BT /F1 12 Tf 1 0 0 1 40 700 Tm <212223304041> Tj ET\nBT /F2 12 Tf 1 0 0 1 40 670 Tm <212223> Tj ET".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page", "MediaBox" => vec![0.into(), 0.into(), 600.into(), 800.into()],
+        "Resources" => dictionary! { "Font" => dictionary! { "F1" => font_id, "F2" => unchanged_id } },
+        "Contents" => content,
+    });
+    let pages_id = doc.add_object(
+        dictionary! { "Type" => "Pages", "Count" => 1, "Kids" => vec![Object::Reference(page_id)] },
+    );
+    doc.get_object_mut(page_id)
+        .unwrap()
+        .as_dict_mut()
+        .unwrap()
+        .set("Parent", pages_id);
+    let catalog = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog);
+    (doc, font_id)
+}
+
+fn first_text(doc: &mut Document) -> String {
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    crate::extract_text_with_positions_mem(&bytes)
+        .unwrap()
+        .into_iter()
+        .find(|item| item.text.contains("ffi"))
+        .unwrap()
+        .text
+}
+
+#[test]
+fn stale_cmap_repairs_only_font_backed_identity_entries_through_extraction() {
+    let raw_cff = named_cff(GLYPHS);
+    let parsed = ttf_parser::cff::Table::parse(&raw_cff).expect("valid synthetic CFF");
+    for name in GLYPHS {
+        assert!(
+            parsed.glyph_index_by_name(name).is_some(),
+            "missing glyph {name}"
+        );
+    }
+    let (mut doc, _) = subset_doc(GLYPHS, DIFFERENCES, STALE_MAP);
+    assert_eq!(first_text(&mut doc), "ščř\u{00a0}ffiΩ");
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    let items = crate::extract_text_with_positions_mem(&bytes).unwrap();
+    assert!(
+        items.iter().any(|item| item.text == "!\"#"),
+        "another font sharing the CMap must remain unchanged"
+    );
+}
+
+#[test]
+fn stale_cmap_keeps_valid_nonidentity_mappings_and_ligatures() {
+    let valid =
+        format!("{STALE_MAP}\n3 beginbfchar\n<21><017e>\n<22><0107>\n<23><00660069>\nendbfchar");
+    let (mut doc, _) = subset_doc(GLYPHS, DIFFERENCES, &valid);
+    assert_eq!(first_text(&mut doc), "žćfi0ffiΩ");
+}
+
+#[test]
+fn stale_cmap_requires_multiple_distinct_letter_disagreements() {
+    for differences in [
+        &DIFFERENCES[..1],
+        &[(33, "scaron"), (34, "scaron"), (35, "scaron")],
+    ] {
+        let (mut doc, _) = subset_doc(GLYPHS, differences, STALE_MAP);
+        assert_eq!(first_text(&mut doc), "!\"#0ffiΩ");
+    }
+}
+
+#[test]
+fn stale_cmap_requires_the_letter_mapping_elsewhere_in_the_cmap() {
+    let cmap = STALE_MAP.replace("<90><0161>", "<90><0041>");
+    let (mut doc, _) = subset_doc(GLYPHS, DIFFERENCES, &cmap);
+    assert_eq!(first_text(&mut doc), "!\"#0ffiΩ");
+}
+
+#[test]
+fn stale_cmap_case_counterparts_need_exact_anchors_and_leave_unrelated_letters_alone() {
+    let glyphs = [GLYPHS, &["Scaron", "Nacute"]].concat();
+    let differences = [DIFFERENCES, &[(36, "Scaron"), (37, "Nacute")]].concat();
+    let (mut doc, font_id) = subset_doc(&glyphs, &differences, STALE_MAP);
+    let page = *doc.get_pages().values().next().unwrap();
+    let contents = doc
+        .get_dictionary(page)
+        .unwrap()
+        .get(b"Contents")
+        .unwrap()
+        .as_reference()
+        .unwrap();
+    doc.get_object_mut(contents)
+        .unwrap()
+        .as_stream_mut()
+        .unwrap()
+        .set_plain_content(b"BT /F1 12 Tf 1 0 0 1 40 700 Tm <2122232425304041> Tj ET".to_vec());
+    // The lowercase counterpart corroborates Scaron, while neither case of
+    // Nacute appears in the old CMap. Three exact anchors are still required.
+    assert_eq!(first_text(&mut doc), "ščřŠ%\u{00a0}ffiΩ");
+    let cmap_id = doc
+        .get_dictionary(font_id)
+        .unwrap()
+        .get(b"ToUnicode")
+        .unwrap()
+        .as_reference()
+        .unwrap();
+    doc.get_object_mut(cmap_id)
+        .unwrap()
+        .as_stream_mut()
+        .unwrap()
+        .set_plain_content(STALE_MAP.replace("<91><010d>", "<91><0041>").into_bytes());
+    assert_eq!(first_text(&mut doc), "!\"#$%0ffiΩ");
+}
+
+#[test]
+fn stale_cmap_requires_the_named_glyphs_in_the_embedded_font() {
+    let (mut doc, _) = subset_doc(&["alpha", "beta", "gamma"], DIFFERENCES, STALE_MAP);
+    assert_eq!(first_text(&mut doc), "!\"#0ffiΩ");
+}
+
+#[test]
+fn stale_cmap_requires_a_simple_embedded_cff_font() {
+    for subtype in ["Type0", "TrueType", "Type3"] {
+        let (mut doc, font_id) = subset_doc(GLYPHS, DIFFERENCES, STALE_MAP);
+        doc.get_object_mut(font_id)
+            .unwrap()
+            .as_dict_mut()
+            .unwrap()
+            .set("Subtype", subtype);
+        let fonts = FontCMaps::from_doc(&doc);
+        let font = doc.get_dictionary(font_id).unwrap();
+        let encoding = parse_font_encoding(&doc, font).unwrap();
+        assert!(stale_identity_cmap_overrides(&doc, font, &fonts, &encoding).is_empty());
+    }
+    let (mut doc, font_id) = subset_doc(GLYPHS, DIFFERENCES, STALE_MAP);
+    doc.get_object_mut(font_id)
+        .unwrap()
+        .as_dict_mut()
+        .unwrap()
+        .remove(b"FontDescriptor");
+    assert_eq!(first_text(&mut doc), "!\"#0ffiΩ");
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,8 +17,14 @@ pub(crate) type PageExtraction = (Vec<TextItem>, Vec<PdfRect>, Vec<PdfLine>);
 /// Font encoding map: maps byte codes to Unicode characters
 pub(crate) type FontEncodingMap = HashMap<u8, char>;
 
+/// Explicit glyph encodings and narrowly verified repairs for a stale CMap.
+pub(crate) struct FontEncoding {
+    pub(crate) differences: FontEncodingMap,
+    pub(crate) identity_overrides: FontEncodingMap,
+}
+
 /// All font encodings for a page
-pub(crate) type PageFontEncodings = HashMap<String, FontEncodingMap>;
+pub(crate) type PageFontEncodings = HashMap<String, FontEncoding>;
 
 /// Font width information extracted from PDF font dictionaries
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Some embedded subset fonts retain stale ToUnicode mappings after their character encoding changes, causing accented letters to extract as punctuation. Recover narrowly verified ASCII identity conflicts using the font's explicit encoding, embedded CFF glyphs, and corroborating mappings. Keep repairs isolated to each font while preserving valid semantic mappings and ligatures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale ToUnicode mappings in embedded subset fonts so accented letters no longer extract as punctuation. The fix recovers ASCII identity conflicts only when at least three distinct letters are corroborated by the font's explicit encoding, embedded CFF glyphs, and the old CMap, and applies repairs per font so other fonts sharing the same CMap remain unchanged. Valid semantic mappings and ligatures are preserved.

<sup>Written for commit 090201901d2796f517615590621c403b1d6b620c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

