### PR TITLE
fix(extractor): decode glyphs under an ActualText made of replacement characters

### DIFF
--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -1647,6 +1647,19 @@ pub(crate) fn extract_page_text_items(
                                 Object::String(bytes, _) => Some(decode_text_string(bytes)),
                                 _ => None,
                             };
+                            // An ActualText holding the replacement character
+                            // is not a transcription: InDesign writes tab
+                            // leaders as U+0009 followed by one U+FFFD per
+                            // dot. The painted glyphs decode better than that.
+                            if actual_text
+                                .as_deref()
+                                .is_some_and(|text| text.contains('\u{FFFD}'))
+                            {
+                                log::debug!(
+                                    "ActualText contains U+FFFD; decoding the glyphs instead"
+                                );
+                                actual_text = None;
+                            }
                         }
                         if let Ok(Object::Integer(id)) = d.get(b"MCID") {
                             mcid = Some(*id);
@@ -3984,5 +3997,29 @@ BT /F1 10 Tf 300 30 Td (7) Tj ET";
                 "{content}: {items:?}"
             );
         }
+    }
+
+    /// InDesign exports tab leaders as a span whose ActualText is U+0009
+    /// followed by one U+FFFD per dot. The replacement character is not a
+    /// transcription, so the painted dots are decoded instead.
+    #[test]
+    fn actual_text_with_replacement_characters_is_ignored() {
+        let items = extract_simple_items(
+            b"BT /F1 10 Tf 72 700 Td (Amy Ganz) Tj /Span <</ActualText <FEFF0009FFFDFFFDFFFD>>> BDC ( . . . ) Tj EMC (Chief) Tj ET",
+        );
+        let text: Vec<_> = items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(text.join("|"), "Amy Ganz . . . Chief");
+        assert!(
+            items.iter().all(|i| !i.text.contains('\u{FFFD}')),
+            "{items:?}"
+        );
+    }
+
+    #[test]
+    fn actual_text_without_replacement_characters_still_replaces_the_glyphs() {
+        let items = extract_simple_items(
+            b"BT /F1 10 Tf 72 700 Td /Span <</ActualText <FEFF00480069>>> BDC (Hx) Tj EMC ET",
+        );
+        assert_eq!(items[0].text, "Hi");
     }
 }

--- a/src/extractor/content_stream.rs
+++ b/src/extractor/content_stream.rs
@@ -4006,10 +4006,10 @@ BT /F1 10 Tf 300 30 Td (7) Tj ET";
     #[test]
     fn actual_text_with_replacement_characters_is_ignored() {
         let items = extract_simple_items(
-            b"BT /F1 10 Tf 72 700 Td (Amy Ganz) Tj /Span <</ActualText <FEFF0009FFFDFFFDFFFD>>> BDC ( . . . ) Tj EMC (Chief) Tj ET",
+            b"BT /F1 10 Tf 72 700 Td (Jane Roe) Tj /Span <</ActualText <FEFF0009FFFDFFFDFFFD>>> BDC ( . . . ) Tj EMC (Chief) Tj ET",
         );
         let text: Vec<_> = items.iter().map(|i| i.text.as_str()).collect();
-        assert_eq!(text.join("|"), "Amy Ganz . . . Chief");
+        assert_eq!(text.join("|"), "Jane Roe . . . Chief");
         assert!(
             items.iter().all(|i| !i.text.contains('\u{FFFD}')),
             "{items:?}"

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -104,11 +104,26 @@ pub(crate) fn bold_heading_level(heading_tiers: &[f32]) -> usize {
 
 /// Detect TOC-style lines that contain dot leaders (e.g., "Section Name .... 42").
 /// These lines should never be joined with adjacent lines into a paragraph.
-/// Handles both consecutive dots ("....") and spaced dots ("...   ...").
+/// Handles consecutive dots ("...."), spaced groups ("...   ...") and single
+/// dots set a space apart (". . . .", as InDesign paints tab leaders).
 pub(crate) fn has_dot_leaders(text: &str) -> bool {
     // Consecutive dots (4+)
     if text.contains("....") {
         return true;
+    }
+    // Single dots separated by one space each: four or more in a row.
+    let mut spaced_run = 0;
+    let mut prev = ' ';
+    for ch in text.chars() {
+        match ch {
+            '.' if spaced_run == 0 || prev == ' ' => spaced_run += 1,
+            ' ' if prev == '.' => {}
+            _ => spaced_run = 0,
+        }
+        if spaced_run >= 4 {
+            return true;
+        }
+        prev = ch;
     }
     // Spaced dot leaders: "..." followed by whitespace and more dots
     // Count occurrences of "..." (3+ dots) — if 2+ groups, it's a dot leader
@@ -970,5 +985,14 @@ mod tests {
         assert!(!is_heading_fragment("Changing objectives:"));
         assert!(!is_heading_fragment("Sales by Region (2024)"));
         assert!(!is_heading_fragment("Results (preliminary)"));
+    }
+
+    #[test]
+    fn has_dot_leaders_recognises_spaced_single_dots() {
+        assert!(has_dot_leaders("Amy Ganz . . . . . . Chief of Staff"));
+        assert!(has_dot_leaders("Name . . . . 12"));
+        assert!(!has_dot_leaders("e.g. i.e. etc. and so on."));
+        assert!(!has_dot_leaders("Wait . . . what?"));
+        assert!(!has_dot_leaders("A. B. C. D."));
     }
 }

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -146,6 +146,32 @@ pub(crate) fn has_dot_leaders(text: &str) -> bool {
     dot_groups >= 2
 }
 
+/// A line made of nothing but dots (and spaces), four or more: the tail of
+/// the previous line's leader, painted as its own run when a leader spans
+/// two text objects. It belongs on that line, not on one of its own. A lone
+/// ellipsis (three dots) is text and stays.
+pub(crate) fn is_leader_continuation(text: &str) -> bool {
+    let mut dots = 0;
+    for ch in text.chars() {
+        match ch {
+            '.' => dots += 1,
+            ' ' => {}
+            _ => return false,
+        }
+    }
+    dots >= 4
+}
+
+/// Number of dots in the trailing run of dots and spaces of `text`: the
+/// length of a leader that ends the line, whether painted `....` or `. . .`.
+pub(crate) fn trailing_leader_dots(text: &str) -> usize {
+    text.chars()
+        .rev()
+        .take_while(|c| *c == '.' || *c == ' ')
+        .filter(|c| *c == '.')
+        .count()
+}
+
 /// Detect a table-of-contents entry: a line ending in a page number preceded by
 /// a dot-leader group (e.g. "Measurement Lab worksheet ... 3"). `has_dot_leaders`
 /// misses single-group leaders ("..."), but a trailing "<dots> <number>" is a
@@ -997,5 +1023,24 @@ mod tests {
         assert!(!has_dot_leaders("Wait. . . . what?"));
         assert!(!has_dot_leaders("A. B. C. D."));
         assert!(has_dot_leaders(". . . . 12"));
+    }
+
+    #[test]
+    fn leader_continuation_is_four_or_more_dots_only() {
+        assert!(is_leader_continuation("........"));
+        assert!(is_leader_continuation(". . . ."));
+        assert!(!is_leader_continuation("..."), "an ellipsis is text");
+        assert!(!is_leader_continuation(".."));
+        assert!(!is_leader_continuation("...... 12"));
+        assert!(!is_leader_continuation("Total assets........"));
+        assert!(!is_leader_continuation(""));
+    }
+
+    #[test]
+    fn trailing_leader_dots_counts_spaced_and_solid_runs() {
+        assert_eq!(trailing_leader_dots("Total assets........"), 8);
+        assert_eq!(trailing_leader_dots("Total assets . . . . "), 4);
+        assert_eq!(trailing_leader_dots("Capital.... 0,00"), 0);
+        assert_eq!(trailing_leader_dots("And then..."), 3);
     }
 }

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -146,10 +146,12 @@ pub(crate) fn has_dot_leaders(text: &str) -> bool {
     dot_groups >= 2
 }
 
-/// A line made of nothing but dots (and spaces), four or more: the tail of
-/// the previous line's leader, painted as its own run when a leader spans
-/// two text objects. It belongs on that line, not on one of its own. A lone
-/// ellipsis (three dots) is text and stays.
+/// A line made of nothing but dots (and spaces), two or more: a candidate
+/// tail of the previous line's leader, painted as its own run when a leader
+/// spans two text objects. Whether it is folded is decided downstream by
+/// `extend_leader`, which requires the line before it to end in a leader of
+/// four or more dots, so a lone ellipsis after ordinary text keeps its own
+/// line.
 pub(crate) fn is_leader_continuation(text: &str) -> bool {
     let mut dots = 0;
     for ch in text.chars() {

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -159,7 +159,7 @@ pub(crate) fn is_leader_continuation(text: &str) -> bool {
             _ => return false,
         }
     }
-    dots >= 4
+    dots >= 2
 }
 
 /// Number of dots in the trailing run of dots and spaces of `text`: the
@@ -1026,11 +1026,12 @@ mod tests {
     }
 
     #[test]
-    fn leader_continuation_is_four_or_more_dots_only() {
+    fn leader_continuation_is_two_or_more_dots_only() {
         assert!(is_leader_continuation("........"));
         assert!(is_leader_continuation(". . . ."));
-        assert!(!is_leader_continuation("..."), "an ellipsis is text");
-        assert!(!is_leader_continuation(".."));
+        assert!(is_leader_continuation("..."));
+        assert!(is_leader_continuation(".."));
+        assert!(!is_leader_continuation("."));
         assert!(!is_leader_continuation("...... 12"));
         assert!(!is_leader_continuation("Total assets........"));
         assert!(!is_leader_continuation(""));

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn has_dot_leaders_recognises_spaced_single_dots() {
-        assert!(has_dot_leaders("Amy Ganz . . . . . . Chief of Staff"));
+        assert!(has_dot_leaders("Jane Roe . . . . . . Chief of Staff"));
         assert!(has_dot_leaders("Name . . . . 12"));
         assert!(!has_dot_leaders("e.g. i.e. etc. and so on."));
         assert!(!has_dot_leaders("Wait . . . what?"));

--- a/src/markdown/analysis.rs
+++ b/src/markdown/analysis.rs
@@ -111,12 +111,13 @@ pub(crate) fn has_dot_leaders(text: &str) -> bool {
     if text.contains("....") {
         return true;
     }
-    // Single dots separated by one space each: four or more in a row.
+    // Single dots separated by one space each: four or more in a row, each
+    // dot standing alone (a period attached to a word does not start one).
     let mut spaced_run = 0;
     let mut prev = ' ';
     for ch in text.chars() {
         match ch {
-            '.' if spaced_run == 0 || prev == ' ' => spaced_run += 1,
+            '.' if prev == ' ' => spaced_run += 1,
             ' ' if prev == '.' => {}
             _ => spaced_run = 0,
         }
@@ -993,6 +994,8 @@ mod tests {
         assert!(has_dot_leaders("Name . . . . 12"));
         assert!(!has_dot_leaders("e.g. i.e. etc. and so on."));
         assert!(!has_dot_leaders("Wait . . . what?"));
+        assert!(!has_dot_leaders("Wait. . . . what?"));
         assert!(!has_dot_leaders("A. B. C. D."));
+        assert!(has_dot_leaders(". . . . 12"));
     }
 }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1504,13 +1504,13 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         if trimmed.is_empty() {
             continue;
         }
-        if !in_code_block && is_leader_continuation(plain_trimmed) {
+        if is_leader_continuation(plain_trimmed) {
             // The tail of a leader painted as its own run: extend the leader
             // line before it, or drop a line of dots that belongs to nothing.
             // Decided before captions, headings and lists, none of which a
-            // line of dots can be; inside a code block the dots are code.
-            // Paragraph and list state are left as they were, so the next
-            // line is treated exactly as if this one had not been painted.
+            // line of dots can be (this path has no code blocks). Paragraph
+            // and list state are left as they were, so the next line is
+            // treated exactly as if this one had not been painted.
             extend_leader(&mut output, plain_trimmed);
             continue;
         }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1030,14 +1030,16 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         if trimmed.is_empty() {
             continue;
         }
-        if !in_code_block && is_leader_continuation(plain_trimmed) {
-            // The tail of a leader painted as its own run: extend the leader
-            // line before it, or drop a line of dots that belongs to nothing.
-            // Decided before captions, headings and lists, none of which a
-            // line of dots can be; inside a code block the dots are code.
-            // Paragraph and list state are left as they were, so the next
-            // line is treated exactly as if this one had not been painted.
-            extend_leader(&mut output, plain_trimmed);
+        if !in_code_block
+            && is_leader_continuation(plain_trimmed)
+            && extend_leader(&mut output, plain_trimmed)
+        {
+            // The tail of a leader painted as its own run has been folded
+            // into the leader line before it; nothing else about the state
+            // changes, so the next line is treated exactly as if this one
+            // had not been painted. A run with no leader line before it (a
+            // table's "rows omitted" ellipsis, a stray leader) keeps its
+            // usual handling below. Inside a code block the dots are code.
             continue;
         }
 
@@ -1364,10 +1366,10 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
 /// newline back: a paragraph or page break means the dots belong to
 /// nothing) is text ending in its leader (`Total assets....`, four or more
 /// dots; a period or an ellipsis does not count), extend that leader with the
-/// dots, inside any closing emphasis or underline markup. Otherwise the dots
-/// carry no information and the caller drops them. This looks at the output
-/// rather than paragraph state because a list item or heading may have
-/// closed the paragraph.
+/// dots, inside any closing emphasis or underline markup, and report true.
+/// Otherwise nothing is touched: the caller gives the line its usual
+/// handling. This looks at the output rather than paragraph state because a
+/// list item or heading may have closed the paragraph.
 fn extend_leader(output: &mut String, dots: &str) -> bool {
     // Paragraph lines are separated lazily, so the previous line may still
     // lack its newline; more than one newline is a paragraph or page break.
@@ -1504,14 +1506,13 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         if trimmed.is_empty() {
             continue;
         }
-        if is_leader_continuation(plain_trimmed) {
-            // The tail of a leader painted as its own run: extend the leader
-            // line before it, or drop a line of dots that belongs to nothing.
-            // Decided before captions, headings and lists, none of which a
-            // line of dots can be (this path has no code blocks). Paragraph
-            // and list state are left as they were, so the next line is
-            // treated exactly as if this one had not been painted.
-            extend_leader(&mut output, plain_trimmed);
+        if is_leader_continuation(plain_trimmed) && extend_leader(&mut output, plain_trimmed) {
+            // The tail of a leader painted as its own run has been folded
+            // into the leader line before it; nothing else about the state
+            // changes, so the next line is treated exactly as if this one
+            // had not been painted. A run with no leader line before it (a
+            // table's "rows omitted" ellipsis, a stray leader) keeps its
+            // usual handling below.
             continue;
         }
 
@@ -2734,14 +2735,17 @@ mod tests {
             line_at("Closing line", 1, 508.0),
         ];
         let md = to_markdown_from_lines(lines, MarkdownOptions::default());
-        assert!(
-            !md.lines().any(|l| {
+        // Runs after a leader line are folded; runs after anything else keep
+        // their usual line of their own, as does a lone ellipsis.
+        let orphan_runs = md
+            .lines()
+            .filter(|l| {
                 let t = l.trim();
                 t.len() >= 4 && t.chars().all(|c| c == '.')
-            }),
-            "no leader run alone:\n{md}"
-        );
-        assert!(md.contains("..."), "the ellipsis line survives:\n{md}");
+            })
+            .count();
+        assert_eq!(orphan_runs, 5, "{md}");
+        assert!(md.contains("\n...\n"), "the ellipsis line survives:\n{md}");
         assert!(md.contains("Total assets.............."), "{md}");
         assert!(md.contains("as per list \"G\"............."), "{md}");
         assert!(md.contains("Deficiency......."), "{md}");

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1030,18 +1030,6 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         if trimmed.is_empty() {
             continue;
         }
-        if !in_code_block
-            && is_leader_continuation(plain_trimmed)
-            && extend_leader(&mut output, plain_trimmed)
-        {
-            // The tail of a leader painted as its own run has been folded
-            // into the leader line before it; nothing else about the state
-            // changes, so the next line is treated exactly as if this one
-            // had not been painted. A run with no leader line before it (a
-            // table's "rows omitted" ellipsis, a stray leader) keeps its
-            // usual handling below. Inside a code block the dots are code.
-            continue;
-        }
 
         // Detect figure/table captions and source citations
         // These should be on their own line followed by a paragraph break
@@ -1059,6 +1047,22 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             || (options.detect_code
                 && (in_code_block || !in_paragraph)
                 && super::classify::line_is_monospace(line));
+        if !in_code_block
+            && !is_code_line
+            && !is_para_break
+            && is_leader_continuation(plain_trimmed)
+            && extend_leader(&mut output, plain_trimmed)
+        {
+            // The tail of a leader painted as its own run has been folded
+            // into the leader line before it; nothing else about the state
+            // changes, so the next line is treated exactly as if this one
+            // had not been painted. Only a vertically adjacent run counts
+            // (a paragraph-sized gap means the dots belong to nothing), a
+            // run with no leader line before it (a table's "rows omitted"
+            // ellipsis, a stray leader) keeps its usual handling below, and
+            // a monospace run is code.
+            continue;
+        }
 
         // Close code block when transitioning to non-code
         if in_code_block && !is_code_line {
@@ -1391,10 +1395,14 @@ fn extend_leader(output: &mut String, dots: &str) -> bool {
         };
         text_end = stripped.len();
     }
-    // A leader run (four or more dots, solid or spaced), not a sentence or
-    // an ellipsis, after text of its own.
+    // A leader run (four or more dots, solid or spaced, starting at a
+    // standalone dot), not a sentence, an ellipsis or `Wait. . . .`, after
+    // text of its own.
     let text = &last_line[..text_end];
-    if trailing_leader_dots(text) < 4 || !text.chars().any(char::is_alphabetic) {
+    if trailing_leader_dots(text) < 4
+        || !has_dot_leaders(text)
+        || !text.chars().any(char::is_alphabetic)
+    {
         return false;
     }
     let insert_at = line_start + text_end;
@@ -1506,13 +1514,17 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         if trimmed.is_empty() {
             continue;
         }
-        if is_leader_continuation(plain_trimmed) && extend_leader(&mut output, plain_trimmed) {
+        if !is_para_break
+            && is_leader_continuation(plain_trimmed)
+            && extend_leader(&mut output, plain_trimmed)
+        {
             // The tail of a leader painted as its own run has been folded
             // into the leader line before it; nothing else about the state
             // changes, so the next line is treated exactly as if this one
-            // had not been painted. A run with no leader line before it (a
-            // table's "rows omitted" ellipsis, a stray leader) keeps its
-            // usual handling below.
+            // had not been painted. Only a vertically adjacent run counts
+            // (a paragraph-sized gap means the dots belong to nothing), and
+            // a run with no leader line before it (a table's "rows omitted"
+            // ellipsis, a stray leader) keeps its usual handling below.
             continue;
         }
 
@@ -2690,10 +2702,14 @@ mod tests {
         let mut out = String::from("And then...\n");
         assert!(!extend_leader(&mut out, "...."));
         assert_eq!(out, "And then...\n");
-        // A spaced leader on the previous line is one too.
+        // A spaced leader on the previous line is one too, but a period
+        // glued to the word followed by spaced dots is punctuation.
         let mut out = String::from("Total assets . . . .\n");
         assert!(extend_leader(&mut out, ". . ."));
         assert_eq!(out, "Total assets . . . ....\n");
+        let mut out = String::from("Wait. . . .\n");
+        assert!(!extend_leader(&mut out, "...."));
+        assert_eq!(out, "Wait. . . .\n");
         let mut out = String::from("<u>Deficiency....</u>\n");
         assert!(extend_leader(&mut out, "...."));
         assert_eq!(out, "<u>Deficiency........</u>\n");
@@ -2733,6 +2749,9 @@ mod tests {
             line_at("......", 1, 532.0),
             line_at("...", 1, 520.0),
             line_at("Closing line", 1, 508.0),
+            // A run a paragraph-sized gap below a leader line is not its tail.
+            line_at("Far leader........", 1, 496.0),
+            line_at("......", 1, 296.0),
         ];
         let md = to_markdown_from_lines(lines, MarkdownOptions::default());
         // Runs after a leader line are folded; runs after anything else keep
@@ -2744,7 +2763,12 @@ mod tests {
                 t.len() >= 4 && t.chars().all(|c| c == '.')
             })
             .count();
-        assert_eq!(orphan_runs, 5, "{md}");
+        assert_eq!(orphan_runs, 6, "{md}");
+        assert!(md.contains("Far leader........\n"), "{md}");
+        assert!(
+            !md.contains("Far leader........."),
+            "no fold across a paragraph gap:\n{md}"
+        );
         assert!(
             md.contains("\n... Closing line") && !md.contains("Introduction...."),
             "the ellipsis survives as text and is not folded into the sentence:\n{md}"

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1421,9 +1421,18 @@ fn extend_leader(output: &mut String, dots: &str) -> bool {
     {
         return false;
     }
-    let insert_at = line_start + text_end;
-    let run: String = dots.chars().filter(|c| *c == '.').collect();
-    output.insert_str(insert_at, &run);
+    // Match the line's own leader style: a spaced leader (`. . . .`) takes
+    // its tail spaced too, so the punctuation-spacing pass collapses the
+    // whole run at once instead of leaving a seam (`. . . ....`).
+    let tail = plain.trim_end_matches([' ', '.']).len();
+    let spaced = plain[tail..].trim().contains(' ');
+    let count = dots.chars().filter(|c| *c == '.').count();
+    let run = if spaced {
+        " .".repeat(count)
+    } else {
+        ".".repeat(count)
+    };
+    output.insert_str(line_start + text_end, &run);
     true
 }
 
@@ -2727,7 +2736,10 @@ mod tests {
         // glued to the word followed by spaced dots is punctuation.
         let mut out = String::from("Total assets . . . .\n");
         assert!(extend_leader(&mut out, ". . ."));
-        assert_eq!(out, "Total assets . . . ....\n");
+        assert_eq!(out, "Total assets . . . . . . .\n");
+        let mut out = String::from("Total assets . . . .\n");
+        assert!(extend_leader(&mut out, "..."));
+        assert_eq!(out, "Total assets . . . . . . .\n");
         let mut out = String::from("Wait. . . .\n");
         assert!(!extend_leader(&mut out, "...."));
         assert_eq!(out, "Wait. . . .\n");
@@ -2758,6 +2770,32 @@ mod tests {
             assert!(!extend_leader(&mut out, "...."), "{prev:?}");
             assert_eq!(out, prev);
         }
+    }
+
+    #[test]
+    fn spaced_leader_tails_fold_in_the_line_style_and_collapse_cleanly() {
+        let lines = vec![
+            line_at(
+                "Balance of secured claims as per list \"B\" . . . . . .",
+                1,
+                700.0,
+            ),
+            line_at(". . . .", 1, 688.0),
+            line_at("Secured creditors as per list \"B\" . . . . . .", 1, 676.0),
+        ];
+        let md = to_markdown_from_lines(lines, MarkdownOptions::default());
+        assert!(
+            md.contains("Balance of secured claims as per list \"B\"..........\n"),
+            "{md}"
+        );
+        assert!(
+            !md.contains(". ....") && !md.contains(".. ."),
+            "no seam between spaced and solid dots:\n{md}"
+        );
+        assert!(
+            md.contains("Secured creditors as per list \"B\"......"),
+            "{md}"
+        );
     }
 
     #[test]

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1515,6 +1515,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             continue;
         }
         if !is_para_break
+            && !(options.detect_code && super::classify::line_is_monospace(line))
             && is_leader_continuation(plain_trimmed)
             && extend_leader(&mut output, plain_trimmed)
         {
@@ -1522,9 +1523,10 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             // into the leader line before it; nothing else about the state
             // changes, so the next line is treated exactly as if this one
             // had not been painted. Only a vertically adjacent run counts
-            // (a paragraph-sized gap means the dots belong to nothing), and
-            // a run with no leader line before it (a table's "rows omitted"
-            // ellipsis, a stray leader) keeps its usual handling below.
+            // (a paragraph-sized gap means the dots belong to nothing), a
+            // run with no leader line before it (a table's "rows omitted"
+            // ellipsis, a stray leader) keeps its usual handling below, and
+            // a monospace run is code for the block detection further down.
             continue;
         }
 

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1012,6 +1012,7 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         }
         // Don't immediately end list on paragraph break
         // Let the continuation check below decide if we're still in a list
+        let (prior_y, prior_x) = (prev_y, prev_x);
         prev_y = line.y;
         prev_x = line_x;
 
@@ -1060,7 +1061,10 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
             // (a paragraph-sized gap means the dots belong to nothing), a
             // run with no leader line before it (a table's "rows omitted"
             // ellipsis, a stray leader) keeps its usual handling below, and
-            // a monospace run is code.
+            // a monospace run is code. The next line measures its gap and
+            // band from the text line, not from the tail.
+            prev_y = prior_y;
+            prev_x = prior_x;
             continue;
         }
 
@@ -1365,6 +1369,11 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
 }
 
 /// Convert text lines to markdown
+/// Inline markup the converters emit around a line's text.
+const MARKUP_TOKENS: [&str; 9] = [
+    "**", "*", "<u>", "</u>", "<s>", "</s>", "<sup>", "</sup>", "<sub>",
+];
+
 /// A line made only of dots is the tail of the previous line's leader,
 /// painted as a separate run. When the line emitted just before it (one
 /// newline back: a paragraph or page break means the dots belong to
@@ -1395,13 +1404,18 @@ fn extend_leader(output: &mut String, dots: &str) -> bool {
         };
         text_end = stripped.len();
     }
-    // A leader run (four or more dots, solid or spaced, starting at a
-    // standalone dot), not a sentence, an ellipsis or `Wait. . . .`, after
-    // text of its own.
-    let text = &last_line[..text_end];
-    if trailing_leader_dots(text) < 4
-        || !has_dot_leaders(text)
-        || !text.chars().any(char::is_alphabetic)
+    // Judge the leader on the text itself, with any inline markup removed:
+    // a run of four or more dots starting at a standalone dot (not a
+    // sentence, an ellipsis or `Wait. . . .`) after a label of its own,
+    // which may be a number (`12......`) but not more dots (`<u>....</u>`).
+    let plain: String = MARKUP_TOKENS
+        .iter()
+        .fold(last_line[..text_end].to_string(), |acc, m| {
+            acc.replace(m, "")
+        });
+    if trailing_leader_dots(&plain) < 4
+        || !has_dot_leaders(&plain)
+        || !plain.chars().any(char::is_alphanumeric)
     {
         return false;
     }
@@ -1497,6 +1511,7 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         }
         // Don't immediately end list on paragraph break
         // Let the continuation check below decide if we're still in a list
+        let prior_y = prev_y;
         prev_y = line.y;
 
         // Get text with optional bold/italic formatting
@@ -1527,6 +1542,8 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
             // run with no leader line before it (a table's "rows omitted"
             // ellipsis, a stray leader) keeps its usual handling below, and
             // a monospace run is code for the block detection further down.
+            // The next line measures its gap from the text line, not the tail.
+            prev_y = prior_y;
             continue;
         }
 
@@ -2712,6 +2729,13 @@ mod tests {
         let mut out = String::from("Wait. . . .\n");
         assert!(!extend_leader(&mut out, "...."));
         assert_eq!(out, "Wait. . . .\n");
+        // A numeric label is a label; an underlined run of dots is not.
+        let mut out = String::from("12......\n");
+        assert!(extend_leader(&mut out, "...."));
+        assert_eq!(out, "12..........\n");
+        let mut out = String::from("<u>........</u>\n");
+        assert!(!extend_leader(&mut out, "...."));
+        assert_eq!(out, "<u>........</u>\n");
         let mut out = String::from("<u>Deficiency....</u>\n");
         assert!(extend_leader(&mut out, "...."));
         assert_eq!(out, "<u>Deficiency........</u>\n");

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -8,8 +8,8 @@ use crate::types::TextLine;
 
 use super::analysis::{
     bold_heading_level, calculate_font_stats, compute_heading_tiers, compute_paragraph_threshold,
-    detect_header_level, font_size_rarity, has_dot_leaders, is_heading_fragment, is_toc_entry_line,
-    is_toc_marker_heading,
+    detect_header_level, font_size_rarity, has_dot_leaders, is_heading_fragment,
+    is_leader_continuation, is_toc_entry_line, is_toc_marker_heading, trailing_leader_dots,
 };
 use super::classify::{format_list_item, is_caption_line, is_list_item, starts_with_bullet_marker};
 use super::heading::classify_heading_sequences;
@@ -1030,6 +1030,16 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         if trimmed.is_empty() {
             continue;
         }
+        if !in_code_block && is_leader_continuation(plain_trimmed) {
+            // The tail of a leader painted as its own run: extend the leader
+            // line before it, or drop a line of dots that belongs to nothing.
+            // Decided before captions, headings and lists, none of which a
+            // line of dots can be; inside a code block the dots are code.
+            // Paragraph and list state are left as they were, so the next
+            // line is treated exactly as if this one had not been painted.
+            extend_leader(&mut output, plain_trimmed);
+            continue;
+        }
 
         // Detect figure/table captions and source citations
         // These should be on their own line followed by a paragraph break
@@ -1349,6 +1359,48 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
 }
 
 /// Convert text lines to markdown
+/// A line made only of dots is the tail of the previous line's leader,
+/// painted as a separate run. When the line emitted just before it (one
+/// newline back: a paragraph or page break means the dots belong to
+/// nothing) is text ending in its leader (`Total assets....`, four or more
+/// dots; a period or an ellipsis does not count), extend that leader with the
+/// dots, inside any closing emphasis or underline markup. Otherwise the dots
+/// carry no information and the caller drops them. This looks at the output
+/// rather than paragraph state because a list item or heading may have
+/// closed the paragraph.
+fn extend_leader(output: &mut String, dots: &str) -> bool {
+    // Paragraph lines are separated lazily, so the previous line may still
+    // lack its newline; more than one newline is a paragraph or page break.
+    let body_len = output.trim_end_matches('\n').len();
+    if output.len() - body_len > 1 {
+        return false;
+    }
+    let line_start = output[..body_len].rfind('\n').map_or(0, |i| i + 1);
+    let last_line = &output[line_start..body_len];
+    // Closing markup after the leader: `**`, `*`, `</u>`, `</s>`.
+    let mut text_end = last_line.len();
+    loop {
+        let head = &last_line[..text_end];
+        let Some(stripped) = ["**", "*", "</u>", "</s>"]
+            .iter()
+            .find_map(|m| head.strip_suffix(m))
+        else {
+            break;
+        };
+        text_end = stripped.len();
+    }
+    // A leader run (four or more dots, solid or spaced), not a sentence or
+    // an ellipsis, after text of its own.
+    let text = &last_line[..text_end];
+    if trailing_leader_dots(text) < 4 || !text.chars().any(char::is_alphabetic) {
+        return false;
+    }
+    let insert_at = line_start + text_end;
+    let run: String = dots.chars().filter(|c| *c == '.').collect();
+    output.insert_str(insert_at, &run);
+    true
+}
+
 pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) -> String {
     if lines.is_empty() {
         return String::new();
@@ -1450,6 +1502,16 @@ pub fn to_markdown_from_lines(lines: Vec<TextLine>, options: MarkdownOptions) ->
         let plain_trimmed = plain_text.trim();
 
         if trimmed.is_empty() {
+            continue;
+        }
+        if !in_code_block && is_leader_continuation(plain_trimmed) {
+            // The tail of a leader painted as its own run: extend the leader
+            // line before it, or drop a line of dots that belongs to nothing.
+            // Decided before captions, headings and lists, none of which a
+            // line of dots can be; inside a code block the dots are code.
+            // Paragraph and list state are left as they were, so the next
+            // line is treated exactly as if this one had not been painted.
+            extend_leader(&mut output, plain_trimmed);
             continue;
         }
 
@@ -2611,6 +2673,97 @@ mod tests {
         assert!(
             md.contains("1. ") && md.contains("A model has CB-1"),
             "numbered list item should remain intact: {md}"
+        );
+    }
+
+    #[test]
+    fn extend_leader_respects_markup_breaks_and_sentences() {
+        let mut out = String::from("**Total assets....**\n");
+        assert!(extend_leader(&mut out, ". . ."));
+        assert_eq!(out, "**Total assets.......**\n");
+        // A paragraph line still waiting for its separator.
+        let mut out = String::from("Intro\n\nTotal assets....");
+        assert!(extend_leader(&mut out, ".."));
+        assert_eq!(out, "Intro\n\nTotal assets......");
+        // An ellipsis closing a sentence is not a leader.
+        let mut out = String::from("And then...\n");
+        assert!(!extend_leader(&mut out, "...."));
+        assert_eq!(out, "And then...\n");
+        // A spaced leader on the previous line is one too.
+        let mut out = String::from("Total assets . . . .\n");
+        assert!(extend_leader(&mut out, ". . ."));
+        assert_eq!(out, "Total assets . . . ....\n");
+        let mut out = String::from("<u>Deficiency....</u>\n");
+        assert!(extend_leader(&mut out, "...."));
+        assert_eq!(out, "<u>Deficiency........</u>\n");
+        // A paragraph or page break in between: the dots belong to nothing.
+        let mut out = String::from("Total assets....\n\n");
+        assert!(!extend_leader(&mut out, "...."));
+        assert_eq!(out, "Total assets....\n\n");
+        // A sentence's period, a bare number, or dots alone are not leaders.
+        for prev in ["Introduction.\n", "............. 19.2\n", "........\n", ""] {
+            let mut out = String::from(prev);
+            assert!(!extend_leader(&mut out, "...."), "{prev:?}");
+            assert_eq!(out, prev);
+        }
+    }
+
+    #[test]
+    fn leader_continuation_lines_extend_the_line_before_them() {
+        let lines = vec![
+            line_at("Total assets........", 1, 700.0),
+            line_at("......", 1, 688.0),
+            line_at("Deficiency.......", 1, 676.0),
+            line_at("9. Real property as per list \"G\".....", 1, 664.0),
+            line_at("........", 1, 652.0),
+            line_at("10. Furniture.......", 1, 640.0),
+            // A value already closed this row: the dots are dropped.
+            line_at("Amount of subscribed capital....... 0,00", 1, 628.0),
+            line_at("....", 1, 616.0),
+            // Dots after a plain line, a dots-and-number table fragment, or
+            // more dots belong to nothing.
+            line_at("2 849,23", 1, 604.0),
+            line_at(".....................", 1, 592.0),
+            line_at("..........", 1, 580.0),
+            line_at("............. 19.2", 1, 568.0),
+            line_at("..........", 1, 556.0),
+            // A sentence's period is not a leader, and a lone ellipsis is text.
+            line_at("Introduction.", 1, 544.0),
+            line_at("......", 1, 532.0),
+            line_at("...", 1, 520.0),
+            line_at("Closing line", 1, 508.0),
+        ];
+        let md = to_markdown_from_lines(lines, MarkdownOptions::default());
+        assert!(
+            !md.lines().any(|l| {
+                let t = l.trim();
+                t.len() >= 4 && t.chars().all(|c| c == '.')
+            }),
+            "no leader run alone:\n{md}"
+        );
+        assert!(md.contains("..."), "the ellipsis line survives:\n{md}");
+        assert!(md.contains("Total assets.............."), "{md}");
+        assert!(md.contains("as per list \"G\"............."), "{md}");
+        assert!(md.contains("Deficiency......."), "{md}");
+        assert!(md.contains("capital....... 0,00"), "{md}");
+        assert!(
+            !md.contains("0,00."),
+            "a closed row takes no trailing dots:\n{md}"
+        );
+        assert!(md.contains("2 849,23"), "{md}");
+        assert!(
+            !md.contains("2 849,23."),
+            "dots are not glued to a plain line:\n{md}"
+        );
+        assert!(md.contains("............. 19.2"), "{md}");
+        assert!(
+            !md.contains("19.2."),
+            "a dots-and-number fragment takes none:\n{md}"
+        );
+        assert!(md.contains("Introduction."), "{md}");
+        assert!(
+            !md.contains("Introduction.."),
+            "a period is not a leader:\n{md}"
         );
     }
 }

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -2745,7 +2745,10 @@ mod tests {
             })
             .count();
         assert_eq!(orphan_runs, 5, "{md}");
-        assert!(md.contains("\n...\n"), "the ellipsis line survives:\n{md}");
+        assert!(
+            md.contains("\n... Closing line") && !md.contains("Introduction...."),
+            "the ellipsis survives as text and is not folded into the sentence:\n{md}"
+        );
         assert!(md.contains("Total assets.............."), "{md}");
         assert!(md.contains("as per list \"G\"............."), "{md}");
         assert!(md.contains("Deficiency......."), "{md}");

--- a/src/markdown/convert.rs
+++ b/src/markdown/convert.rs
@@ -1051,15 +1051,16 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
         if !in_code_block
             && !is_code_line
             && !is_para_break
+            && !is_band_switch
             && is_leader_continuation(plain_trimmed)
             && extend_leader(&mut output, plain_trimmed)
         {
             // The tail of a leader painted as its own run has been folded
             // into the leader line before it; nothing else about the state
             // changes, so the next line is treated exactly as if this one
-            // had not been painted. Only a vertically adjacent run counts
-            // (a paragraph-sized gap means the dots belong to nothing), a
-            // run with no leader line before it (a table's "rows omitted"
+            // had not been painted. Only a vertically adjacent run in the
+            // same band counts (a paragraph-sized gap or the other column
+            // means the dots belong to nothing), a run with no leader line before it (a table's "rows omitted"
             // ellipsis, a stray leader) keeps its usual handling below, and
             // a monospace run is code. The next line measures its gap and
             // band from the text line, not from the tail.
@@ -1370,8 +1371,8 @@ pub(super) fn to_markdown_from_lines_with_tables_and_images(
 
 /// Convert text lines to markdown
 /// Inline markup the converters emit around a line's text.
-const MARKUP_TOKENS: [&str; 9] = [
-    "**", "*", "<u>", "</u>", "<s>", "</s>", "<sup>", "</sup>", "<sub>",
+const MARKUP_TOKENS: [&str; 10] = [
+    "**", "*", "<u>", "</u>", "<s>", "</s>", "<sup>", "</sup>", "<sub>", "</sub>",
 ];
 
 /// A line made only of dots is the tail of the previous line's leader,
@@ -1392,11 +1393,12 @@ fn extend_leader(output: &mut String, dots: &str) -> bool {
     }
     let line_start = output[..body_len].rfind('\n').map_or(0, |i| i + 1);
     let last_line = &output[line_start..body_len];
-    // Closing markup after the leader: `**`, `*`, `</u>`, `</s>`.
+    // Closing markup after the leader: `**`, `*`, `</u>`, `</s>`, `</sup>`,
+    // `</sub>`.
     let mut text_end = last_line.len();
     loop {
         let head = &last_line[..text_end];
-        let Some(stripped) = ["**", "*", "</u>", "</s>"]
+        let Some(stripped) = ["**", "*", "</u>", "</s>", "</sup>", "</sub>"]
             .iter()
             .find_map(|m| head.strip_suffix(m))
         else {
@@ -2736,6 +2738,13 @@ mod tests {
         let mut out = String::from("<u>........</u>\n");
         assert!(!extend_leader(&mut out, "...."));
         assert_eq!(out, "<u>........</u>\n");
+        // Script markup is kept around the extended leader too.
+        let mut out = String::from("<sup>Note....</sup>\n");
+        assert!(extend_leader(&mut out, ".."));
+        assert_eq!(out, "<sup>Note......</sup>\n");
+        let mut out = String::from("<sub>Note....</sub>");
+        assert!(extend_leader(&mut out, ".."));
+        assert_eq!(out, "<sub>Note......</sub>");
         let mut out = String::from("<u>Deficiency....</u>\n");
         assert!(extend_leader(&mut out, "...."));
         assert_eq!(out, "<u>Deficiency........</u>\n");


### PR DESCRIPTION
## Summary

InDesign exports tab leaders as a marked-content span whose `ActualText` is U+0009 followed by one U+FFFD per dot. We honor `ActualText`, as pdftotext and mutool do, so every leader in such documents extracted as a run of replacement characters (`Name \t��������Title`). The painted glyphs underneath are plain dots.

## Change

- An `ActualText` containing U+FFFD is not a transcription; it is treated as absent and the span's glyphs are decoded instead.
- Those leaders are single dots set a space apart (`. . . . .`), which `has_dot_leaders` did not recognise, so the paragraph joiner would have merged the recovered directory lines into one paragraph. It now also accepts four or more single dots separated by one space each (`e.g. i.e.`, `A. B. C. D.` and a mid-sentence ` . . . ` do not qualify).

Before / after on a directory-style line from the motivating document (names replaced):

```
Jane Roe 	����������������������������������
```
```
Jane Roe.................... Chief of Staff
John Doe................... Chief Economist
```

- A leader painted as two text runs leaves its tail as a line of dots. When that run immediately follows a line of text ending in its own leader (`Total assets....`, four or more dots, solid or spaced), it is folded into that line inside any closing emphasis or underline markup. A run after anything else (a value that closed the row, a table's "rows omitted" ellipsis, a page or paragraph break) keeps its previous handling: nothing is deleted. Lone ellipses stay text; inside code blocks the dots are code.

## Tests

Two content-stream tests (a U+FFFD `ActualText` yields the glyphs; a normal `ActualText` still replaces them); `has_dot_leaders` tests for the spaced form and its non-matches; `is_leader_continuation` and `trailing_leader_dots` tests; `extend_leader` unit tests (markup, page/paragraph breaks, sentence periods, ellipses, spaced leaders); and a conversion test with a mixed sequence of leader lines, list items, closed rows, table fragments and an ellipsis.

## Eval footprint

One tracked corpus document changes: a bankruptcy form whose leader-dotted field lines were joined into a single line now keeps one field per line, with leader tails folded back into their lines. An earlier iteration that dropped every orphan run of dots was measured and rejected: it deleted the ellipsis rows of flattened register tables in two reference manuals and merged the rows around them. The motivating document is a local corpus addition not yet tracked in pdf-evals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes extraction of InDesign tab leaders that used `ActualText` with replacement characters, so they now decode as plain dots instead of a run of U+FFFD. Spaced single-dot leaders are recognized, and leader tails painted as their own line are folded into the line before them.

- `ActualText` containing U+FFFD is ignored, and the span's glyphs are decoded instead.
- `has_dot_leaders` now also accepts four or more single dots separated by one space each, provided the run starts with a standalone dot.
- A line made only of dots extends the previous line's leader when vertically adjacent and in the same band, and that line ends in a real leader (judged on the text with inline markup stripped, so a numeric label folds its tail while an underlined dot run does not); the tail follows the leader's own spacing style so the run collapses cleanly, and script markup is preserved around the extended leader. The next line measures its gap from the text line rather than the tail. Otherwise orphan dots keep their usual handling, code runs stay code, and lone ellipses stay text.

<sup>Written for commit f20e489af51c5187776f4c8ed564cdbdac7c3d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

