### PR TITLE
fix(extractor): preserve separated clipped text runs

### DIFF
--- a/src/extractor/clip_boundaries.rs
+++ b/src/extractor/clip_boundaries.rs
@@ -1,0 +1,251 @@
+//! Conservative clipping evidence for preserving independent text runs.
+//!
+//! This does not clip extracted text or infer cells. Only a single finite,
+//! axis-aligned rectangle can establish a boundary; unknown paths retain the
+//! existing merge behavior, even if a later rectangle narrows their clip.
+
+use super::get_number;
+use crate::types::TextItem;
+use lopdf::Object;
+
+const TOLERANCE: f32 = 0.01;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ClipRect {
+    left: f32,
+    bottom: f32,
+    right: f32,
+    top: f32,
+}
+
+impl ClipRect {
+    fn intersection(self, other: Self) -> Option<Self> {
+        let rect = Self {
+            left: self.left.max(other.left),
+            bottom: self.bottom.max(other.bottom),
+            right: self.right.min(other.right),
+            top: self.top.min(other.top),
+        };
+        (rect.left < rect.right && rect.bottom < rect.top).then_some(rect)
+    }
+
+    fn from_path(operands: &[Object], ctm: [f32; 6]) -> Option<Self> {
+        if operands.len() != 4
+            || !ctm.iter().all(|x| x.is_finite())
+            || ctm[1] != 0.0
+            || ctm[2] != 0.0
+        {
+            return None;
+        }
+        let [x, y, w, h] = std::array::from_fn(|i| get_number(&operands[i]));
+        let (x, y, w, h) = (x?, y?, w?, h?);
+        let xs = [ctm[0] * x + ctm[4], ctm[0] * (x + w) + ctm[4]];
+        let ys = [ctm[3] * y + ctm[5], ctm[3] * (y + h) + ctm[5]];
+        if !xs.iter().chain(&ys).all(|x| x.is_finite()) {
+            return None;
+        }
+        let rect = Self {
+            left: xs[0].min(xs[1]),
+            right: xs[0].max(xs[1]),
+            bottom: ys[0].min(ys[1]),
+            top: ys[0].max(ys[1]),
+        };
+        (rect.left < rect.right && rect.bottom < rect.top).then_some(rect)
+    }
+
+    fn contains_advance(self, item: &TextItem) -> bool {
+        item.is_upright()
+            && item.advance_known
+            && item.width > 0.0
+            && [item.x, item.y, item.width].iter().all(|x| x.is_finite())
+            && item.x >= self.left - TOLERANCE
+            && item.x + item.width <= self.right + TOLERANCE
+            && item.y >= self.bottom - TOLERANCE
+            && item.y <= self.top + TOLERANCE
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+enum Clip {
+    #[default]
+    Unbounded,
+    Rect(ClipRect),
+    Unknown,
+}
+
+#[derive(Default)]
+pub(super) struct ClipTracker {
+    active: Clip,
+    saved: Vec<Clip>,
+    // Paths are not part of the saved graphics state. Store at most one rect.
+    path: Option<Clip>,
+    pending: bool,
+    text_clip_pending: bool,
+}
+
+impl ClipTracker {
+    pub(super) fn rect(&self) -> Option<ClipRect> {
+        match self.active {
+            Clip::Rect(rect) if !self.text_clip_pending => Some(rect),
+            _ => None,
+        }
+    }
+
+    pub(super) fn observe(&mut self, operator: &str, operands: &[Object], ctm: [f32; 6]) {
+        match operator {
+            "q" => self.saved.push(self.active),
+            "Q" => self.active = self.saved.pop().unwrap_or(Clip::Unknown),
+            "cm" if operands.len() != 6
+                || !operands
+                    .iter()
+                    .all(|v| get_number(v).is_some_and(f32::is_finite)) =>
+            {
+                self.active = Clip::Unknown;
+            }
+            "re" => {
+                self.path = Some(if self.path.is_none() {
+                    ClipRect::from_path(operands, ctm).map_or(Clip::Unknown, Clip::Rect)
+                } else {
+                    Clip::Unknown
+                });
+            }
+            "m" | "l" | "c" | "v" | "y" | "h" => self.path = Some(Clip::Unknown),
+            "W" | "W*" => self.pending = true,
+            "n" | "S" | "s" | "f" | "F" | "f*" | "B" | "B*" | "b" | "b*" => {
+                if self.pending {
+                    self.active = match (self.active, self.path) {
+                        (Clip::Unbounded, Some(Clip::Rect(rect))) => Clip::Rect(rect),
+                        (Clip::Rect(active), Some(Clip::Rect(rect))) => {
+                            active.intersection(rect).map_or(Clip::Unknown, Clip::Rect)
+                        }
+                        _ => Clip::Unknown,
+                    };
+                }
+                self.path = None;
+                self.pending = false;
+            }
+            // Glyph outlines make the effective clip nonrectangular at ET.
+            // Abstain immediately as well, including q/Q inside the text object.
+            "Tr" if operands
+                .first()
+                .and_then(get_number)
+                .is_some_and(|v| v >= 4.0) =>
+            {
+                self.active = Clip::Unknown;
+                self.text_clip_pending = true;
+            }
+            "ET" if self.text_clip_pending => {
+                self.active = Clip::Unknown;
+                self.text_clip_pending = false;
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(super) fn separated_runs(
+    previous: &TextItem,
+    previous_clip: Option<&ClipRect>,
+    next: &TextItem,
+    next_clip: Option<&ClipRect>,
+) -> bool {
+    match (previous_clip, next_clip) {
+        (Some(left), Some(right)) => {
+            left.right + TOLERANCE < right.left
+                && left.contains_advance(previous)
+                && right.contains_advance(next)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+    fn apply(tracker: &mut ClipTracker, content: &str, ctm: [f32; 6]) {
+        for op in lopdf::content::Content::decode(content.as_bytes())
+            .unwrap()
+            .operations
+        {
+            tracker.observe(&op.operator, &op.operands, ctm);
+        }
+    }
+
+    #[test]
+    fn clip_waits_for_path_end_and_intersects_nested_rectangles() {
+        let mut tracker = ClipTracker::default();
+        apply(&mut tracker, "10 20 80 90 re W", IDENTITY);
+        assert!(tracker.rect().is_none());
+        apply(&mut tracker, "n q 20 10 100 80 re W* f", IDENTITY);
+        let rect = tracker.rect().unwrap();
+        assert_eq!(
+            (rect.left, rect.bottom, rect.right, rect.top),
+            (20.0, 20.0, 90.0, 90.0)
+        );
+        apply(&mut tracker, "Q", IDENTITY);
+        assert_eq!(tracker.rect().unwrap().left, 10.0);
+    }
+
+    #[test]
+    fn path_coordinates_are_captured_when_constructed() {
+        let mut tracker = ClipTracker::default();
+        apply(
+            &mut tracker,
+            "10 20 -5 10 re",
+            [-2.0, 0.0, 0.0, 3.0, 50.0, 7.0],
+        );
+        apply(&mut tracker, "W n", IDENTITY);
+        let rect = tracker.rect().unwrap();
+        assert_eq!(
+            (rect.left, rect.right, rect.bottom, rect.top),
+            (30.0, 40.0, 67.0, 97.0)
+        );
+    }
+
+    #[test]
+    fn uncertain_clips_remain_unknown_until_graphics_restore() {
+        for path in [
+            "0 0 m 10 0 l 10 10 l h W n",
+            "0 0 10 10 re 20 0 10 10 re W n",
+            "0 0 0 10 re W n",
+            "W n",
+            "0 0 10 10 re W n 30 30 10 10 re W n",
+        ] {
+            let mut tracker = ClipTracker::default();
+            apply(&mut tracker, "0 0 100 100 re W n q", IDENTITY);
+            apply(&mut tracker, path, IDENTITY);
+            apply(&mut tracker, "1 1 2 2 re W n", IDENTITY);
+            assert!(tracker.rect().is_none(), "{path}");
+            apply(&mut tracker, "Q", IDENTITY);
+            assert_eq!(tracker.rect().unwrap().right, 100.0);
+        }
+    }
+
+    #[test]
+    fn path_is_not_restored_with_graphics_state() {
+        let mut tracker = ClipTracker::default();
+        apply(&mut tracker, "q 10 20 30 40 re Q W n", IDENTITY);
+        assert_eq!(tracker.rect().unwrap().left, 10.0);
+    }
+
+    #[test]
+    fn unsupported_transforms_and_text_clips_abstain() {
+        for ctm in [
+            [0.0, 1.0, -1.0, 0.0, 0.0, 0.0],
+            [1.0, 0.1, 0.0, 1.0, 0.0, 0.0],
+            [f32::INFINITY, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ] {
+            let mut tracker = ClipTracker::default();
+            apply(&mut tracker, "1 2 30 40 re W n", ctm);
+            assert!(tracker.rect().is_none());
+        }
+        let mut tracker = ClipTracker::default();
+        apply(&mut tracker, "0 0 100 100 re W n BT q 4 Tr Q", IDENTITY);
+        assert!(tracker.rect().is_none());
+        apply(&mut tracker, "ET 1 1 2 2 re W n", IDENTITY);
+        assert!(tracker.rect().is_none());
+    }
+}

--- a/src/extractor/clip_boundaries.rs
+++ b/src/extractor/clip_boundaries.rs
@@ -150,10 +150,11 @@ pub(super) fn separated_runs(
     next_clip: Option<&ClipRect>,
 ) -> bool {
     match (previous_clip, next_clip) {
-        (Some(left), Some(right)) => {
-            left.right + TOLERANCE < right.left
-                && left.contains_advance(previous)
-                && right.contains_advance(next)
+        (Some(previous_rect), Some(next_rect)) => {
+            (previous_rect.right + TOLERANCE < next_rect.left
+                || next_rect.right + TOLERANCE < previous_rect.left)
+                && previous_rect.contains_advance(previous)
+                && next_rect.contains_advance(next)
         }
         _ => false,
     }

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -479,7 +479,18 @@ pub(crate) fn extract_page_text_items(
         stack.iter().rev().find_map(|e| e.mcid)
     }
 
+    let mut clips = super::clip_boundaries::ClipTracker::default();
+    let mut item_clips = Vec::new();
+    let mut shown_clip = None;
     for op in &content.operations {
+        // Record all items appended by the preceding operator, including paths
+        // that continue the loop early. Forms and ActualText remain unproven.
+        item_clips.resize(items.len(), shown_clip);
+        clips.observe(&op.operator, &op.operands, ctm);
+        shown_clip = match op.operator.as_str() {
+            "Tj" | "TJ" | "'" => clips.rect(),
+            _ => None,
+        };
         trace!("{} {:?}", op.operator, op.operands);
         text_paint.observe(&op.operator, &op.operands, &paint_resources);
         match op.operator.as_str() {
@@ -1905,6 +1916,8 @@ pub(crate) fn extract_page_text_items(
         }
     }
 
+    item_clips.resize(items.len(), shown_clip);
+
     // Reverse visual-order RTL runs while candidate indexes are still valid
     // (merge_text_items below reshapes the item list).
     crate::text_utils::fix_visual_order_rtl(&mut items, &rtl_visual_candidates, rtl_logical_ops);
@@ -1925,7 +1938,13 @@ pub(crate) fn extract_page_text_items(
         page_num,
     );
 
-    let items = super::merge_text_items(items);
+    let items = if page_rotation == PageRotation::Upright {
+        super::merge_text_items_with_clips(items, &item_clips)
+    } else {
+        // Clips use the original page frame; rotated-page correction is an
+        // intentionally unsupported provenance case.
+        super::merge_text_items(items)
+    };
     let items = super::merge_subscript_items(items);
     Ok((
         (items, rects, lines),

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -3,6 +3,7 @@
 //! This module extracts text with position information for structure detection.
 
 mod base14;
+mod clip_boundaries;
 mod content_decode;
 pub(crate) mod content_stream;
 mod fonts;
@@ -1211,9 +1212,24 @@ fn trimmed_suffix(next: &TextItem) -> &str {
 }
 
 pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
+    merge_text_items_with_clips(items, &[])
+}
+
+fn merge_text_items_with_clips(
+    items: Vec<TextItem>,
+    clips: &[Option<clip_boundaries::ClipRect>],
+) -> Vec<TextItem> {
     if items.is_empty() {
         return items;
     }
+
+    // References into `items` remain stable throughout grouping and sorting.
+    // Keep clipping provenance private rather than changing the public item type.
+    let clip_by_item: HashMap<*const TextItem, clip_boundaries::ClipRect> = items
+        .iter()
+        .zip(clips)
+        .filter_map(|(item, clip)| clip.map(|rect| (item as *const TextItem, rect)))
+        .collect();
 
     // Group items by (page, Y position) with 5pt tolerance
     let y_tolerance = 5.0;
@@ -1318,6 +1334,15 @@ pub(crate) fn merge_text_items(items: Vec<TextItem>) -> Vec<TextItem> {
                     break;
                 }
                 if gap < -first.font_size * 0.5 && !preserve_stream_order {
+                    break;
+                }
+                let previous = group[j - 1];
+                if clip_boundaries::separated_runs(
+                    previous,
+                    clip_by_item.get(&(previous as *const TextItem)),
+                    next,
+                    clip_by_item.get(&(next as *const TextItem)),
+                ) {
                     break;
                 }
                 // Vertically stacked DIGITS at different baselines — the

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5192,6 +5192,70 @@ fn clipping_provenance_follows_sorted_items_and_supported_show_operators() {
     );
 }
 
+fn clipped_rtl_items(left_clip: &str, right_clip: &str, visual_order: bool) -> Vec<TextItem> {
+    use lopdf::{dictionary, Document, Stream};
+
+    let field = |clip: &str, x: u32, text: &str| {
+        format!("q {clip} BT /F1 12 Tf 10 Tz 1 0 0 1 {x} 100 Tm ({text}) Tj ET Q\n")
+    };
+    let content = if visual_order {
+        field(left_clip, 50, "AB") + &field(right_clip, 52, "CD")
+    } else {
+        field(right_clip, 52, "DC") + &field(left_clip, 50, "BA")
+    };
+    let mut doc = Document::load_mem(&make_text_pdf(&content, "0 0 300 300")).unwrap();
+    let cmap = doc.add_object(Stream::new(
+        dictionary! {},
+        b"begincmap\n1 begincodespacerange\n<00> <FF>\nendcodespacerange\n\
+          4 beginbfchar\n<41> <05D0>\n<42> <05D1>\n<43> <05D2>\n<44> <05D3>\n\
+          endbfchar\nendcmap"
+            .to_vec(),
+    ));
+    let font = doc.get_object_mut((5, 0)).unwrap().as_dict_mut().unwrap();
+    font.set("ToUnicode", cmap);
+    font.set("FirstChar", 65);
+    font.set("LastChar", 68);
+    font.set("Widths", vec![lopdf::Object::Integer(500); 4]);
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    extract_text_with_positions_mem(&bytes).unwrap()
+}
+
+#[test]
+fn separated_rtl_clips_keep_runs_in_both_text_storage_orders() {
+    for visual_order in [false, true] {
+        let items = clipped_rtl_items("50 98 1.3 15 re W n", "52 98 1.3 15 re W n", visual_order);
+        assert_eq!(
+            items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["\u{05D1}\u{05D0}", "\u{05D3}\u{05D2}"]
+        );
+        assert_eq!(items.iter().map(|i| i.x).collect::<Vec<_>>(), [50.0, 52.0]);
+        assert!(items.iter().all(|i| i.advance_known));
+        // These narrow, measured runs would otherwise merge; their clip
+        // association must survive visual-order character correction too.
+        assert_eq!(clipped_rtl_items("", "", visual_order).len(), 1);
+    }
+}
+
+#[test]
+fn rtl_clips_still_require_separation_and_contained_advances() {
+    for (left, right) in [
+        ("50 98 10 15 re W n", "50 98 10 15 re W n"),
+        ("50 98 2 15 re W n", "52 98 1.3 15 re W n"),
+        ("50 98 2.2 15 re W n", "52 98 1.3 15 re W n"),
+        ("50 98 1.995 15 re W n", "52 98 1.3 15 re W n"),
+        ("50 98 1.1 15 re W n", "52 98 1.3 15 re W n"),
+        ("50 98 1.3 15 re W n", ""),
+        ("50 98 1.3 15 re W n", "52 98 m 54 98 l 54 110 l h W n"),
+    ] {
+        assert_eq!(
+            clipped_rtl_items(left, right, true).len(),
+            1,
+            "{left}; {right}"
+        );
+    }
+}
+
 #[test]
 fn clip_rounding_gaps_and_rotated_page_frames_keep_existing_output() {
     let touching = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5029,3 +5029,205 @@ BT /F1 12 Tf 0 -1 1 0 320 704 Tm (LINE) Tj ET";
         );
     }
 }
+
+fn clipped_run_items(content: &str) -> Vec<TextItem> {
+    extract_text_with_positions_mem(&make_text_pdf(content, "0 0 300 300")).unwrap()
+}
+
+fn clipped_field(clip: &str, x: f32, text: &str) -> String {
+    format!("q {clip} BT /F1 12 Tf 1 0 0 1 {x} 100 Tm ({text}) Tj ET Q\n")
+}
+
+#[test]
+fn separated_rectangular_clips_preserve_independent_measured_runs() {
+    let content = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")
+        + &clipped_field("84 98 25 15 re W* n", 84.0, "Beta")
+        + &clipped_field("112 98 45 15 re W n", 112.0, "Gamma");
+    let items = clipped_run_items(&content);
+    assert_eq!(
+        items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+        ["Alpha", "Beta", "Gamma"]
+    );
+    assert!(items.iter().all(|i| i.advance_known));
+    assert_eq!(
+        items.iter().map(|i| i.x).collect::<Vec<_>>(),
+        [50.0, 84.0, 112.0]
+    );
+}
+
+#[test]
+fn same_touching_overlapping_and_unknown_clips_keep_existing_merges() {
+    for (left, right) in [
+        ("50 98 100 15 re W n", "50 98 100 15 re W n"),
+        ("50 98 34 15 re W n", "84 98 25 15 re W n"),
+        ("50 98 36 15 re W n", "84 98 25 15 re W n"),
+        ("", ""),
+        ("50 98 31 15 re W n", ""),
+        ("", "84 98 25 15 re W n"),
+        ("50 98 31 15 re W n", "84 98 m 109 98 l 109 113 l h W n"),
+        ("50 98 31 15 re W n", "84 98 25 15 re 200 0 1 1 re W n"),
+    ] {
+        let content = clipped_field(left, 50.0, "Alpha") + &clipped_field(right, 84.0, "Beta");
+        let items = clipped_run_items(&content);
+        assert_eq!(items.len(), 1, "{left} / {right}: {items:?}");
+        assert_eq!(items[0].text, "Alpha Beta");
+    }
+    let currency = clipped_field("50 98 9 15 re W n", 50.0, "$")
+        + &clipped_field("59 98 20 15 re W n", 59.0, "60");
+    assert_eq!(clipped_run_items(&currency)[0].text, "$ 60");
+}
+
+#[test]
+fn clipping_preserves_prose_and_text_operator_fragments_within_one_clip() {
+    let prose = "q 40 90 150 40 re W n BT /F1 12 Tf 50 100 Td [(Al) (pha)] TJ ET \
+        q BT /F1 12 Tf 84 100 Td (Beta) Tj ET Q Q";
+    assert_eq!(clipped_run_items(prose)[0].text, "Alpha Beta");
+    // Each source word belongs to its own separated clip, regardless of whether
+    // downstream layout uses the words as prose or as fields.
+    let fields = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")
+        + &clipped_field("84 98 31 15 re W n", 84.0, "Alpha");
+    assert_eq!(
+        clipped_run_items(&fields)
+            .iter()
+            .map(|i| i.text.as_str())
+            .collect::<Vec<_>>(),
+        ["Alpha", "Alpha"]
+    );
+}
+
+#[test]
+fn clip_sidecar_stays_aligned_across_skipped_text_and_graphics_restore() {
+    let content = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")
+        + "BT /F1 12 Tf 3 Tr (Hidden) Tj () TJ ET\n"
+        + &clipped_field("84 98 25 15 re W n", 84.0, "Beta");
+    let items = clipped_run_items(&content);
+    assert_eq!(
+        items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+        ["Alpha", "Beta"]
+    );
+}
+
+#[test]
+fn nested_clips_and_transformed_paths_preserve_only_proven_boundaries() {
+    let left = "q 0 0 200 200 re W n 50 98 31 15 re W n \
+        1 0 0 1 10 0 cm BT /F1 12 Tf 40 100 Td (Alpha) Tj ET Q\n";
+    let right = "q 2 0 0 1 0 0 cm 42 98 12.5 15 re W n \
+        0.5 0 0 1 0 0 cm BT /F1 12 Tf 84 100 Td (Beta) Tj ET Q";
+    let items = clipped_run_items(&(left.to_string() + right));
+    assert_eq!(
+        items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+        ["Alpha", "Beta"]
+    );
+}
+
+#[test]
+fn partially_clipped_or_unmeasured_advances_do_not_prove_a_boundary() {
+    let content = clipped_field("50 98 15 15 re W n", 50.0, "Alpha")
+        + &clipped_field("84 98 25 15 re W n", 84.0, "Beta");
+    assert_eq!(clipped_run_items(&content)[0].text, "Alpha Beta");
+    let content = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")
+        + &clipped_field("84 98 25 15 re W n", 84.0, "Beta");
+    let bytes = make_text_pdf(&content, "0 0 300 300");
+    let unknown_font = String::from_utf8(bytes)
+        .unwrap()
+        .replace("/Helvetica", "/UnknownXX");
+    let items = extract_text_with_positions_mem(unknown_font.as_bytes()).unwrap();
+    assert_eq!(items.len(), 1);
+    assert!(!items[0].advance_known);
+}
+
+#[test]
+fn clip_provenance_does_not_guess_form_or_actual_text_boundaries() {
+    use lopdf::{dictionary, Object, Stream};
+    let content = "q 50 98 31 15 re W n /A Do Q q 84 98 25 15 re W n /B Do Q";
+    let mut doc = lopdf::Document::load_mem(&make_text_pdf(content, "0 0 300 300")).unwrap();
+    let a = doc.add_object(Stream::new(
+        dictionary! {
+            "Type" => "XObject", "Subtype" => "Form",
+            "BBox" => vec![0.into(),0.into(),300.into(),300.into()],
+        },
+        b"BT /F1 12 Tf 50 100 Td (Alpha) Tj ET".to_vec(),
+    ));
+    let b = doc.add_object(Stream::new(
+        dictionary! {
+            "Type" => "XObject", "Subtype" => "Form",
+            "BBox" => vec![0.into(),0.into(),300.into(),300.into()],
+        },
+        b"BT /F1 12 Tf 84 100 Td (Beta) Tj ET".to_vec(),
+    ));
+    let page_id = doc.get_pages()[&1];
+    doc.get_dictionary_mut(page_id)
+        .unwrap()
+        .get_mut(b"Resources")
+        .unwrap()
+        .as_dict_mut()
+        .unwrap()
+        .set(
+            "XObject",
+            dictionary! {"A"=>Object::Reference(a),"B"=>Object::Reference(b)},
+        );
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    let items = extract_text_with_positions_mem(&bytes).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].text, "Alpha Beta");
+    let actual = "q 50 98 31 15 re W n BT /F1 12 Tf 50 100 Td \
+        /Span << /ActualText (Alpha) >> BDC (Alpha) Tj EMC ET Q \
+        q 84 98 25 15 re W n BT /F1 12 Tf 84 100 Td \
+        /Span << /ActualText (Beta) >> BDC (Beta) Tj EMC ET Q";
+    assert_eq!(clipped_run_items(actual)[0].text, "Alpha Beta");
+}
+
+#[test]
+fn clipping_provenance_follows_sorted_items_and_supported_show_operators() {
+    let content = "q 112 98 45 15 re W n BT /F1 12 Tf 112 100 Td (Gamma) Tj ET Q \
+        q 50 98 31 15 re W n BT /F1 12 Tf 50 100 Td [(Al) (pha)] TJ ET Q \
+        q 84 98 25 15 re W n BT /F1 12 Tf 84 112 Td 12 TL (Beta) ' ET Q";
+    assert_eq!(
+        clipped_run_items(content)
+            .iter()
+            .map(|i| i.text.as_str())
+            .collect::<Vec<_>>(),
+        ["Alpha", "Beta", "Gamma"]
+    );
+}
+
+#[test]
+fn clip_rounding_gaps_and_rotated_page_frames_keep_existing_output() {
+    let touching = clipped_field("50 98 31 15 re W n", 50.0, "Alpha")
+        + &clipped_field("81.005 98 28 15 re W n", 84.0, "Beta");
+    assert_eq!(clipped_run_items(&touching)[0].text, "Alpha Beta");
+    let rotated = "q 98 50 15 31 re W n BT /F1 12 Tf 0 1 -1 0 100 50 Tm (Alpha) Tj ET Q \
+        q 98 84 15 25 re W n BT /F1 12 Tf 0 1 -1 0 100 84 Tm (Beta) Tj ET Q";
+    let unclipped = rotated
+        .replace("98 50 15 31 re W n", "")
+        .replace("98 84 15 25 re W n", "");
+    let observed = clipped_run_items(rotated);
+    let control = clipped_run_items(&unclipped);
+    assert_eq!(
+        observed
+            .iter()
+            .map(|i| (&i.text, i.x, i.y, i.width))
+            .collect::<Vec<_>>(),
+        control
+            .iter()
+            .map(|i| (&i.text, i.x, i.y, i.width))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn separated_clipped_word_fragments_keep_text_when_assembled() {
+    let content = clipped_field("50 98 10.8 15 re W n", 50.0, "Al")
+        + &clipped_field("61 98 21 15 re W n", 61.0, "pha");
+    let items = clipped_run_items(&content);
+    assert_eq!(
+        items.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+        ["Al", "pha"]
+    );
+    let md = process_pdf_mem(&make_text_pdf(&content, "0 0 300 300"))
+        .unwrap()
+        .markdown
+        .unwrap();
+    assert_eq!(md.trim(), "Alpha");
+}


### PR DESCRIPTION
## Summary

Preserve independently positioned text runs when their measured advances lie inside distinct rectangular clipping regions. This prevents neighboring fields from being merged across an explicit source boundary while retaining the existing behavior for touching, overlapping, or uncertain clipping geometry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PDF text merging so separately clipped fields no longer get concatenated into one line, and keeps those runs intact even when text is stored in RTL visual order.

- Tracks only proven, axis-aligned rectangular clip boundaries; clipping from paths, forms, rotated pages, or unsupported transforms is ignored and retains existing merge behavior.
- Clips are associated with text runs before visual-order RTL correction so separated runs survive both storage orders.

<sup>Written for commit 848b44c929f5454944d855e9815415633a363893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

