### PR TITLE
fix(vision): gate `fusion` behind `ocr` so `render-pdfium` and `vision` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
       - name: Run OCR clippy
         run: cargo clippy --features ocr -- -D warnings
 
+      # The intermediate feature sets are what a browser, text-only or
+      # renderer-only consumer actually compiles. Only default and ocr were
+      # ever built here, so a vision-gated module importing an ocr-gated item
+      # broke both of them without failing CI.
+      - name: Run vision clippy
+        run: cargo clippy --features vision -- -D warnings
+
+      - name: Run renderer-only clippy
+        run: cargo clippy --features render-pdfium -- -D warnings
+
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -12,7 +12,7 @@
 mod contracts;
 #[cfg(all(feature = "model-download", not(target_arch = "wasm32")))]
 mod download;
-#[cfg(all(feature = "vision", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
 mod fusion;
 #[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
 mod image_analysis;
@@ -37,7 +37,7 @@ pub use contracts::{
 };
 #[cfg(all(feature = "model-download", not(target_arch = "wasm32")))]
 pub use download::{HttpModelDownloadError, HttpModelDownloader, DEFAULT_MODEL_DOWNLOAD_TIMEOUT};
-#[cfg(all(feature = "vision", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "ocr", not(target_arch = "wasm32")))]
 pub use fusion::{
     fuse_ocr_pages, ocr_page_to_markdown, FusedPageMarkdown, FusedPages, OcrFusionError,
     OcrFusionOptions,

--- a/src/vision/pdfium.rs
+++ b/src/vision/pdfium.rs
@@ -2,9 +2,12 @@
 
 use std::path::Path;
 
-use firecrawl_pdfium::{PageChar, Pdfium, PixelFormat, PixelPoint, RenderConfig};
+#[cfg(feature = "ocr")]
+use firecrawl_pdfium::PageChar;
+use firecrawl_pdfium::{Pdfium, PixelFormat, PixelPoint, RenderConfig};
 use thiserror::Error;
 
+#[cfg(feature = "ocr")]
 use crate::types::{ItemType, TextItem};
 
 use super::{
@@ -77,6 +80,7 @@ pub struct PdfiumRenderer {
 }
 
 /// Positioned native text recovered from one selected PDF page.
+#[cfg(feature = "ocr")]
 #[derive(Debug)]
 pub(crate) struct PdfiumTextPage {
     pub(crate) page: u32,
@@ -127,6 +131,7 @@ impl PdfiumRenderer {
     /// suspicious embedded text layer before paying for rasterization and
     /// OCR. A page-level text failure is treated as an unavailable recovery
     /// candidate so the caller can continue to its normal OCR fallback.
+    #[cfg(feature = "ocr")]
     pub(crate) fn extract_text_pages(
         &self,
         pdf_bytes: &[u8],
@@ -216,6 +221,7 @@ impl PdfiumRenderer {
     }
 }
 
+#[cfg(feature = "ocr")]
 fn text_chars_to_items(chars: &[PageChar], page: u32) -> Vec<TextItem> {
     #[derive(Debug, Clone, Copy)]
     struct Bounds {
@@ -413,8 +419,10 @@ fn bgr_to_rgb_in_place(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "ocr")]
     use firecrawl_pdfium::{PagePoint, PageRect};
 
+    #[cfg(feature = "ocr")]
     fn page_char(value: char, bounds: PageRect) -> PageChar {
         PageChar {
             unicode: Some(value),
@@ -451,6 +459,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "ocr")]
     #[test]
     fn invalid_character_geometry_splits_text_runs() {
         let chars = [
@@ -470,6 +479,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ocr")]
     #[test]
     fn coordinates_that_overflow_f32_are_discarded() {
         let left = f64::from(f32::MAX) * 2.0;


### PR DESCRIPTION
## Problem

Neither `--features render-pdfium` nor `--features vision` compiles on `main`:

```
$ cargo build --features render-pdfium
error[E0432]: unresolved import `crate::tables::complete_table_markdown_from_items`
  --> src/vision/fusion.rs
```

`mod fusion` is gated on `vision`, but it imports `complete_table_markdown_from_items`, which is gated on `ocr`. So any feature set that turns on `vision` without also turning on `ocr` fails to build — including the renderer-only set.

This matters because `src/vision/mod.rs`'s own doc comment describes exactly that split as intentional:

> so browser WASM, text-only consumers, and renderer-only users take on no model-management or inference dependencies

Renderer-only is a real use case: rasterising a couple of pages to hand to a vision model, without pulling in ONNX Runtime and the OCR model stack.

## Fix

Gate `fusion` on `ocr` instead of `vision`, matching `pipeline` and `image_analysis`.

Every public item in `fusion` is OCR-shaped (`fuse_ocr_pages`, `ocr_page_to_markdown`, `FusedPageMarkdown`, `FusedPages`, `OcrFusionError`, `OcrFusionOptions`) and its internals are driven only by the `ocr`-gated pipeline. And since `vision` alone never built, nothing could have depended on `fusion` without `ocr` — so this removes no reachable API.

The same reasoning applies to the OCR-only native-text probe in `vision::pdfium` (`PdfiumTextPage`, `extract_text_pages`, `text_chars_to_items`), which is only called from the OCR pipeline. Gating it on `ocr` keeps a renderer-only build free of dead code — without it, `cargo clippy --features render-pdfium -- -D warnings` fails on unused items.

I first tried the other direction (widening the complete-tables chain to `vision`). It compiled, but clippy then reported ~6 dead-code errors under `render-pdfium`, which is the signal that the dependency was pointing the wrong way. Happy to switch to that shape instead if you'd rather keep `fusion` available without `ocr` — it's a larger diff.

## Why CI didn't catch it

The workflow only built `default` and `ocr`. Both happen to satisfy the import, so a `vision`-gated module depending on an `ocr`-gated item broke the intermediate feature sets silently. This PR adds `vision` and `render-pdfium` clippy jobs as the regression guard.

## Verification

- `cargo clippy -- -D warnings` passes for `default`, `vision`, `render-pdfium`, `ocr`, `ocr-oar`, `model-cache`
- `cargo test` passes for `default`, `vision`, `render-pdfium`, `ocr`
- End-to-end render under `render-pdfium` alone (no `ocr`), with `PDFIUM_LIB_PATH` set: `rendered 1 page(s); page 2 is 992x1400`

3 files changed, 23 insertions(+), 3 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `render-pdfium` and `vision` feature builds by gating the `fusion` module on `ocr` instead of `vision`.

- The `fusion` module imports `complete_table_markdown_from_items`, which is gated on `ocr`, so `vision` without `ocr` never compiled.
- OCR-only native-text helpers in `vision::pdfium` are gated on `ocr` to keep renderer-only builds free of dead code.
- CI now runs clippy for `vision` and `render-pdfium` to catch this regression.

<sup>Written for commit 185c7537df2979ed72f11c934af13b27ec24c724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/pdf-inspector/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

