### PR TITLE
fix(fonts): read blank symbolic TrueType glyphs as word spaces

### DIFF
--- a/src/extractor/blank_glyph_tests.rs
+++ b/src/extractor/blank_glyph_tests.rs
@@ -1,9 +1,64 @@
 use lopdf::{dictionary, Document, Object, ObjectId, Stream};
 
+/// How the synthetic font's `cmap` addresses its glyphs.
+#[derive(Clone, Copy)]
+enum Cmap {
+    /// (1,0) format 0: byte code → glyph.
+    MacRoman,
+    /// (3,0) format 4: `0xF000 + code` → glyph.
+    SymbolPrivate,
+    /// (3,0) format 4: bare `code` → glyph.
+    SymbolBare,
+    /// (3,0) format 4: both `0xF000 + code` → glyph and bare `code` → the
+    /// glyph after it, to show which one wins.
+    SymbolBoth,
+}
+
 /// A minimal TrueType font: `head`, `hhea`, `maxp`, `hmtx`, `loca`, `glyf`
 /// and a (1,0) format 0 `cmap`. Glyph 0 is `.notdef`; each entry in
 /// `glyphs` is `(outlined, advance)`, mapped from `codes[i]`.
 fn synthetic_truetype(glyphs: &[(bool, u16)], codes: &[u8]) -> Vec<u8> {
+    synthetic_truetype_with(glyphs, codes, Cmap::MacRoman)
+}
+
+/// (3,0) format 4 subtable: one segment per mapping, `code → gid`.
+fn symbol_cmap(mappings: &[(u16, u16)]) -> Vec<u8> {
+    let mut mappings = mappings.to_vec();
+    mappings.sort();
+    let segs = mappings.len() as u16 + 1;
+    let mut sub = Vec::new();
+    sub.extend(4u16.to_be_bytes()); // format
+    sub.extend((16 + 8 * segs).to_be_bytes()); // length
+    sub.extend(0u16.to_be_bytes()); // language
+    sub.extend((segs * 2).to_be_bytes());
+    sub.extend([0u8; 6]);
+    for &(code, _) in &mappings {
+        sub.extend(code.to_be_bytes()); // endCode
+    }
+    sub.extend(0xFFFFu16.to_be_bytes());
+    sub.extend(0u16.to_be_bytes()); // reservedPad
+    for &(code, _) in &mappings {
+        sub.extend(code.to_be_bytes()); // startCode
+    }
+    sub.extend(0xFFFFu16.to_be_bytes());
+    for &(code, gid) in &mappings {
+        sub.extend(gid.wrapping_sub(code).to_be_bytes()); // idDelta
+    }
+    sub.extend(1u16.to_be_bytes());
+    for _ in 0..segs {
+        sub.extend(0u16.to_be_bytes()); // idRangeOffset
+    }
+    let mut cmap = Vec::new();
+    cmap.extend(0u16.to_be_bytes());
+    cmap.extend(1u16.to_be_bytes());
+    cmap.extend(3u16.to_be_bytes()); // platform Windows
+    cmap.extend(0u16.to_be_bytes()); // encoding Symbol
+    cmap.extend(12u32.to_be_bytes());
+    cmap.extend(sub);
+    cmap
+}
+
+fn synthetic_truetype_with(glyphs: &[(bool, u16)], codes: &[u8], kind: Cmap) -> Vec<u8> {
     let num_glyphs = glyphs.len() as u16 + 1;
     let square: Vec<u8> = {
         let mut g = Vec::new();
@@ -48,20 +103,50 @@ fn synthetic_truetype(glyphs: &[(bool, u16)], codes: &[u8]) -> Vec<u8> {
         hmtx.extend(advance.to_be_bytes());
         hmtx.extend(0i16.to_be_bytes());
     }
-    let mut cmap = Vec::new();
-    cmap.extend(0u16.to_be_bytes()); // version
-    cmap.extend(1u16.to_be_bytes()); // one subtable
-    cmap.extend(1u16.to_be_bytes()); // platform Macintosh
-    cmap.extend(0u16.to_be_bytes()); // encoding Roman
-    cmap.extend(12u32.to_be_bytes()); // offset
-    cmap.extend(0u16.to_be_bytes()); // format 0
-    cmap.extend(262u16.to_be_bytes());
-    cmap.extend(0u16.to_be_bytes()); // language
-    let mut glyph_ids = [0u8; 256];
-    for (i, &code) in codes.iter().enumerate() {
-        glyph_ids[code as usize] = i as u8 + 1;
-    }
-    cmap.extend(glyph_ids);
+    let cmap = match kind {
+        Cmap::MacRoman => {
+            let mut cmap = Vec::new();
+            cmap.extend(0u16.to_be_bytes()); // version
+            cmap.extend(1u16.to_be_bytes()); // one subtable
+            cmap.extend(1u16.to_be_bytes()); // platform Macintosh
+            cmap.extend(0u16.to_be_bytes()); // encoding Roman
+            cmap.extend(12u32.to_be_bytes()); // offset
+            cmap.extend(0u16.to_be_bytes()); // format 0
+            cmap.extend(262u16.to_be_bytes());
+            cmap.extend(0u16.to_be_bytes()); // language
+            let mut glyph_ids = [0u8; 256];
+            for (i, &code) in codes.iter().enumerate() {
+                glyph_ids[code as usize] = i as u8 + 1;
+            }
+            cmap.extend(glyph_ids);
+            cmap
+        }
+        Cmap::SymbolPrivate => symbol_cmap(
+            &codes
+                .iter()
+                .enumerate()
+                .map(|(i, &c)| (0xF000 + u16::from(c), i as u16 + 1))
+                .collect::<Vec<_>>(),
+        ),
+        Cmap::SymbolBare => symbol_cmap(
+            &codes
+                .iter()
+                .enumerate()
+                .map(|(i, &c)| (u16::from(c), i as u16 + 1))
+                .collect::<Vec<_>>(),
+        ),
+        Cmap::SymbolBoth => symbol_cmap(
+            &codes
+                .iter()
+                .enumerate()
+                .flat_map(|(i, &c)| {
+                    let gid = i as u16 + 1;
+                    let next = (gid % glyphs.len() as u16) + 1;
+                    [(0xF000 + u16::from(c), gid), (u16::from(c), next)]
+                })
+                .collect::<Vec<_>>(),
+        ),
+    };
     let mut tables: Vec<(&[u8; 4], Vec<u8>)> = vec![
         (b"cmap", cmap),
         (b"glyf", glyf),
@@ -102,10 +187,21 @@ fn doc_with_font(
     encoding: Option<&str>,
     content: &[u8],
 ) -> (Document, ObjectId) {
+    doc_with_font_cmap(glyphs, codes, tounicode, encoding, content, Cmap::MacRoman)
+}
+
+fn doc_with_font_cmap(
+    glyphs: &[(bool, u16)],
+    codes: &[u8],
+    tounicode: Option<&str>,
+    encoding: Option<&str>,
+    content: &[u8],
+    kind: Cmap,
+) -> (Document, ObjectId) {
     let mut doc = Document::with_version("1.4");
     let font_file = doc.add_object(Stream::new(
         dictionary! {},
-        synthetic_truetype(glyphs, codes),
+        synthetic_truetype_with(glyphs, codes, kind),
     ));
     let mut widths = vec![Object::Integer(0); 256];
     for (i, &code) in codes.iter().enumerate() {
@@ -157,8 +253,11 @@ fn text_of(doc: &mut Document) -> String {
 /// Codes `!` `"` `$` map to glyphs 1 (`3`), 2 (`r`) and 3 (the blank space).
 const WORD_FOR_MAC: &[(bool, u16)] = &[(true, 500), (true, 400), (false, 226)];
 const CODES: &[u8] = &[0x21, 0x22, 0x24];
+/// Ten entries: fewer than ten and the CMap loader treats the ToUnicode as
+/// too sparse and prefers the embedded cmap, which is a different subject.
 const STALE_TOUNICODE: &str = "1 begincodespacerange\n<00><FF>\nendcodespacerange\n\
-3 beginbfchar\n<21><0033>\n<22><0072>\n<24><0024>\nendbfchar";
+10 beginbfchar\n<21><0033>\n<22><0072>\n<24><0024>\n<30><0030>\n<31><0031>\n<32><0032>\n\
+<33><0033>\n<34><0034>\n<35><0035>\n<36><0036>\nendbfchar";
 const CONTENT: &[u8] = b"BT /F1 12 Tf 1 0 0 1 40 700 Tm (!\"$\"!) Tj ET";
 
 #[test]
@@ -272,4 +371,48 @@ fn non_symbolic_fonts_are_left_alone() {
         .unwrap()
         .set("FontDescriptor", descriptor);
     assert_eq!(text_of(&mut doc), "3r$r3");
+}
+
+#[test]
+fn symbol_cmaps_are_read_through_the_private_range_first() {
+    // (3,0) tables address symbolic glyphs at F000+code; the bare code is
+    // the last resort. In `SymbolBoth` the bare code points at the glyph
+    // after the intended one, so `$` (blank at F024) stays a space only if
+    // the private range is consulted first, and `!` (outlined at F021, blank
+    // `$` glyph at bare 0x22...) is untouched.
+    for kind in [Cmap::SymbolPrivate, Cmap::SymbolBare, Cmap::SymbolBoth] {
+        let (mut doc, _) = doc_with_font_cmap(
+            WORD_FOR_MAC,
+            CODES,
+            Some(STALE_TOUNICODE),
+            None,
+            CONTENT,
+            kind,
+        );
+        assert_eq!(text_of(&mut doc), "3r r3", "{:?}", kind as u8);
+    }
+}
+
+#[test]
+fn all_blank_font_counts_every_mapped_code() {
+    // Three mapped codes with one zero-advance glyph is still a text layer,
+    // not a single-space subset.
+    let (mut doc, _) = doc_with_font(
+        &[(false, 500), (false, 0), (false, 226)],
+        CODES,
+        Some(STALE_TOUNICODE),
+        None,
+        CONTENT,
+    );
+    assert_eq!(text_of(&mut doc), "3r$r3");
+}
+
+#[test]
+fn bidi_and_math_invisible_labels_keep_their_label() {
+    for label in ["200E", "202A", "2062", "2066"] {
+        let cmap = STALE_TOUNICODE.replace("<24><0024>", &format!("<24><{label}>"));
+        let (mut doc, _) = doc_with_font(WORD_FOR_MAC, CODES, Some(&cmap), None, CONTENT);
+        let text = text_of(&mut doc);
+        assert!(!text.contains(' '), "label {label}: {text:?}");
+    }
 }

--- a/src/extractor/blank_glyph_tests.rs
+++ b/src/extractor/blank_glyph_tests.rs
@@ -1,0 +1,275 @@
+use lopdf::{dictionary, Document, Object, ObjectId, Stream};
+
+/// A minimal TrueType font: `head`, `hhea`, `maxp`, `hmtx`, `loca`, `glyf`
+/// and a (1,0) format 0 `cmap`. Glyph 0 is `.notdef`; each entry in
+/// `glyphs` is `(outlined, advance)`, mapped from `codes[i]`.
+fn synthetic_truetype(glyphs: &[(bool, u16)], codes: &[u8]) -> Vec<u8> {
+    let num_glyphs = glyphs.len() as u16 + 1;
+    let square: Vec<u8> = {
+        let mut g = Vec::new();
+        g.extend(1i16.to_be_bytes()); // one contour
+        for v in [0i16, 0, 500, 700] {
+            g.extend(v.to_be_bytes()); // bbox
+        }
+        g.extend(2u16.to_be_bytes()); // endPtsOfContours
+        g.extend(0u16.to_be_bytes()); // no instructions
+        g.extend([1u8, 1, 1]); // on-curve, i16 coordinates
+        for v in [0i16, 500, 0, 0, 0, 700] {
+            g.extend(v.to_be_bytes());
+        }
+        g
+    };
+    let mut glyf = Vec::new();
+    let mut loca: Vec<u8> = Vec::new();
+    loca.extend(0u32.to_be_bytes());
+    glyf.extend(&square); // .notdef has an outline
+    loca.extend((glyf.len() as u32).to_be_bytes());
+    for &(outlined, _) in glyphs {
+        if outlined {
+            glyf.extend(&square);
+        }
+        loca.extend((glyf.len() as u32).to_be_bytes());
+    }
+    let mut head = vec![0u8; 54];
+    head[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    head[12..16].copy_from_slice(&0x5F0F_3CF5u32.to_be_bytes());
+    head[18..20].copy_from_slice(&1000u16.to_be_bytes()); // unitsPerEm
+    head[50..52].copy_from_slice(&1i16.to_be_bytes()); // long loca offsets
+    let mut hhea = vec![0u8; 36];
+    hhea[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    hhea[34..36].copy_from_slice(&num_glyphs.to_be_bytes());
+    let mut maxp = vec![0u8; 32];
+    maxp[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    maxp[4..6].copy_from_slice(&num_glyphs.to_be_bytes());
+    let mut hmtx = Vec::new();
+    hmtx.extend(600u16.to_be_bytes());
+    hmtx.extend(0i16.to_be_bytes());
+    for &(_, advance) in glyphs {
+        hmtx.extend(advance.to_be_bytes());
+        hmtx.extend(0i16.to_be_bytes());
+    }
+    let mut cmap = Vec::new();
+    cmap.extend(0u16.to_be_bytes()); // version
+    cmap.extend(1u16.to_be_bytes()); // one subtable
+    cmap.extend(1u16.to_be_bytes()); // platform Macintosh
+    cmap.extend(0u16.to_be_bytes()); // encoding Roman
+    cmap.extend(12u32.to_be_bytes()); // offset
+    cmap.extend(0u16.to_be_bytes()); // format 0
+    cmap.extend(262u16.to_be_bytes());
+    cmap.extend(0u16.to_be_bytes()); // language
+    let mut glyph_ids = [0u8; 256];
+    for (i, &code) in codes.iter().enumerate() {
+        glyph_ids[code as usize] = i as u8 + 1;
+    }
+    cmap.extend(glyph_ids);
+    let mut tables: Vec<(&[u8; 4], Vec<u8>)> = vec![
+        (b"cmap", cmap),
+        (b"glyf", glyf),
+        (b"head", head),
+        (b"hhea", hhea),
+        (b"hmtx", hmtx),
+        (b"loca", loca),
+        (b"maxp", maxp),
+    ];
+    tables.sort_by_key(|(tag, _)| **tag);
+    let mut font = Vec::new();
+    font.extend(0x0001_0000u32.to_be_bytes());
+    font.extend((tables.len() as u16).to_be_bytes());
+    font.extend([0u8; 6]); // searchRange, entrySelector, rangeShift
+    let mut offset = 12 + 16 * tables.len();
+    let mut body = Vec::new();
+    for (tag, data) in &tables {
+        font.extend(*tag);
+        font.extend(0u32.to_be_bytes()); // checksum, unchecked
+        font.extend((offset as u32).to_be_bytes());
+        font.extend((data.len() as u32).to_be_bytes());
+        let padded = data.len().div_ceil(4) * 4;
+        body.extend(data);
+        body.extend(std::iter::repeat_n(0u8, padded - data.len()));
+        offset += padded;
+    }
+    font.extend(body);
+    font
+}
+
+/// Space glyph on code `$` (0x24, no outline, advance 226) between two
+/// letters, as Word 2011 for Mac writes it. `tounicode` may label `$` as
+/// itself; `encoding` optionally adds an `/Encoding` name.
+fn doc_with_font(
+    glyphs: &[(bool, u16)],
+    codes: &[u8],
+    tounicode: Option<&str>,
+    encoding: Option<&str>,
+    content: &[u8],
+) -> (Document, ObjectId) {
+    let mut doc = Document::with_version("1.4");
+    let font_file = doc.add_object(Stream::new(
+        dictionary! {},
+        synthetic_truetype(glyphs, codes),
+    ));
+    let mut widths = vec![Object::Integer(0); 256];
+    for (i, &code) in codes.iter().enumerate() {
+        widths[code as usize] = Object::Integer(i64::from(glyphs[i].1));
+    }
+    let mut font = dictionary! {
+        "Type" => "Font", "Subtype" => "TrueType", "BaseFont" => "ABCDEF+Synthetic-Bold",
+        "FirstChar" => 0, "LastChar" => 255, "Widths" => widths,
+        "FontDescriptor" => dictionary! { "Flags" => 4, "FontFile2" => font_file },
+    };
+    if let Some(cmap) = tounicode {
+        let cmap_id = doc.add_object(Stream::new(dictionary! {}, cmap.as_bytes().to_vec()));
+        font.set("ToUnicode", cmap_id);
+    }
+    if let Some(name) = encoding {
+        font.set("Encoding", Object::Name(name.as_bytes().to_vec()));
+    }
+    let font_id = doc.add_object(font);
+    let content_id = doc.add_object(Stream::new(dictionary! {}, content.to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page", "MediaBox" => vec![0.into(), 0.into(), 600.into(), 800.into()],
+        "Resources" => dictionary! { "Font" => dictionary! { "F1" => font_id } },
+        "Contents" => content_id,
+    });
+    let pages_id = doc.add_object(
+        dictionary! { "Type" => "Pages", "Count" => 1, "Kids" => vec![Object::Reference(page_id)] },
+    );
+    doc.get_object_mut(page_id)
+        .unwrap()
+        .as_dict_mut()
+        .unwrap()
+        .set("Parent", pages_id);
+    let catalog = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog);
+    (doc, font_id)
+}
+
+fn text_of(doc: &mut Document) -> String {
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    crate::extract_text_with_positions_mem(&bytes)
+        .unwrap()
+        .into_iter()
+        .map(|item| item.text)
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Codes `!` `"` `$` map to glyphs 1 (`3`), 2 (`r`) and 3 (the blank space).
+const WORD_FOR_MAC: &[(bool, u16)] = &[(true, 500), (true, 400), (false, 226)];
+const CODES: &[u8] = &[0x21, 0x22, 0x24];
+const STALE_TOUNICODE: &str = "1 begincodespacerange\n<00><FF>\nendcodespacerange\n\
+3 beginbfchar\n<21><0033>\n<22><0072>\n<24><0024>\nendbfchar";
+const CONTENT: &[u8] = b"BT /F1 12 Tf 1 0 0 1 40 700 Tm (!\"$\"!) Tj ET";
+
+#[test]
+fn synthetic_truetype_parses_with_the_intended_outlines() {
+    let data = synthetic_truetype(WORD_FOR_MAC, CODES);
+    let face = ttf_parser::Face::parse(&data, 0).expect("valid synthetic TrueType");
+    assert_eq!(face.number_of_glyphs(), 4);
+    let cmap = face.tables().cmap.unwrap();
+    let subtable = cmap.subtables.get(0).unwrap();
+    let gid = |code: u8| subtable.glyph_index(u32::from(code)).unwrap();
+    assert!(face.glyph_bounding_box(gid(0x21)).is_some());
+    assert!(face.glyph_bounding_box(gid(0x24)).is_none());
+    assert_eq!(face.glyph_hor_advance(gid(0x24)), Some(226));
+}
+
+#[test]
+fn blank_glyph_reads_as_space_despite_stale_tounicode() {
+    let (mut doc, _) = doc_with_font(WORD_FOR_MAC, CODES, Some(STALE_TOUNICODE), None, CONTENT);
+    assert_eq!(text_of(&mut doc), "3r r3");
+}
+
+#[test]
+fn blank_glyph_reads_as_space_without_tounicode() {
+    let (mut doc, _) = doc_with_font(WORD_FOR_MAC, CODES, None, None, CONTENT);
+    assert_eq!(text_of(&mut doc), "!\" \"!");
+}
+
+#[test]
+fn fonts_with_an_encoding_keep_their_tounicode() {
+    // With `/Encoding` the codes no longer route through the font's own
+    // cmap, so the outline evidence does not apply.
+    let (mut doc, _) = doc_with_font(
+        WORD_FOR_MAC,
+        CODES,
+        Some(STALE_TOUNICODE),
+        Some("WinAnsiEncoding"),
+        CONTENT,
+    );
+    assert_eq!(text_of(&mut doc), "3r$r3");
+}
+
+#[test]
+fn all_blank_fonts_are_an_invisible_layer_and_stay_untouched() {
+    let (mut doc, _) = doc_with_font(
+        &[(false, 500), (false, 400), (false, 226)],
+        CODES,
+        Some(STALE_TOUNICODE),
+        None,
+        CONTENT,
+    );
+    assert_eq!(text_of(&mut doc), "3r$r3");
+}
+
+#[test]
+fn blank_glyph_without_advance_is_not_a_space() {
+    let (mut doc, _) = doc_with_font(
+        &[(true, 500), (true, 400), (false, 0)],
+        CODES,
+        Some(STALE_TOUNICODE),
+        None,
+        CONTENT,
+    );
+    assert_eq!(text_of(&mut doc), "3r$r3");
+}
+
+#[test]
+fn blank_glyph_labelled_as_invisible_formatting_is_not_a_space() {
+    // A soft hyphen or a zero-width space renders as nothing: a blank glyph
+    // is what the label already says, so it is not evidence of a stale
+    // ToUnicode. Downstream cleanup may drop the invisible character, but
+    // no word space is invented.
+    for label in ["00AD", "200B"] {
+        let cmap = STALE_TOUNICODE.replace("<24><0024>", &format!("<24><{label}>"));
+        let (mut doc, _) = doc_with_font(WORD_FOR_MAC, CODES, Some(&cmap), None, CONTENT);
+        let text = text_of(&mut doc);
+        assert!(!text.contains(' '), "label {label}: {text:?}");
+        assert_eq!(
+            text.replace(['\u{00AD}', '\u{200B}'], ""),
+            "3rr3",
+            "label {label}"
+        );
+    }
+}
+
+#[test]
+fn blank_glyph_labelled_as_a_tab_reads_as_a_word_space() {
+    // Word for Mac labels the blank tab glyph U+0009; in prose it is a word
+    // gap, and a literal tab has no use in Markdown.
+    let cmap = STALE_TOUNICODE.replace("<24><0024>", "<24><0009>");
+    let (mut doc, _) = doc_with_font(WORD_FOR_MAC, CODES, Some(&cmap), None, CONTENT);
+    assert_eq!(text_of(&mut doc), "3r r3");
+}
+
+#[test]
+fn non_symbolic_fonts_are_left_alone() {
+    let (mut doc, font_id) =
+        doc_with_font(WORD_FOR_MAC, CODES, Some(STALE_TOUNICODE), None, CONTENT);
+    let descriptor = doc
+        .get_object(font_id)
+        .unwrap()
+        .as_dict()
+        .unwrap()
+        .get(b"FontDescriptor")
+        .unwrap()
+        .clone();
+    let mut descriptor = descriptor.as_dict().unwrap().clone();
+    descriptor.set("Flags", 32); // Nonsymbolic
+    doc.get_object_mut(font_id)
+        .unwrap()
+        .as_dict_mut()
+        .unwrap()
+        .set("FontDescriptor", descriptor);
+    assert_eq!(text_of(&mut doc), "3r$r3");
+}

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -400,7 +400,8 @@ pub(crate) fn extract_page_text_items(
         .collect();
 
     // Build font encoding maps from Differences arrays
-    let (font_encodings, has_gid_fonts) = build_font_encodings(doc, &fonts, font_cmaps);
+    let (font_encodings, has_gid_fonts) =
+        build_font_encodings(doc, &fonts, font_cmaps, style_cache);
 
     // Build font width info for accurate text positioning
     let font_widths = build_font_widths(doc, &fonts);

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -760,6 +760,7 @@ pub(crate) fn build_font_encodings(
     doc: &Document,
     fonts: &std::collections::BTreeMap<Vec<u8>, &lopdf::Dictionary>,
     cmaps: &FontCMaps,
+    font_cache: &mut FontStyleCache,
 ) -> (PageFontEncodings, bool) {
     let mut encodings = PageFontEncodings::new();
     let mut has_gid_fonts = false;
@@ -767,6 +768,8 @@ pub(crate) fn build_font_encodings(
     for (font_name, font_dict) in fonts {
         let resource_name = String::from_utf8_lossy(font_name).to_string();
 
+        let mut differences = FontEncodingMap::new();
+        let mut identity_overrides = FontEncodingMap::new();
         if let Some(result) = parse_font_encoding(doc, font_dict) {
             if !result.gid_codes.is_empty()
                 && !tounicode_maps_codes(font_dict, cmaps, &result.gid_codes)
@@ -774,20 +777,154 @@ pub(crate) fn build_font_encodings(
                 has_gid_fonts = true;
             }
             if !result.map.is_empty() {
-                let identity_overrides =
-                    stale_identity_cmap_overrides(doc, font_dict, cmaps, &result);
-                encodings.insert(
-                    resource_name,
-                    FontEncoding {
-                        differences: result.map,
-                        identity_overrides,
-                    },
-                );
+                identity_overrides = stale_identity_cmap_overrides(doc, font_dict, cmaps, &result);
+                differences = result.map;
             }
+        }
+        let blank_codes = blank_glyph_codes(doc, font_dict, font_cache);
+        if !differences.is_empty() || !blank_codes.is_empty() {
+            encodings.insert(
+                resource_name,
+                FontEncoding {
+                    differences,
+                    identity_overrides,
+                    blank_codes,
+                },
+            );
         }
     }
 
     (encodings, has_gid_fonts)
+}
+
+/// Whether `code`, decoded as `label`, is a blank glyph standing in for a
+/// word space: the glyph paints nothing but advances. A tab or no-break
+/// space label is spacing already and reads as a plain space too; labels
+/// that are invisible formatting (soft hyphen, zero-width joiners, byte
+/// order mark) keep their meaning, since a blank glyph is exactly what they
+/// render as.
+fn blank_glyph_reads_as_space(encoding: Option<&FontEncoding>, code: u8, label: &str) -> bool {
+    encoding.is_some_and(|map| map.blank_codes.contains(&code))
+        && label.chars().any(|c| {
+            !matches!(
+                c,
+                '\u{00AD}' | '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{2060}' | '\u{FEFF}'
+            )
+        })
+}
+
+/// Codes of a symbolic TrueType font whose glyph has no outline but a
+/// positive advance. Painted, such a glyph leaves a gap and nothing else, so
+/// the code reads as a space whatever the font's ToUnicode says. Word 2011
+/// for Mac writes subsets whose ToUnicode labels the space glyph with the
+/// code it landed on ("$", "!", "&"), turning every word space into
+/// punctuation. Only symbolic fonts without an `/Encoding` are considered:
+/// they map codes through their own `cmap`, which is the evidence used here.
+/// A font with no outlined glyph at all (an invisible text layer) is left
+/// alone. Results are cached per embedded font program.
+fn blank_glyph_codes(
+    doc: &Document,
+    font_dict: &lopdf::Dictionary,
+    font_cache: &mut FontStyleCache,
+) -> std::collections::HashSet<u8> {
+    use ttf_parser::PlatformId;
+
+    let font_file = || -> Option<ObjectId> {
+        if font_dict.get(b"Subtype").ok()?.as_name().ok()? != b"TrueType"
+            || font_dict.get(b"Encoding").is_ok()
+        {
+            return None;
+        }
+        let descriptor = resolve_dict(doc, font_dict.get(b"FontDescriptor").ok()?)?;
+        // Flags bit 3: symbolic. Non-symbolic fonts route codes through a
+        // standard encoding, not their own cmap.
+        if descriptor.get(b"Flags").ok()?.as_i64().ok()? & 4 == 0 {
+            return None;
+        }
+        descriptor.get(b"FontFile2").ok()?.as_reference().ok()
+    };
+    let Some(ff_ref) = font_file() else {
+        return Default::default();
+    };
+    if let Some(cached) = font_cache.blank_codes_by_font_file.get(&ff_ref) {
+        return cached.clone();
+    }
+    let compute = || -> Option<std::collections::HashSet<u8>> {
+        let data = font_file_data(doc, ff_ref)?;
+        let face = ttf_parser::Face::parse(&data, 0).ok()?;
+        let cmap = face.tables().cmap?;
+        // Symbolic fonts address their glyphs through a (1,0) table by
+        // code, or a (3,0) table by code in one of the private ranges
+        // F000-F2FF, with the bare code as the last resort (PDF 32000-1,
+        // 9.6.6.4).
+        let glyph_for = |code: u8| -> Option<ttf_parser::GlyphId> {
+            let code = u32::from(code);
+            for subtable in cmap.subtables {
+                let candidates: &[u32] = match (subtable.platform_id, subtable.encoding_id) {
+                    (PlatformId::Macintosh, _) => &[code],
+                    (PlatformId::Windows, 0) => {
+                        &[0xF000 + code, 0xF100 + code, 0xF200 + code, code]
+                    }
+                    _ => continue,
+                };
+                for &candidate in candidates {
+                    if let Some(gid) = subtable.glyph_index(candidate) {
+                        if gid.0 != 0 {
+                            return Some(gid);
+                        }
+                    }
+                }
+            }
+            None
+        };
+        let mut blank = std::collections::HashSet::new();
+        let mut outlined = 0usize;
+        // Control codes never carry a word space; Word's subsets start at
+        // 0x21 and other producers keep 0x00-0x1F for genuinely blank
+        // control glyphs.
+        for code in 0x20u8..=255 {
+            let Some(gid) = glyph_for(code) else {
+                continue;
+            };
+            if face.glyph_bounding_box(gid).is_some() {
+                outlined += 1;
+                continue;
+            }
+            // The glyph program's own advance keeps the result a property
+            // of the font file, which is what the cache is keyed by.
+            if face.glyph_hor_advance(gid).is_some_and(|w| w > 0) {
+                blank.insert(code);
+            }
+        }
+        // Word for Mac also writes a subset per run, so a space painted on
+        // its own arrives as a font holding nothing but `.notdef` and that
+        // blank glyph, with one code mapped. With no outline anywhere, at
+        // most two mapped codes still read as such a space subset; more is
+        // an invisible text layer, which keeps its text.
+        if blank.is_empty() || (outlined == 0 && blank.len() > 2) {
+            return None;
+        }
+        debug!(
+            "blank glyph codes for {}: {:?}",
+            font_dict
+                .get(b"BaseFont")
+                .ok()
+                .and_then(|o| o.as_name().ok())
+                .map(|n| String::from_utf8_lossy(n).into_owned())
+                .unwrap_or_default(),
+            {
+                let mut codes: Vec<u8> = blank.iter().copied().collect();
+                codes.sort_unstable();
+                codes
+            }
+        );
+        Some(blank)
+    };
+    let blank = compute().unwrap_or_default();
+    font_cache
+        .blank_codes_by_font_file
+        .insert(ff_ref, blank.clone());
+    blank
 }
 
 /// Some subset producers change the simple font's glyph encoding but retain
@@ -1115,8 +1252,9 @@ pub(crate) fn get_font_file2_obj_num(doc: &Document, font_dict: &lopdf::Dictiona
         .map(|r| r.0)
 }
 
-/// Document-scoped memo of embedded-font style flags, keyed by the
-/// FontFile2/FontFile3 stream's object id. The same font program is
+/// Document-scoped memo of facts read from embedded font programs, keyed
+/// by the FontFile2/FontFile3 stream's object id: style flags, and the
+/// blank-glyph codes of `blank_glyph_codes`. The same font program is
 /// referenced from every page that uses the font, and decompressing +
 /// parsing it dominates `descriptor_style_flags` — without the memo that
 /// cost repeats per page whenever the descriptor leaves a flag unset
@@ -1124,6 +1262,9 @@ pub(crate) fn get_font_file2_obj_num(doc: &Document, font_dict: &lopdf::Dictiona
 #[derive(Debug, Default)]
 pub(crate) struct FontStyleCache {
     by_font_file: HashMap<ObjectId, (bool, bool)>,
+    /// Blank-glyph codes per embedded font program (see `blank_glyph_codes`),
+    /// so a font shared across pages is scanned once.
+    blank_codes_by_font_file: HashMap<ObjectId, std::collections::HashSet<u8>>,
 }
 
 impl FontStyleCache {
@@ -1317,43 +1458,52 @@ pub(crate) fn extract_text_from_operand(
                 // This prevents partial CMap results from blocking the Differences path.
                 if entry.primary.code_byte_length == 1 {
                     let encoding_map = font_encodings.get(current_font);
+                    let decode_byte = |b: u8| -> Option<String> {
+                        let code = b as u16;
+                        // 1. Primary CMap
+                        if let Some(s) = entry.primary.lookup(code) {
+                            if !s.contains('\u{FFFD}') {
+                                if s == (b as char).to_string() {
+                                    if let Some(&ch) =
+                                        encoding_map.and_then(|map| map.identity_overrides.get(&b))
+                                    {
+                                        return Some(ch.to_string());
+                                    }
+                                }
+                                return Some(s);
+                            }
+                        }
+                        // 2. Fallback CMap (embedded font cmap)
+                        if let Some(fb) = entry.fallback.as_ref().and_then(|c| c.lookup(code)) {
+                            if !fb.contains('\u{FFFD}') {
+                                return Some(fb);
+                            }
+                        }
+                        // 3. Differences mapped it? Use Differences result
+                        if let Some(map) = encoding_map {
+                            if let Some(&ch) = map.differences.get(&b) {
+                                return Some(ch.to_string());
+                            }
+                        }
+                        // 4. Printable single-byte fallback
+                        if b >= 0x20 {
+                            return Some(
+                                decode_single_byte_fallback_char(b, use_cp1252_fallback)
+                                    .to_string(),
+                            );
+                        }
+                        None
+                    };
                     let decoded: String = bytes
                         .iter()
                         .filter_map(|&b| {
-                            let code = b as u16;
-                            // 1. Primary CMap
-                            if let Some(s) = entry.primary.lookup(code) {
-                                if !s.contains('\u{FFFD}') {
-                                    if s == (b as char).to_string() {
-                                        if let Some(&ch) = encoding_map
-                                            .and_then(|map| map.identity_overrides.get(&b))
-                                        {
-                                            return Some(ch.to_string());
-                                        }
-                                    }
-                                    return Some(s);
-                                }
+                            let label = decode_byte(b)?;
+                            // A glyph with no outline paints a gap, whatever
+                            // its label says.
+                            if blank_glyph_reads_as_space(encoding_map, b, &label) {
+                                return Some(" ".to_string());
                             }
-                            // 2. Fallback CMap (embedded font cmap)
-                            if let Some(fb) = entry.fallback.as_ref().and_then(|c| c.lookup(code)) {
-                                if !fb.contains('\u{FFFD}') {
-                                    return Some(fb);
-                                }
-                            }
-                            // 3. Differences mapped it? Use Differences result
-                            if let Some(map) = encoding_map {
-                                if let Some(&ch) = map.differences.get(&b) {
-                                    return Some(ch.to_string());
-                                }
-                            }
-                            // 4. Printable single-byte fallback
-                            if b >= 0x20 {
-                                return Some(
-                                    decode_single_byte_fallback_char(b, use_cp1252_fallback)
-                                        .to_string(),
-                                );
-                            }
-                            None
+                            Some(label)
                         })
                         .collect();
                     if !decoded.is_empty() {
@@ -1464,14 +1614,16 @@ pub(crate) fn extract_text_from_operand(
             // The Differences array overrides specific codes in a base encoding (typically
             // WinAnsiEncoding). We must combine Differences entries with the base encoding
             // rather than using filter_map which silently drops unmapped bytes.
-            if let Some(encoding_map) = font_encodings.get(current_font) {
-                let encoding_map = &encoding_map.differences;
-                let has_diff_match = bytes.iter().any(|b| encoding_map.contains_key(b));
+            if let Some(encoding) = font_encodings.get(current_font) {
+                let encoding_map = &encoding.differences;
+                let has_diff_match = bytes
+                    .iter()
+                    .any(|b| encoding_map.contains_key(b) || encoding.blank_codes.contains(b));
                 if has_diff_match {
                     let decoded: String = bytes
                         .iter()
                         .filter_map(|&b| {
-                            if let Some(&ch) = encoding_map.get(&b) {
+                            let label = if let Some(&ch) = encoding_map.get(&b) {
                                 Some(ch)
                             } else if b >= 0x20 {
                                 // Base encoding fallback for printable bytes.
@@ -1480,7 +1632,13 @@ pub(crate) fn extract_text_from_operand(
                                 Some(decode_single_byte_fallback_char(b, use_cp1252_fallback))
                             } else {
                                 None // Skip unmapped control characters
+                            }?;
+                            // A glyph with no outline paints a gap, whatever
+                            // its label says.
+                            if blank_glyph_reads_as_space(Some(encoding), b, &label.to_string()) {
+                                return Some(' ');
                             }
+                            Some(label)
                         })
                         .collect();
                     if !decoded.is_empty() {
@@ -2593,7 +2751,8 @@ end",
         let (doc, page_id) = gid_font_doc(bfchar);
         let cmaps = FontCMaps::from_doc(&doc);
         let fonts = doc.get_page_fonts(page_id).unwrap();
-        let (_, has_gid_fonts) = build_font_encodings(&doc, &fonts, &cmaps);
+        let (_, has_gid_fonts) =
+            build_font_encodings(&doc, &fonts, &cmaps, &mut FontStyleCache::new());
         has_gid_fonts
     }
 
@@ -2685,3 +2844,7 @@ end",
 #[cfg(test)]
 #[path = "stale_cmap_tests.rs"]
 mod stale_cmap_tests;
+
+#[cfg(test)]
+#[path = "blank_glyph_tests.rs"]
+mod blank_glyph_tests;

--- a/src/extractor/fonts.rs
+++ b/src/extractor/fonts.rs
@@ -805,12 +805,23 @@ pub(crate) fn build_font_encodings(
 /// render as.
 fn blank_glyph_reads_as_space(encoding: Option<&FontEncoding>, code: u8, label: &str) -> bool {
     encoding.is_some_and(|map| map.blank_codes.contains(&code))
-        && label.chars().any(|c| {
-            !matches!(
-                c,
-                '\u{00AD}' | '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{2060}' | '\u{FEFF}'
-            )
-        })
+        && label.chars().any(|c| !is_invisible_format(c))
+}
+
+/// Characters that render as nothing by design: soft hyphen, zero-width
+/// spaces and joiners, bidi marks, embeddings and isolates, invisible math
+/// operators, byte order mark. A blank glyph labelled with one of these is
+/// the label's own rendering, not a stale space.
+fn is_invisible_format(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00AD}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{2064}'
+            | '\u{2066}'..='\u{2069}'
+            | '\u{FEFF}'
+    )
 }
 
 /// Codes of a symbolic TrueType font whose glyph has no outline but a
@@ -861,7 +872,7 @@ fn blank_glyph_codes(
             let code = u32::from(code);
             for subtable in cmap.subtables {
                 let candidates: &[u32] = match (subtable.platform_id, subtable.encoding_id) {
-                    (PlatformId::Macintosh, _) => &[code],
+                    (PlatformId::Macintosh, 0) => &[code],
                     (PlatformId::Windows, 0) => {
                         &[0xF000 + code, 0xF100 + code, 0xF200 + code, code]
                     }
@@ -879,6 +890,7 @@ fn blank_glyph_codes(
         };
         let mut blank = std::collections::HashSet::new();
         let mut outlined = 0usize;
+        let mut mapped = 0usize;
         // Control codes never carry a word space; Word's subsets start at
         // 0x21 and other producers keep 0x00-0x1F for genuinely blank
         // control glyphs.
@@ -886,6 +898,7 @@ fn blank_glyph_codes(
             let Some(gid) = glyph_for(code) else {
                 continue;
             };
+            mapped += 1;
             if face.glyph_bounding_box(gid).is_some() {
                 outlined += 1;
                 continue;
@@ -901,7 +914,7 @@ fn blank_glyph_codes(
         // blank glyph, with one code mapped. With no outline anywhere, at
         // most two mapped codes still read as such a space subset; more is
         // an invisible text layer, which keeps its text.
-        if blank.is_empty() || (outlined == 0 && blank.len() > 2) {
+        if blank.is_empty() || (outlined == 0 && mapped > 2) {
             return None;
         }
         debug!(

--- a/src/extractor/xobjects.rs
+++ b/src/extractor/xobjects.rs
@@ -333,7 +333,8 @@ fn extract_form_xobject_text_inner(
         })
         .map(|(name, _)| String::from_utf8_lossy(name).into_owned())
         .collect();
-    let (font_encodings, _has_gid_fonts) = build_font_encodings(doc, &form_fonts, font_cmaps);
+    let (font_encodings, _has_gid_fonts) =
+        build_font_encodings(doc, &form_fonts, font_cmaps, style_cache);
 
     // Build font width info for the form
     let font_widths = build_font_widths(doc, &form_fonts);

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,10 @@ pub(crate) type FontEncodingMap = HashMap<u8, char>;
 pub(crate) struct FontEncoding {
     pub(crate) differences: FontEncodingMap,
     pub(crate) identity_overrides: FontEncodingMap,
+    /// Codes whose embedded glyph has no outline but a positive advance:
+    /// painted, they leave a gap and nothing else, so they read as spaces
+    /// whatever the font's ToUnicode claims (see `blank_glyph_codes`).
+    pub(crate) blank_codes: std::collections::HashSet<u8>,
 }
 
 /// All font encodings for a page


### PR DESCRIPTION
## Summary

Word 2011 for Mac writes symbolic TrueType subsets whose ToUnicode labels the space glyph with whatever code it landed on, so every word space extracts as `$`, `!` or `&` (`3rd$Workshop$on$Chest$Wall$Deformities`). It also emits one subset per run, so a lone space arrives as a font holding nothing but `.notdef` and that glyph. Same family as #516 (stale ToUnicode), different container.

## Change

- For a symbolic TrueType font without `/Encoding`, look each printable code up in the embedded font's own `cmap` ((1,0) by code, (3,0) via the F0xx private ranges first). A glyph with **no outline but a positive advance** paints nothing, so the code reads as a space whatever its label says.
- Labels that are themselves invisible formatting (soft hyphen, zero-width marks, BOM) keep their meaning. Tab and NBSP labels read as a plain space: they are spacing already.
- A font with no outline anywhere and more than two mapped codes is an invisible text layer and keeps its text; one or two codes is Word's single-space subset.
- Applied in both the CMap and the Differences decode paths through one helper; results cached per font program in the existing per-document font cache.

## Tests

Nine unit tests on a hand-built TrueType (`head`/`hhea`/`maxp`/`hmtx`/`loca`/`glyf`/`cmap`): stale label, no ToUnicode, wide-run control, `/Encoding` present, non-symbolic flag, all-blank layer, zero advance, invisible-format labels, tab label.

## Eval footprint

Five corpus documents change, all from this rule: the motivating conference programme recovers its word spaces and headings; a student handbook gets spaces around emphasis markers and its bullets become list items (its blank glyphs are labelled TAB); two documents lose a phantom `#` from a blank ZapfDingbats glyph; one has whitespace-only changes. Measured against a rebaselined main, since #518 and #519 landed today without a pdf-evals sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Word 2011 for Mac symbolic TrueType subsets extracting every word space as `$`, `!`, or `&`.

**Bug Fixes**
- Reads glyphs with no outline but a positive advance as spaces, via the embedded font's own cmap, regardless of their ToUnicode label.
- Applies to symbolic TrueType fonts without an `/Encoding`; invisible formatting labels (soft hyphen, zero-width marks, bidi and math controls) keep their meaning, while tab and NBSP labels become plain spaces.
- Leaves fonts with no outlines and more than two mapped codes untouched, since those are invisible text layers.
- Caches results per font program and applies the rule in both the CMap and Differences decode paths.

<sup>Written for commit b1983e344f1cf1aee3ede9a342437789d67bf5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

