### PR TITLE
fix(tounicode): decode cmap-less TrueType subsets by standard Mac glyph order

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1032,6 +1032,19 @@ fn identity_h_font_has_fallback(font_dict: &lopdf::Dictionary, doc: &Document) -
             if embedded_font_has_cmap(doc, ff_ref) {
                 return true;
             }
+            // Fallback 3: no cmap, but the glyph order is the standard
+            // Macintosh one and the metrics corroborate it (see
+            // `mac_glyph_order`); extraction decodes it.
+            if crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc)
+                && doc
+                    .get_object(ff_ref)
+                    .and_then(Object::as_stream)
+                    .ok()
+                    .and_then(|stream| stream.decompressed_content().ok())
+                    .is_some_and(|data| crate::mac_glyph_order::font_file_follows_mac_order(&data))
+            {
+                return true;
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod adobe_korea1;
 pub mod detector;
 pub mod extractor;
 pub mod glyph_names;
+mod mac_glyph_order;
 pub mod markdown;
 pub mod process_mode;
 pub mod structure_tree;

--- a/src/mac_glyph_order.rs
+++ b/src/mac_glyph_order.rs
@@ -291,13 +291,21 @@ pub(crate) fn cid_to_gid_is_identity(cid_font_dict: &lopdf::Dictionary, doc: &Do
     }
 }
 
+/// Whether an Identity CIDFont's embedded program decodes through the
+/// standard Macintosh order: the detector's view of the same decision, so
+/// pages this rescues are not routed to OCR.
+pub(crate) fn font_file_follows_mac_order(font_data: &[u8]) -> bool {
+    build_cmap_from_mac_glyph_order(font_data).is_some()
+}
+
 /// Build a GID→Unicode CMap for a TrueType font that has neither a `cmap`
 /// table nor glyph names, assuming the standard Macintosh glyph order.
 ///
 /// The assumption is only accepted when the font's own metrics corroborate
 /// it: at least three glyphs at the digit positions (19–28) exist and share
 /// one advance, as tabular figures do; the glyph at the space position (3)
-/// advances without an outline; `i` and `l` are narrower than `m` and `w`;
+/// advances without an outline; every present `i` and `l` is narrower than
+/// every present `m` and `w`;
 /// and capitals average wider than lowercase. Each check only applies to
 /// glyphs the subset kept. Everything else keeps today's behaviour.
 pub(crate) fn build_cmap_from_mac_glyph_order(font_data: &[u8]) -> Option<ToUnicodeCMap> {
@@ -338,14 +346,12 @@ pub(crate) fn build_cmap_from_mac_glyph_order(font_data: &[u8]) -> Option<ToUnic
     // fails these as often as it passes them.
     // A subset too sparse to run any of them is left alone.
     let mut letter_checks = 0usize;
-    let narrow = [advance(76), advance(79)]; // i l
-    let wide = [advance(80), advance(90)]; // m w
-    for (n, w) in narrow.iter().zip(wide) {
-        if let (Some(n), Some(w)) = (n, w) {
-            letter_checks += 1;
-            if *n >= w {
-                return None;
-            }
+    let narrow: Vec<u16> = [76u16, 79].into_iter().filter_map(advance).collect(); // i l
+    let wide: Vec<u16> = [80u16, 90].into_iter().filter_map(advance).collect(); // m w
+    if let (Some(widest_narrow), Some(narrowest_wide)) = (narrow.iter().max(), wide.iter().min()) {
+        letter_checks += 1;
+        if widest_narrow >= narrowest_wide {
+            return None;
         }
     }
     let mean = |range: std::ops::RangeInclusive<u16>| {

--- a/src/mac_glyph_order.rs
+++ b/src/mac_glyph_order.rs
@@ -1,0 +1,388 @@
+//! Standard Macintosh glyph order as a last-resort CID→Unicode mapping.
+//!
+//! A TrueType subset embedded for an Identity-H CIDFont sometimes keeps
+//! neither a `cmap` table nor glyph names, and the PDF carries no
+//! ToUnicode. The glyph IDs are then the only handle on the text. The core
+//! Windows and Macintosh fonts (Arial, Times New Roman, Helvetica, ...) place
+//! the 258 glyphs of the standard Macintosh ordering first, so for those
+//! fonts the glyph ID alone still names the character. The order is only
+//! assumed when the font's own metrics corroborate it.
+
+use crate::glyph_names::glyph_to_char;
+use crate::tounicode::ToUnicodeCMap;
+use lopdf::{Document, Object};
+
+/// The 258 glyph names of the standard Macintosh ordering (`post` format 1;
+/// TrueType Reference Manual, "The 'post' table"). The core Windows and
+/// Macintosh fonts (Arial, Times New Roman, Helvetica, ...) place these
+/// glyphs first in this order, so a subset that dropped its `cmap` and its
+/// glyph names still exposes them through the glyph ID alone.
+const MAC_GLYPH_NAMES: [&str; 258] = [
+    ".notdef",
+    ".null",
+    "nonmarkingreturn",
+    "space",
+    "exclam",
+    "quotedbl",
+    "numbersign",
+    "dollar",
+    "percent",
+    "ampersand",
+    "quotesingle",
+    "parenleft",
+    "parenright",
+    "asterisk",
+    "plus",
+    "comma",
+    "hyphen",
+    "period",
+    "slash",
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "colon",
+    "semicolon",
+    "less",
+    "equal",
+    "greater",
+    "question",
+    "at",
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "H",
+    "I",
+    "J",
+    "K",
+    "L",
+    "M",
+    "N",
+    "O",
+    "P",
+    "Q",
+    "R",
+    "S",
+    "T",
+    "U",
+    "V",
+    "W",
+    "X",
+    "Y",
+    "Z",
+    "bracketleft",
+    "backslash",
+    "bracketright",
+    "asciicircum",
+    "underscore",
+    "grave",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+    "braceleft",
+    "bar",
+    "braceright",
+    "asciitilde",
+    "Adieresis",
+    "Aring",
+    "Ccedilla",
+    "Eacute",
+    "Ntilde",
+    "Odieresis",
+    "Udieresis",
+    "aacute",
+    "agrave",
+    "acircumflex",
+    "adieresis",
+    "atilde",
+    "aring",
+    "ccedilla",
+    "eacute",
+    "egrave",
+    "ecircumflex",
+    "edieresis",
+    "iacute",
+    "igrave",
+    "icircumflex",
+    "idieresis",
+    "ntilde",
+    "oacute",
+    "ograve",
+    "ocircumflex",
+    "odieresis",
+    "otilde",
+    "uacute",
+    "ugrave",
+    "ucircumflex",
+    "udieresis",
+    "dagger",
+    "degree",
+    "cent",
+    "sterling",
+    "section",
+    "bullet",
+    "paragraph",
+    "germandbls",
+    "registered",
+    "copyright",
+    "trademark",
+    "acute",
+    "dieresis",
+    "notequal",
+    "AE",
+    "Oslash",
+    "infinity",
+    "plusminus",
+    "lessequal",
+    "greaterequal",
+    "yen",
+    "mu",
+    "partialdiff",
+    "summation",
+    "product",
+    "pi",
+    "integral",
+    "ordfeminine",
+    "ordmasculine",
+    "Omega",
+    "ae",
+    "oslash",
+    "questiondown",
+    "exclamdown",
+    "logicalnot",
+    "radical",
+    "florin",
+    "approxequal",
+    "Delta",
+    "guillemotleft",
+    "guillemotright",
+    "ellipsis",
+    "nonbreakingspace",
+    "Agrave",
+    "Atilde",
+    "Otilde",
+    "OE",
+    "oe",
+    "endash",
+    "emdash",
+    "quotedblleft",
+    "quotedblright",
+    "quoteleft",
+    "quoteright",
+    "divide",
+    "lozenge",
+    "ydieresis",
+    "Ydieresis",
+    "fraction",
+    "currency",
+    "guilsinglleft",
+    "guilsinglright",
+    "fi",
+    "fl",
+    "daggerdbl",
+    "periodcentered",
+    "quotesinglbase",
+    "quotedblbase",
+    "perthousand",
+    "Acircumflex",
+    "Ecircumflex",
+    "Aacute",
+    "Edieresis",
+    "Egrave",
+    "Iacute",
+    "Icircumflex",
+    "Idieresis",
+    "Igrave",
+    "Oacute",
+    "Ocircumflex",
+    "apple",
+    "Ograve",
+    "Uacute",
+    "Ucircumflex",
+    "Ugrave",
+    "dotlessi",
+    "circumflex",
+    "tilde",
+    "macron",
+    "breve",
+    "dotaccent",
+    "ring",
+    "cedilla",
+    "hungarumlaut",
+    "ogonek",
+    "caron",
+    "Lslash",
+    "lslash",
+    "Scaron",
+    "scaron",
+    "Zcaron",
+    "zcaron",
+    "brokenbar",
+    "Eth",
+    "eth",
+    "Yacute",
+    "yacute",
+    "Thorn",
+    "thorn",
+    "minus",
+    "multiply",
+    "onesuperior",
+    "twosuperior",
+    "threesuperior",
+    "onehalf",
+    "onequarter",
+    "threequarters",
+    "franc",
+    "Gbreve",
+    "gbreve",
+    "Idotaccent",
+    "Scedilla",
+    "scedilla",
+    "Cacute",
+    "cacute",
+    "Ccaron",
+    "ccaron",
+    "dcroat",
+];
+
+/// Whether the CIDFont maps CIDs to glyph IDs without a table, so the CIDs
+/// in the content stream are the embedded font's glyph IDs.
+pub(crate) fn cid_to_gid_is_identity(cid_font_dict: &lopdf::Dictionary, doc: &Document) -> bool {
+    match cid_font_dict.get(b"CIDToGIDMap") {
+        Err(_) => true,
+        Ok(Object::Name(name)) => name == b"Identity",
+        Ok(Object::Reference(r)) => {
+            matches!(doc.get_object(*r), Ok(Object::Name(name)) if name == b"Identity")
+        }
+        Ok(_) => false,
+    }
+}
+
+/// Build a GID→Unicode CMap for a TrueType font that has neither a `cmap`
+/// table nor glyph names, assuming the standard Macintosh glyph order.
+///
+/// The assumption is only accepted when the font's own metrics corroborate
+/// it: at least three glyphs at the digit positions (19–28) exist and share
+/// one advance, as tabular figures do; the glyph at the space position (3)
+/// advances without an outline; `i` and `l` are narrower than `m` and `w`;
+/// and capitals average wider than lowercase. Each check only applies to
+/// glyphs the subset kept. Everything else keeps today's behaviour.
+pub(crate) fn build_cmap_from_mac_glyph_order(font_data: &[u8]) -> Option<ToUnicodeCMap> {
+    use ttf_parser::GlyphId;
+
+    let face = ttf_parser::Face::parse(font_data, 0).ok()?;
+    if face.tables().cmap.is_some() || face.tables().glyf.is_none() {
+        return None;
+    }
+    if (0..face.number_of_glyphs()).any(|gid| face.glyph_name(GlyphId(gid)).is_some()) {
+        return None;
+    }
+    let present = |gid: u16| face.glyph_bounding_box(GlyphId(gid)).is_some();
+    let advance = |gid: u16| {
+        present(gid)
+            .then(|| face.glyph_hor_advance(GlyphId(gid)))
+            .flatten()
+    };
+    // Tabular figures: the digits present share one advance.
+    let digits: Vec<u16> = (19u16..=28).filter_map(advance).collect();
+    if digits.len() < 3 {
+        return None;
+    }
+    let (min, max) = digits
+        .iter()
+        .fold((u16::MAX, 0u16), |(lo, hi), &w| (lo.min(w), hi.max(w)));
+    if min == 0 || u32::from(max - min) * 100 > u32::from(max) * 2 {
+        return None;
+    }
+    // The space advances without an outline.
+    if face.number_of_glyphs() > 3
+        && (present(3) || face.glyph_hor_advance(GlyphId(3)).is_none_or(|w| w == 0))
+    {
+        return None;
+    }
+    // Letter proportions: `i` and `l` are narrower than `m` and `w`, and
+    // capitals are wider than lowercase on average. A random glyph order
+    // fails these as often as it passes them.
+    // A subset too sparse to run any of them is left alone.
+    let mut letter_checks = 0usize;
+    let narrow = [advance(76), advance(79)]; // i l
+    let wide = [advance(80), advance(90)]; // m w
+    for (n, w) in narrow.iter().zip(wide) {
+        if let (Some(n), Some(w)) = (n, w) {
+            letter_checks += 1;
+            if *n >= w {
+                return None;
+            }
+        }
+    }
+    let mean = |range: std::ops::RangeInclusive<u16>| {
+        let widths: Vec<u32> = range.filter_map(advance).map(u32::from).collect();
+        (widths.len() >= 3).then(|| widths.iter().sum::<u32>() / widths.len() as u32)
+    };
+    if let (Some(upper), Some(lower)) = (mean(36..=61), mean(68..=93)) {
+        letter_checks += 1;
+        if upper <= lower {
+            return None;
+        }
+    }
+    if letter_checks == 0 {
+        return None;
+    }
+
+    // Only slots the subset kept: an outline, or a blank glyph that still
+    // advances (space, no-break space).
+    let mut cmap = ToUnicodeCMap::new();
+    let count = usize::from(face.number_of_glyphs()).min(MAC_GLYPH_NAMES.len());
+    for (gid, name) in MAC_GLYPH_NAMES.iter().enumerate().take(count) {
+        let gid = gid as u16;
+        let kept = present(gid) || face.glyph_hor_advance(GlyphId(gid)).is_some_and(|w| w > 0);
+        if !kept {
+            continue;
+        }
+        if let Some(ch) = glyph_to_char(name) {
+            cmap.char_map.insert(gid, ch.to_string());
+        }
+    }
+    if cmap.char_map.is_empty() {
+        return None;
+    }
+    cmap.code_byte_length = 2;
+    Some(cmap)
+}
+
+#[cfg(test)]
+#[path = "tounicode_mac_order_tests.rs"]
+mod tests;

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -2290,28 +2290,30 @@ impl FontCMaps {
             }
 
             // Try parsing embedded TrueType/OpenType cmap
-            if let Some(ff_ref) = font_file_ref {
-                if let Ok(stream) = doc.get_object(ff_ref).and_then(Object::as_stream) {
-                    let data = match stream.decompressed_content() {
-                        Ok(d) => d,
-                        Err(_) => stream.content.clone(),
-                    };
-                    if let Some(cmap) = build_cmap_from_truetype(&data) {
-                        debug!(
-                            "TrueType CMap obj={:<6} (embedded font) char_map={}",
-                            lookup_key,
-                            cmap.char_map.len()
-                        );
-                        by_obj_num.insert(
-                            lookup_key,
-                            CMapEntry {
-                                primary: cmap,
-                                remapped: None,
-                                fallback: None,
-                            },
-                        );
-                        resolved = true;
-                    }
+            let font_data = font_file_ref.and_then(|ff_ref| {
+                let stream = doc.get_object(ff_ref).and_then(Object::as_stream).ok()?;
+                Some(
+                    stream
+                        .decompressed_content()
+                        .unwrap_or_else(|_| stream.content.clone()),
+                )
+            });
+            if let Some(data) = font_data.as_deref() {
+                if let Some(cmap) = build_cmap_from_truetype(data) {
+                    debug!(
+                        "TrueType CMap obj={:<6} (embedded font) char_map={}",
+                        lookup_key,
+                        cmap.char_map.len()
+                    );
+                    by_obj_num.insert(
+                        lookup_key,
+                        CMapEntry {
+                            primary: cmap,
+                            remapped: None,
+                            fallback: None,
+                        },
+                    );
+                    resolved = true;
                 }
             }
 
@@ -2320,6 +2322,32 @@ impl FontCMaps {
                 if let Some(cmap) = build_cmap_from_cid_system_info(cid_font_dict, doc) {
                     debug!(
                         "Predefined CMap obj={:<6} (CIDSystemInfo) char_map={}",
+                        lookup_key,
+                        cmap.char_map.len()
+                    );
+                    by_obj_num.insert(
+                        lookup_key,
+                        CMapEntry {
+                            primary: cmap,
+                            remapped: None,
+                            fallback: None,
+                        },
+                    );
+                    resolved = true;
+                }
+            }
+
+            // A subset stripped of both its cmap and its glyph names leaves
+            // only the glyph order; fonts that keep the standard Macintosh
+            // ordering still decode, when their metrics corroborate it. A
+            // predefined CID collection above is authoritative and wins.
+            if !resolved && crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc) {
+                if let Some(cmap) = font_data
+                    .as_deref()
+                    .and_then(crate::mac_glyph_order::build_cmap_from_mac_glyph_order)
+                {
+                    debug!(
+                        "Standard Macintosh glyph order obj={:<6} (embedded font without cmap) char_map={}",
                         lookup_key,
                         cmap.char_map.len()
                     );

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -2340,13 +2340,13 @@ impl FontCMaps {
             // A subset stripped of both its cmap and its glyph names leaves
             // only the glyph order; fonts that keep the standard Macintosh
             // ordering still decode, when their metrics corroborate it. A
-            // predefined CID collection above is authoritative and wins, and
-            // so does the CID-as-Unicode passthrough below: CIDs that look
-            // like Unicode are not glyph IDs.
-            if !resolved
-                && !cid_values_look_like_unicode(cid_font_dict)
-                && crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc)
-            {
+            // predefined CID collection above is authoritative and wins. The
+            // CID-as-Unicode passthrough below is not vetoed by the /W
+            // median: a Unicode-keyed font has its digits at 0x30-0x39 and
+            // nothing at glyph slots 19-28, so the corroboration itself
+            // declines it, while a Mac-order subset's letter GIDs (68-93)
+            // would push the median past the passthrough threshold.
+            if !resolved && crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc) {
                 if let Some(cmap) = font_data
                     .as_deref()
                     .and_then(crate::mac_glyph_order::build_cmap_from_mac_glyph_order)

--- a/src/tounicode.rs
+++ b/src/tounicode.rs
@@ -2340,8 +2340,13 @@ impl FontCMaps {
             // A subset stripped of both its cmap and its glyph names leaves
             // only the glyph order; fonts that keep the standard Macintosh
             // ordering still decode, when their metrics corroborate it. A
-            // predefined CID collection above is authoritative and wins.
-            if !resolved && crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc) {
+            // predefined CID collection above is authoritative and wins, and
+            // so does the CID-as-Unicode passthrough below: CIDs that look
+            // like Unicode are not glyph IDs.
+            if !resolved
+                && !cid_values_look_like_unicode(cid_font_dict)
+                && crate::mac_glyph_order::cid_to_gid_is_identity(cid_font_dict, doc)
+            {
                 if let Some(cmap) = font_data
                     .as_deref()
                     .and_then(crate::mac_glyph_order::build_cmap_from_mac_glyph_order)

--- a/src/tounicode_mac_order_tests.rs
+++ b/src/tounicode_mac_order_tests.rs
@@ -329,3 +329,20 @@ fn mac_order_compares_every_narrow_letter_with_every_wide_one() {
     glyphs[90] = (true, 722); // w
     assert!(build_cmap_from_mac_glyph_order(&cmapless_truetype(&glyphs)).is_none());
 }
+
+#[test]
+fn mac_order_declines_a_unicode_keyed_font() {
+    // Chromium- and Qt-style fonts index glyphs by code point: digits at
+    // 0x30-0x39, letters at 0x41+, and nothing at the Macintosh digit slots.
+    // The passthrough handles those; the ordering must not claim them.
+    let mut glyphs = vec![(false, 0u16); 0x7B];
+    glyphs[0] = (true, 750);
+    glyphs[0x20] = (false, 278);
+    for code in 0x30..=0x39 {
+        glyphs[code] = (true, 556);
+    }
+    for code in (0x41..=0x5A).chain(0x61..=0x7A) {
+        glyphs[code] = (true, 600);
+    }
+    assert!(build_cmap_from_mac_glyph_order(&cmapless_truetype(&glyphs)).is_none());
+}

--- a/src/tounicode_mac_order_tests.rs
+++ b/src/tounicode_mac_order_tests.rs
@@ -1,0 +1,268 @@
+use super::*;
+use crate::tounicode::ToUnicodeCMap;
+use lopdf::{dictionary, Document, Object, Stream};
+
+/// A minimal TrueType font with `head`, `hhea`, `maxp`, `hmtx`, `loca` and
+/// `glyf` but no `cmap` and no `post` names. Glyph `i` is `(outlined,
+/// advance)`; a missing glyph is `(false, 0)`.
+fn cmapless_truetype(glyphs: &[(bool, u16)]) -> Vec<u8> {
+    let square: Vec<u8> = {
+        let mut g = Vec::new();
+        g.extend(1i16.to_be_bytes());
+        for v in [0i16, 0, 500, 700] {
+            g.extend(v.to_be_bytes());
+        }
+        g.extend(2u16.to_be_bytes());
+        g.extend(0u16.to_be_bytes());
+        g.extend([1u8, 1, 1]);
+        for v in [0i16, 500, 0, 0, 0, 700] {
+            g.extend(v.to_be_bytes());
+        }
+        g
+    };
+    let mut glyf = Vec::new();
+    let mut loca: Vec<u8> = Vec::new();
+    loca.extend(0u32.to_be_bytes());
+    for &(outlined, _) in glyphs {
+        if outlined {
+            glyf.extend(&square);
+        }
+        loca.extend((glyf.len() as u32).to_be_bytes());
+    }
+    let num_glyphs = glyphs.len() as u16;
+    let mut head = vec![0u8; 54];
+    head[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    head[12..16].copy_from_slice(&0x5F0F_3CF5u32.to_be_bytes());
+    head[18..20].copy_from_slice(&1000u16.to_be_bytes());
+    head[50..52].copy_from_slice(&1i16.to_be_bytes());
+    let mut hhea = vec![0u8; 36];
+    hhea[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    hhea[34..36].copy_from_slice(&num_glyphs.to_be_bytes());
+    let mut maxp = vec![0u8; 32];
+    maxp[0..4].copy_from_slice(&0x0001_0000u32.to_be_bytes());
+    maxp[4..6].copy_from_slice(&num_glyphs.to_be_bytes());
+    let mut hmtx = Vec::new();
+    for &(_, advance) in glyphs {
+        hmtx.extend(advance.to_be_bytes());
+        hmtx.extend(0i16.to_be_bytes());
+    }
+    let mut tables: Vec<(&[u8; 4], Vec<u8>)> = vec![
+        (b"glyf", glyf),
+        (b"head", head),
+        (b"hhea", hhea),
+        (b"hmtx", hmtx),
+        (b"loca", loca),
+        (b"maxp", maxp),
+    ];
+    tables.sort_by_key(|(tag, _)| **tag);
+    let mut font = Vec::new();
+    font.extend(0x0001_0000u32.to_be_bytes());
+    font.extend((tables.len() as u16).to_be_bytes());
+    font.extend([0u8; 6]);
+    let mut offset = 12 + 16 * tables.len();
+    let mut body = Vec::new();
+    for (tag, data) in &tables {
+        font.extend(*tag);
+        font.extend(0u32.to_be_bytes());
+        font.extend((offset as u32).to_be_bytes());
+        font.extend((data.len() as u32).to_be_bytes());
+        let padded = data.len().div_ceil(4) * 4;
+        body.extend(data);
+        body.extend(std::iter::repeat_n(0u8, padded - data.len()));
+        offset += padded;
+    }
+    font.extend(body);
+    font
+}
+
+/// An Arial-like subset in the standard Macintosh order: blank space at 3,
+/// tabular digits at 19–28, `A`–`Z` at 36–61, `a`–`z` at 68–93, with the
+/// glyphs not in the subset left empty.
+fn arial_like(digit_widths: &[u16], space: (bool, u16)) -> Vec<(bool, u16)> {
+    let mut glyphs = vec![(false, 0u16); 98];
+    glyphs[0] = (true, 750); // .notdef box
+    glyphs[3] = space;
+    for (i, &w) in digit_widths.iter().enumerate() {
+        glyphs[19 + i] = (true, w);
+    }
+    for gid in 36..=61 {
+        glyphs[gid] = (true, 667);
+    }
+    for gid in 68..=93 {
+        glyphs[gid] = (true, 556);
+    }
+    glyphs[76] = (true, 222); // i
+    glyphs[79] = (true, 222); // l
+    glyphs[80] = (true, 833); // m
+    glyphs[90] = (true, 722); // w
+    glyphs
+}
+
+fn decode(cmap: &ToUnicodeCMap, gids: &[u16]) -> String {
+    let bytes: Vec<u8> = gids.iter().flat_map(|g| g.to_be_bytes()).collect();
+    cmap.decode_cids(&bytes)
+}
+
+#[test]
+fn mac_order_decodes_a_cmapless_subset_with_tabular_digits() {
+    let font = cmapless_truetype(&arial_like(&[556; 10], (false, 278)));
+    let cmap = build_cmap_from_mac_glyph_order(&font).expect("corroborated");
+    // "How many" in glyph IDs: H=43 o=82 w=90 space=3 m=80 a=68 n=81 y=92
+    assert_eq!(decode(&cmap, &[43, 82, 90, 3, 80, 68, 81, 92]), "How many");
+    assert_eq!(decode(&cmap, &[26, 25, 23]), "764");
+}
+
+#[test]
+fn mac_order_needs_at_least_three_equal_width_digits() {
+    for widths in [&[556u16, 556][..], &[556, 556, 500, 556][..], &[][..]] {
+        let font = cmapless_truetype(&arial_like(widths, (false, 278)));
+        assert!(
+            build_cmap_from_mac_glyph_order(&font).is_none(),
+            "digit widths {widths:?} must not corroborate the ordering"
+        );
+    }
+}
+
+#[test]
+fn mac_order_needs_a_blank_advancing_space_glyph() {
+    for space in [(true, 278), (false, 0)] {
+        let font = cmapless_truetype(&arial_like(&[556; 10], space));
+        assert!(
+            build_cmap_from_mac_glyph_order(&font).is_none(),
+            "space glyph {space:?} must not corroborate the ordering"
+        );
+    }
+}
+
+#[test]
+fn mac_order_is_not_used_when_the_font_has_a_cmap_or_names() {
+    // The regular cmap path owns fonts with a cmap; a font with names goes
+    // through the post-table path. Both are represented by real fonts in the
+    // wider suite; here the builder must simply decline a font whose glyph
+    // count is too small to hold the digit run.
+    let font = cmapless_truetype(&[(true, 750), (false, 0), (false, 0), (false, 278)]);
+    assert!(build_cmap_from_mac_glyph_order(&font).is_none());
+}
+
+#[test]
+fn cid_to_gid_identity_is_absent_or_named() {
+    let doc = Document::with_version("1.4");
+    assert!(cid_to_gid_is_identity(&dictionary! {}, &doc));
+    assert!(cid_to_gid_is_identity(
+        &dictionary! { "CIDToGIDMap" => "Identity" },
+        &doc
+    ));
+    let mut doc = Document::with_version("1.4");
+    let stream = doc.add_object(Stream::new(dictionary! {}, vec![0, 0, 0, 5]));
+    assert!(!cid_to_gid_is_identity(
+        &dictionary! { "CIDToGIDMap" => stream },
+        &doc
+    ));
+}
+
+/// End to end: an Identity-H CIDFontType2 with no ToUnicode whose embedded
+/// subset lost its cmap decodes through the standard order, and the same
+/// font with a CIDToGIDMap stream does not.
+#[test]
+fn identity_h_font_without_cmap_extracts_through_mac_order() {
+    for (cid_to_gid, expected) in [(None, "How many"), (Some(vec![0u8; 8]), "")] {
+        let mut doc = Document::with_version("1.5");
+        let font_file = doc.add_object(Stream::new(
+            dictionary! {},
+            cmapless_truetype(&arial_like(&[556; 10], (false, 278))),
+        ));
+        let descriptor = doc.add_object(dictionary! {
+            "Type" => "FontDescriptor", "FontName" => "ABCDEF+ArialMT", "Flags" => 4,
+            "FontFile2" => font_file,
+        });
+        let mut cid_font = dictionary! {
+            "Type" => "Font", "Subtype" => "CIDFontType2", "BaseFont" => "ABCDEF+ArialMT",
+            "CIDSystemInfo" => dictionary! { "Registry" => Object::string_literal("Adobe"), "Ordering" => Object::string_literal("Identity"), "Supplement" => 0 },
+            "FontDescriptor" => descriptor, "DW" => 600,
+        };
+        if let Some(map) = cid_to_gid {
+            let map_id = doc.add_object(Stream::new(dictionary! {}, map));
+            cid_font.set("CIDToGIDMap", map_id);
+        }
+        let cid_font_id = doc.add_object(cid_font);
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font", "Subtype" => "Type0", "BaseFont" => "ABCDEF+ArialMT",
+            "Encoding" => "Identity-H", "DescendantFonts" => vec![Object::Reference(cid_font_id)],
+        });
+        let content = doc.add_object(Stream::new(
+            dictionary! {},
+            b"BT /F1 12 Tf 1 0 0 1 40 700 Tm <002B0052005A0003005000440051005C> Tj ET".to_vec(),
+        ));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page", "MediaBox" => vec![0.into(), 0.into(), 600.into(), 800.into()],
+            "Resources" => dictionary! { "Font" => dictionary! { "F1" => font_id } },
+            "Contents" => content,
+        });
+        let pages_id = doc.add_object(dictionary! {
+            "Type" => "Pages", "Count" => 1, "Kids" => vec![Object::Reference(page_id)],
+        });
+        doc.get_object_mut(page_id)
+            .unwrap()
+            .as_dict_mut()
+            .unwrap()
+            .set("Parent", pages_id);
+        let catalog = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", catalog);
+        let mut bytes = Vec::new();
+        doc.save_to(&mut bytes).unwrap();
+        let text: String = crate::extract_text_with_positions_mem(&bytes)
+            .unwrap()
+            .into_iter()
+            .map(|item| item.text)
+            .collect::<Vec<_>>()
+            .join("|");
+        if expected.is_empty() {
+            assert!(!text.contains("How many"), "CIDToGIDMap stream: {text:?}");
+        } else {
+            assert_eq!(text, expected);
+        }
+    }
+}
+
+#[test]
+fn mac_order_needs_letter_proportions_to_agree() {
+    // A wide `i` or lowercase averaging wider than capitals says the glyphs
+    // at those positions are not the letters the ordering claims.
+    let mut wide_i = arial_like(&[556; 10], (false, 278));
+    wide_i[76] = (true, 900);
+    let mut wide_lower = arial_like(&[556; 10], (false, 278));
+    for gid in 68..=93 {
+        wide_lower[gid] = (true, 700);
+    }
+    wide_lower[76] = (true, 222);
+    wide_lower[79] = (true, 222);
+    wide_lower[80] = (true, 833);
+    wide_lower[90] = (true, 722);
+    for glyphs in [wide_i, wide_lower] {
+        assert!(build_cmap_from_mac_glyph_order(&cmapless_truetype(&glyphs)).is_none());
+    }
+}
+
+#[test]
+fn mac_order_needs_letters_present_to_check() {
+    // Digits and a space alone are not evidence of the ordering.
+    let mut glyphs = vec![(false, 0u16); 98];
+    glyphs[0] = (true, 750);
+    glyphs[3] = (false, 278);
+    for gid in 19..=28 {
+        glyphs[gid] = (true, 556);
+    }
+    assert!(build_cmap_from_mac_glyph_order(&cmapless_truetype(&glyphs)).is_none());
+}
+
+#[test]
+fn mac_order_maps_only_slots_the_subset_kept() {
+    let font = cmapless_truetype(&arial_like(&[556; 10], (false, 278)));
+    let cmap = build_cmap_from_mac_glyph_order(&font).unwrap();
+    assert!(cmap.char_map.contains_key(&3), "space advances");
+    assert!(cmap.char_map.contains_key(&36), "A has an outline");
+    assert!(
+        !cmap.char_map.contains_key(&4),
+        "exclam is not in the subset"
+    );
+}

--- a/src/tounicode_mac_order_tests.rs
+++ b/src/tounicode_mac_order_tests.rs
@@ -6,6 +6,12 @@ use lopdf::{dictionary, Document, Object, Stream};
 /// `glyf` but no `cmap` and no `post` names. Glyph `i` is `(outlined,
 /// advance)`; a missing glyph is `(false, 0)`.
 fn cmapless_truetype(glyphs: &[(bool, u16)]) -> Vec<u8> {
+    truetype(glyphs, false, false)
+}
+
+/// The same font, optionally with a (3,1) `cmap` mapping `A` to glyph 36,
+/// or a `post` format 2 table naming glyph 36 `A`.
+fn truetype(glyphs: &[(bool, u16)], with_cmap: bool, with_post_names: bool) -> Vec<u8> {
     let square: Vec<u8> = {
         let mut g = Vec::new();
         g.extend(1i16.to_be_bytes());
@@ -54,6 +60,43 @@ fn cmapless_truetype(glyphs: &[(bool, u16)]) -> Vec<u8> {
         (b"loca", loca),
         (b"maxp", maxp),
     ];
+    if with_cmap {
+        // One (3,1) format 4 subtable with a single segment: 'A' → glyph 36.
+        let mut cmap = Vec::new();
+        cmap.extend(0u16.to_be_bytes());
+        cmap.extend(1u16.to_be_bytes());
+        cmap.extend(3u16.to_be_bytes());
+        cmap.extend(1u16.to_be_bytes());
+        cmap.extend(12u32.to_be_bytes());
+        let seg_count_x2 = 4u16; // 'A' segment + 0xFFFF terminator
+        cmap.extend(4u16.to_be_bytes()); // format
+        cmap.extend(32u16.to_be_bytes()); // length
+        cmap.extend(0u16.to_be_bytes()); // language
+        cmap.extend(seg_count_x2.to_be_bytes());
+        cmap.extend([0u8; 6]); // searchRange, entrySelector, rangeShift
+        cmap.extend(0x41u16.to_be_bytes()); // endCode
+        cmap.extend(0xFFFFu16.to_be_bytes());
+        cmap.extend(0u16.to_be_bytes()); // reservedPad
+        cmap.extend(0x41u16.to_be_bytes()); // startCode
+        cmap.extend(0xFFFFu16.to_be_bytes());
+        cmap.extend((36u16.wrapping_sub(0x41)).to_be_bytes()); // idDelta
+        cmap.extend(1u16.to_be_bytes());
+        cmap.extend(0u16.to_be_bytes()); // idRangeOffset
+        cmap.extend(0u16.to_be_bytes());
+        tables.push((b"cmap", cmap));
+    }
+    if with_post_names {
+        // post format 2: glyph 36 carries the custom name "A", the rest .notdef.
+        let mut post = Vec::new();
+        post.extend(0x0002_0000u32.to_be_bytes());
+        post.extend([0u8; 28]);
+        post.extend(num_glyphs.to_be_bytes());
+        for gid in 0..num_glyphs {
+            post.extend(if gid == 36 { 258u16 } else { 0u16 }.to_be_bytes());
+        }
+        post.extend([1u8, b'A']);
+        tables.push((b"post", post));
+    }
     tables.sort_by_key(|(tag, _)| **tag);
     let mut font = Vec::new();
     font.extend(0x0001_0000u32.to_be_bytes());
@@ -135,13 +178,24 @@ fn mac_order_needs_a_blank_advancing_space_glyph() {
 }
 
 #[test]
-fn mac_order_is_not_used_when_the_font_has_a_cmap_or_names() {
-    // The regular cmap path owns fonts with a cmap; a font with names goes
-    // through the post-table path. Both are represented by real fonts in the
-    // wider suite; here the builder must simply decline a font whose glyph
-    // count is too small to hold the digit run.
+fn mac_order_declines_a_font_too_small_for_the_digit_run() {
     let font = cmapless_truetype(&[(true, 750), (false, 0), (false, 0), (false, 278)]);
     assert!(build_cmap_from_mac_glyph_order(&font).is_none());
+}
+
+#[test]
+fn mac_order_is_not_used_when_the_font_has_a_cmap_or_glyph_names() {
+    // A cmap or post names are authoritative; those fonts take the regular
+    // embedded-cmap and glyph-name paths instead.
+    let glyphs = arial_like(&[556; 10], (false, 278));
+    let with_cmap = truetype(&glyphs, true, false);
+    let face = ttf_parser::Face::parse(&with_cmap, 0).unwrap();
+    assert_eq!(face.glyph_index('A').map(|g| g.0), Some(36));
+    assert!(build_cmap_from_mac_glyph_order(&with_cmap).is_none());
+    let with_names = truetype(&glyphs, false, true);
+    let face = ttf_parser::Face::parse(&with_names, 0).unwrap();
+    assert_eq!(face.glyph_name(ttf_parser::GlyphId(36)), Some("A"));
+    assert!(build_cmap_from_mac_glyph_order(&with_names).is_none());
 }
 
 #[test]
@@ -165,7 +219,9 @@ fn cid_to_gid_identity_is_absent_or_named() {
 /// font with a CIDToGIDMap stream does not.
 #[test]
 fn identity_h_font_without_cmap_extracts_through_mac_order() {
-    for (cid_to_gid, expected) in [(None, "How many"), (Some(vec![0u8; 8]), "")] {
+    // With a CIDToGIDMap stream the CIDs are not glyph IDs, so the order is
+    // not applied and today's output stands: the CIDs as Latin-1 characters.
+    for (cid_to_gid, expected) in [(None, "How many"), (Some(vec![0u8; 8]), "+RZPDQ\\")] {
         let mut doc = Document::with_version("1.5");
         let font_file = doc.add_object(Stream::new(
             dictionary! {},
@@ -216,11 +272,7 @@ fn identity_h_font_without_cmap_extracts_through_mac_order() {
             .map(|item| item.text)
             .collect::<Vec<_>>()
             .join("|");
-        if expected.is_empty() {
-            assert!(!text.contains("How many"), "CIDToGIDMap stream: {text:?}");
-        } else {
-            assert_eq!(text, expected);
-        }
+        assert_eq!(text, expected, "CIDToGIDMap stream case");
     }
 }
 
@@ -265,4 +317,15 @@ fn mac_order_maps_only_slots_the_subset_kept() {
         !cmap.char_map.contains_key(&4),
         "exclam is not in the subset"
     );
+}
+
+#[test]
+fn mac_order_compares_every_narrow_letter_with_every_wide_one() {
+    // `i` narrower than `m` but `l` wider than `w`: a cross-pair violation.
+    let mut glyphs = arial_like(&[556; 10], (false, 278));
+    glyphs[76] = (true, 222); // i
+    glyphs[79] = (true, 800); // l
+    glyphs[80] = (true, 833); // m
+    glyphs[90] = (true, 722); // w
+    assert!(build_cmap_from_mac_glyph_order(&cmapless_truetype(&glyphs)).is_none());
 }


### PR DESCRIPTION
## Summary

Some producers embed a TrueType subset for an Identity-H CIDFont with **neither a `cmap` table nor glyph names**, and write no ToUnicode. The glyph IDs are then the only handle on the text, and we emitted them as characters (`&KDW/RV’RPHVWLF` for `Chat Los Domestic`). The core Windows and Macintosh fonts (Arial, Times New Roman, Helvetica, ...) place the 258 glyphs of the standard Macintosh ordering first, so for those fonts the glyph ID alone still names the character. This is pdf.js's fallback for the same case.

## Change

New module `mac_glyph_order` with the 258-name table and a builder used as a **last resort** in the no-ToUnicode pass: after the embedded `cmap`, the `post` names and the predefined CID collections have all failed, and only when `CIDToGIDMap` is identity.

The ordering is assumed only when the font's own metrics corroborate it, each check applying to the glyphs the subset kept:

- at least three glyphs at the digit positions (19–28) exist and share one advance, as tabular figures do;
- the glyph at the space position (3) advances without an outline;
- `i` and `l` are narrower than `m` and `w`;
- capitals average wider than lowercase;
- at least one of the letter checks must have been possible.

Only slots the subset kept (an outline, or a blank glyph that advances) are mapped. There is no glyph-order metadata left to verify against once `cmap` and `post` are gone; these four independent checks are the evidence, and a subset too sparse to run them keeps today's output.

## Tests

Nine tests on a hand-built cmap-less TrueType: decodes an Arial-like subset; rejects too few or unequal digits, an outlined or zero-advance space, wrong letter proportions, a digits-only subset; maps only kept slots; `CIDToGIDMap` identity detection; an end-to-end Identity-H document with and without a `CIDToGIDMap` stream.

## Eval footprint

One corpus document changes: five pages of chatbot screenshots in a report become readable text. Measured against a rebaselined main (#518 and #519 landed without a pdf-evals sync).

Known limitation, shared with the existing embedded-`cmap` path: fallback CMaps are keyed by the font file object, so two CIDFonts sharing one font program with different `CIDToGIDMap`s would share the mapping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ToUnicode extraction for Identity-H TrueType subsets without a `cmap`, glyph names, or ToUnicode data, so text no longer falls back to raw glyph IDs (for example, `&KDW/RV’RPHVWLF`).

- Uses the standard Macintosh glyph order only for identity `CIDToGIDMap`s whose metrics show tabular digits, an advancing blank space, and plausible letter widths.
- Runs after embedded `cmap`, glyph-name, and predefined CID mappings, but before CID-as-Unicode passthrough; metric checks reject Unicode-keyed fonts without relying on `/W` values.
- Maps only glyph slots retained by the subset and recognizes rescued fonts so their pages avoid OCR.
- Adds twelve tests covering valid mappings, rejection cases, passthrough behavior, and end-to-end extraction.
- Fallback CMaps remain keyed by font file object, so shared font programs with different `CIDToGIDMap`s can share a mapping.

<sup>Written for commit bb934e3fe8e81a68d2d02d2156eb65d65a369827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

